### PR TITLE
Handle overlay lock poison errors

### DIFF
--- a/src/action_handler.rs
+++ b/src/action_handler.rs
@@ -131,7 +131,7 @@ impl MouseMaster {
 
     /// Function to update the overlay window
     fn update_overlay(&self) {
-        if let Some(ref mut ov) = *OVERLAY.lock().unwrap() {
+        if let Some(ref mut ov) = *OVERLAY.lock().unwrap_or_else(|e| e.into_inner()) {
             ov.update_color(self.left_click_held);
         }
     }

--- a/src/jump_overlay.rs
+++ b/src/jump_overlay.rs
@@ -251,7 +251,10 @@ extern "system" fn jump_window_proc(hwnd: HWND, msg: u32, wparam: WPARAM, lparam
         WM_PAINT => {
             let ps = &mut PAINTSTRUCT::default();
             let hdc = unsafe { BeginPaint(hwnd, ps) };
-            JUMP_OVERLAY.lock().unwrap().draw(hdc);
+            JUMP_OVERLAY
+                .lock()
+                .unwrap_or_else(|e| e.into_inner())
+                .draw(hdc);
             unsafe { EndPaint(hwnd, ps) };
             LRESULT(0)
         }
@@ -262,11 +265,11 @@ extern "system" fn jump_window_proc(hwnd: HWND, msg: u32, wparam: WPARAM, lparam
 }
 
 pub fn show_jump_overlay(config: &Config) {
-    let mut ov = JUMP_OVERLAY.lock().unwrap();
+    let mut ov = JUMP_OVERLAY.lock().unwrap_or_else(|e| e.into_inner());
     ov.initialize(config);
     ov.show();
 }
 
 pub fn hide_jump_overlay() {
-    JUMP_OVERLAY.lock().unwrap().hide();
+    JUMP_OVERLAY.lock().unwrap_or_else(|e| e.into_inner()).hide();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -186,7 +186,11 @@ unsafe extern "system" fn keyboard_hook(code: i32, w_param: WPARAM, l_param: LPA
                     return LRESULT(1);
                 }
 
-                if let Some((x, y)) = JUMP_OVERLAY.lock().unwrap().handle_key(virtual_key) {
+                if let Some((x, y)) = JUMP_OVERLAY
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner())
+                    .handle_key(virtual_key)
+                {
                     action_handler.mouse_master.move_mouse_to(x, y);
                     action_handler.mouse_master.jump_active = false;
                 }

--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -245,7 +245,7 @@ extern "system" fn window_proc(hwnd: HWND, msg: u32, _wparam: WPARAM, _lparam: L
     match msg {
         WM_PAINT => {
             // println!("🖌 Overlay WM_PAINT triggered!");
-            if let Some(ref mut ov) = *OVERLAY.lock().unwrap() {
+            if let Some(ref mut ov) = *OVERLAY.lock().unwrap_or_else(|e| e.into_inner()) {
                 ov.repaint();
             }
             LRESULT(0)


### PR DESCRIPTION
## Summary
- handle `PoisonError` on `OVERLAY` and `JUMP_OVERLAY`

## Testing
- `cargo check` *(fails: The system library `xi` required by crate `x11` was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68461a97909083329bbf75a5e7abb6d2