### PR TITLE
Graceful overlay initialization

### DIFF
--- a/src/action_handler.rs
+++ b/src/action_handler.rs
@@ -131,7 +131,9 @@ impl MouseMaster {
 
     /// Function to update the overlay window
     fn update_overlay(&self) {
-        OVERLAY.lock().unwrap().update_color(self.left_click_held);
+        if let Some(ref mut ov) = *OVERLAY.lock().unwrap() {
+            ov.update_color(self.left_click_held);
+        }
     }
 
     /// Simulates a right mouse click


### PR DESCRIPTION
## Summary
- handle overlay startup errors
- skip overlay operations if window failed to initialize

## Testing
- `cargo check` *(fails: The system library `xi` required by crate `x11` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_684618dd07c883329aa2bfca9f5e5602