### PR TITLE
Add basic jump grid overlay

### DIFF
--- a/src/action_handler.rs
+++ b/src/action_handler.rs
@@ -1,5 +1,6 @@
 use crate::overlay::OVERLAY;
 use crate::{action, Config};
+use crate::jump_overlay;
 use action::Action;
 use enigo::*;
 
@@ -11,6 +12,7 @@ pub struct MouseMaster {
     pub acceleration_counter: u32,
     pub top_speed: i32,
     pub left_click_held: bool,
+    pub jump_active: bool,
 }
 
 #[derive(Debug, PartialEq)]
@@ -30,6 +32,7 @@ impl MouseMaster {
             acceleration_counter: 0,
             top_speed: config.top_speed,
             left_click_held: false,
+            jump_active: false,
         }
     }
 
@@ -206,6 +209,13 @@ impl MouseMaster {
 
     /// Activates jump mode
     fn activate_jump_mode(&mut self) {
-        println!("Jump Mode Activated!");
+        use crate::jump_overlay::{show_jump_overlay, hide_jump_overlay};
+        if self.jump_active {
+            hide_jump_overlay();
+            self.jump_active = false;
+        } else {
+            show_jump_overlay(&self.config);
+            self.jump_active = true;
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,12 +2,14 @@ mod action;
 mod action_handler;
 mod keyboard;
 mod overlay;
+mod jump_overlay;
 
 use action::*;
 use action_handler::*;
 use keyboard::*;
 use lazy_static::lazy_static;
 use overlay::OVERLAY;
+use jump_overlay::JUMP_OVERLAY;
 use serde::Deserialize;
 use std::collections::HashSet;
 use std::sync::RwLock;
@@ -95,6 +97,11 @@ unsafe extern "system" fn keyboard_hook(code: i32, w_param: WPARAM, l_param: LPA
             let mut active_keys = ACTIVE_KEYS.write().unwrap();
 
             let is_keydown = w_param.0 as u32 == WM_KEYDOWN || w_param.0 as u32 == WM_SYSKEYDOWN;
+
+            if action_handler.mouse_master.jump_active {
+                JUMP_OVERLAY.lock().unwrap().handle_key(virtual_key);
+                return LRESULT(1);
+            }
 
             println!(
                 "[DEBUG] Processing Key Event | VirtualKey: {:?} | KeyDown: {}",


### PR DESCRIPTION
## Summary
- create `jump_overlay` module for drawing a simple grid overlay
- track `jump_active` state in `MouseMaster`
- toggle jump overlay via `JumpMode` action
- route keyboard events to jump overlay when active

## Testing
- `cargo check` *(fails: system library `xi` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845e723ff5c833296f9ad266fa99eb3