### PR TITLE
Use typed Win32 handle validity checks in jump overlay

### DIFF
--- a/src/jump_overlay.rs
+++ b/src/jump_overlay.rs
@@ -121,7 +121,7 @@ impl JumpOverlay {
 
                 let pen = CreatePen(PS_SOLID, 1, RGB(255, 255, 255));
                 let old_pen = SelectObject(hdc, pen.into());
-                if old_pen.0 == 0 {
+                if old_pen.is_invalid() {
                     eprintln!("[Win32] SelectObject failed: {:?}", GetLastError());
                     DeleteObject(pen.into());
                     return;
@@ -223,7 +223,7 @@ impl JumpOverlay {
             if let Some(hwnd) = self.hwnd {
                 unsafe {
                     let hdc = GetDC(Some(hwnd));
-                    if hdc.0 == 0 {
+                    if hdc.is_invalid() {
                         eprintln!("[Win32] GetDC failed: {:?}", GetLastError());
                     } else {
                         self.draw(hdc);


### PR DESCRIPTION
### Motivation
- Replace raw `.0` field comparisons on Win32 handle wrapper types with pointer-safe, higher-level checks to avoid direct pointer/int comparisons and prefer the wrapper's validity API.

### Description
- In `src/jump_overlay.rs` replace `old_pen.0 == 0` with `old_pen.is_invalid()` and `hdc.0 == 0` with `hdc.is_invalid()` while keeping existing logging, `DeleteObject`, and early-return cleanup behavior unchanged.

### Testing
- Ran `cargo check` as a compile-only validation, which reached the build step but failed due to a missing system X11 Xi pkg-config dependency (`xi.pc`), an environment issue unrelated to these source changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08bd3114d883328de554aca4a79693)