### PR TITLE
Use UTF-16 slices directly for jump overlay labels

### DIFF
--- a/src/jump_overlay.rs
+++ b/src/jump_overlay.rs
@@ -1,6 +1,6 @@
 use std::ptr;
 use std::sync::{Arc, Mutex};
-use windows::core::{w, PCWSTR};
+use windows::core::w;
 use windows::Win32::Foundation::*;
 use windows::Win32::Graphics::Gdi::*;
 use windows::Win32::System::LibraryLoader::GetModuleHandleW;
@@ -149,19 +149,10 @@ impl JumpOverlay {
                     for col in 0..self.grid_size.0 {
                         let col_code = Self::index_to_code(col as usize, col_len);
                         let code = format!("{}{}", row_code, col_code);
-                        let mut text: Vec<u16> = code
-                            .encode_utf16()
-                            .chain(std::iter::once(0))
-                            .collect();
+                        let text: Vec<u16> = code.encode_utf16().collect();
                         let x = rect.left + col as i32 * cell_w + cell_w / 2 - 8;
                         let y = rect.top + row as i32 * cell_h + cell_h / 2 - 8;
-                        TextOutW(
-                            hdc,
-                            x,
-                            y,
-                            PCWSTR(text.as_ptr()),
-                            (text.len() - 1) as i32,
-                        );
+                        TextOutW(hdc, x, y, &text);
                     }
                 }
 


### PR DESCRIPTION
### Motivation
- Simplify label drawing by keeping UTF-16 encoding while avoiding manual `PCWSTR` pointer casting and explicit length arguments to `TextOutW`.
- Eliminate potential off-by-one / trailing-null confusion and remove an unused import tied to the old calling style.

### Description
- Stop importing `PCWSTR` and keep only `use windows::core::w;` in `src/jump_overlay.rs`.
- Build the UTF-16 buffer with `code.encode_utf16().collect()` (no trailing NUL) and pass the Rust slice directly to `TextOutW` as `&text`.
- Replace the previous `PCWSTR(text.as_ptr())` + `(text.len() - 1)` call with `TextOutW(hdc, x, y, &text)`.
- Preserve label composition as `row_code + col_code` so rendered labels remain complete and not intentionally truncated.

### Testing
- Ran `cargo check`, which failed in this environment due to a missing system dependency (`xi.pc` for the `x11` crate) and not because of the overlay code changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08bde39c2483328002046b4dcc14df)