### PR TITLE
Add jump overlay navigation sequence

### DIFF
--- a/src/action_handler.rs
+++ b/src/action_handler.rs
@@ -175,6 +175,11 @@ impl MouseMaster {
         }
     }
 
+    /// Moves the mouse cursor instantly to the given absolute position
+    pub fn move_mouse_to(&mut self, x: i32, y: i32) {
+        self.enigo.move_mouse(x, y, Coordinate::Abs).unwrap();
+    }
+
     /// Resets the speed and acceleration counter when motion stops
     pub fn reset_speed(&mut self) {
         self.current_speed = self.config.starting_speed;

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -552,6 +552,49 @@ impl VirtualKey {
             _ => None,
         }
     }
+
+    /// Convert a `VirtualKey` representing alphanumeric keys into a `char`
+    pub fn to_char(self) -> Option<char> {
+        match self {
+            Self::A => Some('A'),
+            Self::B => Some('B'),
+            Self::C => Some('C'),
+            Self::D => Some('D'),
+            Self::E => Some('E'),
+            Self::F => Some('F'),
+            Self::G => Some('G'),
+            Self::H => Some('H'),
+            Self::I => Some('I'),
+            Self::J => Some('J'),
+            Self::K => Some('K'),
+            Self::L => Some('L'),
+            Self::M => Some('M'),
+            Self::N => Some('N'),
+            Self::O => Some('O'),
+            Self::P => Some('P'),
+            Self::Q => Some('Q'),
+            Self::R => Some('R'),
+            Self::S => Some('S'),
+            Self::T => Some('T'),
+            Self::U => Some('U'),
+            Self::V => Some('V'),
+            Self::W => Some('W'),
+            Self::X => Some('X'),
+            Self::Y => Some('Y'),
+            Self::Z => Some('Z'),
+            Self::Num0 => Some('0'),
+            Self::Num1 => Some('1'),
+            Self::Num2 => Some('2'),
+            Self::Num3 => Some('3'),
+            Self::Num4 => Some('4'),
+            Self::Num5 => Some('5'),
+            Self::Num6 => Some('6'),
+            Self::Num7 => Some('7'),
+            Self::Num8 => Some('8'),
+            Self::Num9 => Some('9'),
+            _ => None,
+        }
+    }
 }
 
 /// Struct for managing keybindings

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,7 +99,10 @@ unsafe extern "system" fn keyboard_hook(code: i32, w_param: WPARAM, l_param: LPA
             let is_keydown = w_param.0 as u32 == WM_KEYDOWN || w_param.0 as u32 == WM_SYSKEYDOWN;
 
             if action_handler.mouse_master.jump_active {
-                JUMP_OVERLAY.lock().unwrap().handle_key(virtual_key);
+                if let Some((x, y)) = JUMP_OVERLAY.lock().unwrap().handle_key(virtual_key) {
+                    action_handler.mouse_master.move_mouse_to(x, y);
+                    action_handler.mouse_master.jump_active = false;
+                }
                 return LRESULT(1);
             }
 


### PR DESCRIPTION
## Summary
- track jump-mode keystrokes inside the overlay
- convert buffered keys to a grid location and move the mouse
- expose helper `VirtualKey::to_char`
- add `move_mouse_to` API

## Testing
- `cargo check --quiet` *(fails: package `x11` build script could not run)*
 