### PR TITLE
Fix zero grid size check in draw

### DIFF
--- a/src/jump_overlay.rs
+++ b/src/jump_overlay.rs
@@ -91,6 +91,13 @@ impl JumpOverlay {
 
     fn draw(&self) {
         if let Some(hwnd) = self.hwnd {
+            if self.grid_size.0 == 0 || self.grid_size.1 == 0 {
+                println!(
+                    "JumpOverlay::draw aborted due to zero grid size: ({}, {})",
+                    self.grid_size.0, self.grid_size.1
+                );
+                return;
+            }
             unsafe {
                 let mut rect = RECT::default();
                 GetClientRect(hwnd, &mut rect);


### PR DESCRIPTION
## Summary
- check grid_size before drawing to avoid division by zero

## Testing
- `cargo check` *(fails: xi.pc not found)*

 