### PR TITLE
Use thread-local storage for Win32-affine hook and jump overlay

### DIFF
--- a/src/jump_overlay.rs
+++ b/src/jump_overlay.rs
@@ -1,20 +1,20 @@
+use std::cell::RefCell;
 use std::ptr;
-use std::sync::{Arc, Mutex};
 use windows::core::{w, PCWSTR};
 use windows::Win32::Foundation::*;
 use windows::Win32::Graphics::Gdi::*;
 use windows::Win32::System::LibraryLoader::GetModuleHandleW;
 use windows::Win32::UI::WindowsAndMessaging::*;
 
-use crate::{Config, keyboard::VirtualKey, overlay::RGB};
+use crate::{keyboard::VirtualKey, overlay::RGB, Config};
 
-lazy_static::lazy_static! {
-    /// Global instance of the jump overlay.
+thread_local! {
+    /// Thread-local jump overlay state.
     ///
-    /// `JumpOverlay` only interacts with Windows APIs from the thread that
-    /// installs the keyboard hook and runs the message loop.  Because no other
-    /// threads access it, `Send` and `Sync` are unnecessary.
-    pub static ref JUMP_OVERLAY: Arc<Mutex<JumpOverlay>> = Arc::new(Mutex::new(JumpOverlay::new()));
+    /// Win32 window handles (`HWND`) are thread-affine and must be created and
+    /// manipulated from the UI/hook thread that owns the window. We intentionally
+    /// keep `JumpOverlay` in TLS to prevent accidental cross-thread access.
+    pub static JUMP_OVERLAY: RefCell<JumpOverlay> = RefCell::new(JumpOverlay::new());
 }
 
 pub struct JumpOverlay {
@@ -24,14 +24,20 @@ pub struct JumpOverlay {
     input: String,
 }
 
-
 impl JumpOverlay {
     pub fn new() -> Self {
-        Self { hwnd: None, grid_size: (10, 10), visible: false, input: String::new() }
+        Self {
+            hwnd: None,
+            grid_size: (10, 10),
+            visible: false,
+            input: String::new(),
+        }
     }
 
     fn create_window(&mut self) {
-        if self.hwnd.is_some() { return; }
+        if self.hwnd.is_some() {
+            return;
+        }
         unsafe {
             let h_instance = GetModuleHandleW(None).unwrap();
             let class = w!("JumpOverlayClass");
@@ -94,7 +100,9 @@ impl JumpOverlay {
 
     pub fn hide(&mut self) {
         if let Some(h) = self.hwnd {
-            unsafe { ShowWindow(h, SW_HIDE); }
+            unsafe {
+                ShowWindow(h, SW_HIDE);
+            }
             self.visible = false;
         }
     }
@@ -149,19 +157,11 @@ impl JumpOverlay {
                     for col in 0..self.grid_size.0 {
                         let col_code = Self::index_to_code(col as usize, col_len);
                         let code = format!("{}{}", row_code, col_code);
-                        let mut text: Vec<u16> = code
-                            .encode_utf16()
-                            .chain(std::iter::once(0))
-                            .collect();
+                        let mut text: Vec<u16> =
+                            code.encode_utf16().chain(std::iter::once(0)).collect();
                         let x = rect.left + col as i32 * cell_w + cell_w / 2 - 8;
                         let y = rect.top + row as i32 * cell_h + cell_h / 2 - 8;
-                        TextOutW(
-                            hdc,
-                            x,
-                            y,
-                            PCWSTR(text.as_ptr()),
-                            (text.len() - 1) as i32,
-                        );
+                        TextOutW(hdc, x, y, PCWSTR(text.as_ptr()), (text.len() - 1) as i32);
                     }
                 }
 
@@ -234,7 +234,12 @@ impl JumpOverlay {
             if self.input.len() >= self.expected_len() {
                 let row_len = Self::letters_needed(self.grid_size.1);
                 let row_code: Vec<char> = self.input.chars().take(row_len).collect();
-                let col_code: Vec<char> = self.input.chars().skip(row_len).take(Self::letters_needed(self.grid_size.0)).collect();
+                let col_code: Vec<char> = self
+                    .input
+                    .chars()
+                    .skip(row_len)
+                    .take(Self::letters_needed(self.grid_size.0))
+                    .collect();
                 let row = Self::code_to_index(&row_code);
                 let col = Self::code_to_index(&col_code);
                 self.input.clear();
@@ -246,15 +251,17 @@ impl JumpOverlay {
     }
 }
 
-extern "system" fn jump_window_proc(hwnd: HWND, msg: u32, wparam: WPARAM, lparam: LPARAM) -> LRESULT {
+extern "system" fn jump_window_proc(
+    hwnd: HWND,
+    msg: u32,
+    wparam: WPARAM,
+    lparam: LPARAM,
+) -> LRESULT {
     match msg {
         WM_PAINT => {
             let ps = &mut PAINTSTRUCT::default();
             let hdc = unsafe { BeginPaint(hwnd, ps) };
-            JUMP_OVERLAY
-                .lock()
-                .unwrap_or_else(|e| e.into_inner())
-                .draw(hdc);
+            JUMP_OVERLAY.with(|overlay| overlay.borrow().draw(hdc));
             unsafe { EndPaint(hwnd, ps) };
             LRESULT(0)
         }
@@ -265,11 +272,13 @@ extern "system" fn jump_window_proc(hwnd: HWND, msg: u32, wparam: WPARAM, lparam
 }
 
 pub fn show_jump_overlay(config: &Config) {
-    let mut ov = JUMP_OVERLAY.lock().unwrap_or_else(|e| e.into_inner());
-    ov.initialize(config);
-    ov.show();
+    JUMP_OVERLAY.with(|overlay| {
+        let mut ov = overlay.borrow_mut();
+        ov.initialize(config);
+        ov.show();
+    });
 }
 
 pub fn hide_jump_overlay() {
-    JUMP_OVERLAY.lock().unwrap_or_else(|e| e.into_inner()).hide();
+    JUMP_OVERLAY.with(|overlay| overlay.borrow_mut().hide());
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,21 +1,22 @@
 mod action;
 mod action_handler;
+mod jump_overlay;
 mod keyboard;
 mod overlay;
-mod jump_overlay;
 
 use action::*;
 use action_handler::*;
+use jump_overlay::{hide_jump_overlay, JUMP_OVERLAY};
 use keyboard::*;
 use lazy_static::lazy_static;
 use overlay::OVERLAY;
-use jump_overlay::{JUMP_OVERLAY, hide_jump_overlay};
 use serde::Deserialize;
+use std::cell::RefCell;
 use std::collections::HashSet;
-use std::sync::{RwLock, Mutex};
+use std::sync::RwLock;
 use std::thread::sleep;
 use std::time::Duration;
-use std::{env, fs, error::Error, io};
+use std::{env, error::Error, fs, io};
 use windows::Win32::Foundation::*;
 use windows::Win32::System::LibraryLoader::*;
 use windows::Win32::UI::Input::KeyboardAndMouse::{GetAsyncKeyState, GetKeyState};
@@ -50,8 +51,15 @@ lazy_static! {
     };
     static ref KEY_ACTIONS: RwLock<KeyBindings> = RwLock::new(KeyBindings::new());
     static ref ACTIVE_KEYS: RwLock<HashSet<VirtualKey>> = RwLock::new(HashSet::new());
-    /// Stores the installed keyboard hook handle so it can be cleaned up on panic.
-    static ref KEYBOARD_HOOK_HANDLE: Mutex<Option<KeyboardHook>> = Mutex::new(None);
+}
+
+thread_local! {
+    /// Thread-local keyboard hook guard.
+    ///
+    /// The low-level hook handle (`HHOOK`) should be installed and unhooked on the
+    /// same thread. Keeping the RAII guard in TLS preserves that ownership model
+    /// and avoids sharing the Win32 handle wrapper across threads.
+    static KEYBOARD_HOOK_HANDLE: RefCell<Option<KeyboardHook>> = const { RefCell::new(None) };
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -87,7 +95,10 @@ struct GridSize {
 
 impl Default for GridSize {
     fn default() -> Self {
-        Self { width: 10, height: 10 }
+        Self {
+            width: 10,
+            height: 10,
+        }
     }
 }
 
@@ -188,10 +199,8 @@ unsafe extern "system" fn keyboard_hook(code: i32, w_param: WPARAM, l_param: LPA
                     return LRESULT(1);
                 }
 
-                if let Some((x, y)) = JUMP_OVERLAY
-                    .lock()
-                    .unwrap_or_else(|e| e.into_inner())
-                    .handle_key(virtual_key)
+                if let Some((x, y)) =
+                    JUMP_OVERLAY.with(|overlay| overlay.borrow_mut().handle_key(virtual_key))
                 {
                     action_handler.mouse_master.move_mouse_to(x, y);
                     action_handler.mouse_master.jump_active = false;
@@ -272,7 +281,7 @@ unsafe fn install_keyboard_hook() -> windows::core::Result<()> {
     )?;
 
     // Store the hook guard for cleanup on panic
-    *KEYBOARD_HOOK_HANDLE.lock().unwrap() = Some(KeyboardHook(hook));
+    KEYBOARD_HOOK_HANDLE.with(|slot| *slot.borrow_mut() = Some(KeyboardHook(hook)));
 
     Ok(())
 }
@@ -284,7 +293,9 @@ fn main() {
     std::panic::set_hook(Box::new(|info| {
         eprintln!("Application panicked: {}", info);
         // Drop the hook guard so the keyboard is unhooked
-        KEYBOARD_HOOK_HANDLE.lock().unwrap().take();
+        KEYBOARD_HOOK_HANDLE.with(|slot| {
+            slot.borrow_mut().take();
+        });
         hide_jump_overlay();
         std::process::exit(1);
     }));


### PR DESCRIPTION
### Motivation
- Win32 objects like `HWND` and `HHOOK` are thread-affine and must be created/used on the same thread, so global mutex-backed objects risk cross-thread misuse. 
- Keep RAII semantics for the keyboard hook while ensuring ownership stays on the installing (UI/hook) thread.

### Description
- Replaced the global `JUMP_OVERLAY: Arc<Mutex<JumpOverlay>>` with a thread-local `thread_local! { static JUMP_OVERLAY: RefCell<JumpOverlay> }` in `src/jump_overlay.rs`, and added comments explaining the Win32 thread-affinity rationale. 
- Updated overlay access sites (`jump_window_proc`, `show_jump_overlay`, `hide_jump_overlay`) to call `JUMP_OVERLAY.with(...)` and use `borrow()`/`borrow_mut()` instead of locking a mutex. 
- Replaced `KEYBOARD_HOOK_HANDLE: Mutex<Option<KeyboardHook>>` with a thread-local `KEYBOARD_HOOK_HANDLE: RefCell<Option<KeyboardHook>>` in `src/main.rs`, and updated install/panic cleanup paths to access the TLS slot via `KEYBOARD_HOOK_HANDLE.with(...)`. 
- Preserved `KeyboardHook` RAII `Drop` behavior (unhook on drop) and added comments near both globals explaining why TLS is intentional for `HWND`/`HHOOK` ownership. 
- Ensured no remaining `lazy_static`/`static` in the modified paths directly contains `HWND`/`HHOOK` wrappers; Win32-affine state is now TLS-backed.

### Testing
- Ran `cargo fmt` successfully. 
- Ran `cargo check`; build was blocked in this environment by a missing system dependency (`xi`) required by a transitive `x11` crate, so compilation could not complete here (error from `pkg-config`), not related to the code changes themselves.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08bb063aa88332837b8ea6930ae04b)