### PR TITLE
Add JumpMode action

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -33,6 +33,10 @@ key_bindings = [
         "left_click"
     ],
     [
+        "F",
+        "jump_mode"
+    ],
+    [
         "W",
         "move_up"
     ]

--- a/src/action.rs
+++ b/src/action.rs
@@ -15,6 +15,7 @@ pub enum Action {
     RightClick,
     Exit,
     SlowMouse,
+    JumpMode,
 }
 
 impl Action {
@@ -32,6 +33,7 @@ impl Action {
             "right_click" => Some(Self::RightClick),
             "exit" => Some(Self::Exit),
             "slow_mouse" => Some(Self::SlowMouse),
+            "jump_mode" => Some(Self::JumpMode),
             _ => None,
         }
     }

--- a/src/action_handler.rs
+++ b/src/action_handler.rs
@@ -50,6 +50,7 @@ impl MouseMaster {
             Action::SlowMouse => {
                 // println!("[DEBUG] SlowMouse triggered - No acceleration");
             }
+            Action::JumpMode => self.activate_jump_mode(),
         }
     }
     /// Toggles between `Idle` and `Active` mode
@@ -201,5 +202,10 @@ impl MouseMaster {
 
         println!("Switched to mode: {}", mode);
         // FUTURE GROWTH
+    }
+
+    /// Activates jump mode
+    fn activate_jump_mode(&mut self) {
+        println!("Jump Mode Activated!");
     }
 }


### PR DESCRIPTION
## Summary
- support a new `JumpMode` action with string `"jump_mode"`
- handle `Action::JumpMode` in the event handler
- add an example key binding for the feature in `config.toml`

## Testing
- `cargo check` *(fails: The system library `xi` required by crate `x11` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845e644e5148332b399537fb7e26f44