### PR TITLE
Invalidate-driven painting for JumpOverlay and add state regression tests

### DIFF
--- a/src/action.rs
+++ b/src/action.rs
@@ -29,6 +29,7 @@ impl Action {
             "move_up_right" => Some(Self::MoveUpRight),
             "move_up_left" => Some(Self::MoveUpLeft),
             "move_down_right" => Some(Self::MoveDownRight),
+            "move_down_left" => Some(Self::MoveDownLeft),
             "left_click" => Some(Self::LeftClick),
             "right_click" => Some(Self::RightClick),
             "exit" => Some(Self::Exit),
@@ -57,6 +58,7 @@ impl ActionHandler {
     }
 
     /// Add an action to the handler
+    #[allow(dead_code)]
     pub fn add_action<F>(&mut self, action: Action, callback: F)
     where
         F: Fn() + Send + Sync + 'static,

--- a/src/action_handler.rs
+++ b/src/action_handler.rs
@@ -125,6 +125,7 @@ impl MouseMaster {
     }
 
     /// Detect when left click is released
+    #[allow(dead_code)]
     fn release_left_click(&mut self) {
         println!("[DEBUG] Left Click Released!");
         self.left_click_held = false; // ✅ Reset state
@@ -199,6 +200,7 @@ impl MouseMaster {
     }
 
     /// Displays a grid on the screen (for future extensions)
+    #[allow(dead_code)]
     pub fn display_grid(&self) {
         println!(
             "Displaying grid of size {}x{}",
@@ -208,6 +210,7 @@ impl MouseMaster {
     }
 
     /// Switches to a different mode
+    #[allow(dead_code)]
     pub fn switch_mode(&mut self, mode: &str) {
         if self.current_mode == ModeState::Active {
             self.current_mode = ModeState::Idle;

--- a/src/jump_overlay.rs
+++ b/src/jump_overlay.rs
@@ -82,8 +82,8 @@ impl JumpOverlay {
             );
             match hwnd {
                 Ok(h) => {
-                    SetLayeredWindowAttributes(h, COLORREF(0), 180, LWA_ALPHA);
-                    ShowWindow(h, SW_HIDE);
+                    let _ = SetLayeredWindowAttributes(h, COLORREF(0), 180, LWA_ALPHA);
+                    let _ = ShowWindow(h, SW_HIDE);
                     self.hwnd = Some(h);
                 }
                 Err(e) => {
@@ -104,7 +104,7 @@ impl JumpOverlay {
         if let Some(h) = self.hwnd {
             unsafe {
                 // Use non-activating show mode so jump overlay never steals focus.
-                ShowWindow(h, SW_SHOWNOACTIVATE);
+                let _ = ShowWindow(h, SW_SHOWNOACTIVATE);
             }
             self.request_repaint();
             self.visible = true;
@@ -115,7 +115,7 @@ impl JumpOverlay {
         self.input.clear();
         if let Some(h) = self.hwnd {
             unsafe {
-                ShowWindow(h, SW_HIDE);
+                let _ = ShowWindow(h, SW_HIDE);
             }
         }
         self.visible = false;
@@ -145,22 +145,22 @@ impl JumpOverlay {
                 let old_pen = SelectObject(hdc, pen.into());
                 if old_pen.0.is_null() {
                     println!("SelectObject failed: {:?}", GetLastError());
-                    DeleteObject(pen.into());
+                    let _ = DeleteObject(pen.into());
                     return;
                 }
 
                 // draw vertical lines
                 for x in 0..=self.grid_size.0 {
                     let pos = rect.left + (x as i32 * cell_w);
-                    MoveToEx(hdc, pos, rect.top, None);
-                    LineTo(hdc, pos, rect.bottom);
+                    let _ = MoveToEx(hdc, pos, rect.top, None);
+                    let _ = LineTo(hdc, pos, rect.bottom);
                 }
 
                 // draw horizontal lines
                 for y in 0..=self.grid_size.1 {
                     let pos = rect.top + (y as i32 * cell_h);
-                    MoveToEx(hdc, rect.left, pos, None);
-                    LineTo(hdc, rect.right, pos);
+                    let _ = MoveToEx(hdc, rect.left, pos, None);
+                    let _ = LineTo(hdc, rect.right, pos);
                 }
 
                 // draw labels
@@ -175,12 +175,12 @@ impl JumpOverlay {
                             code.encode_utf16().chain(std::iter::once(0)).collect();
                         let x = rect.left + col as i32 * cell_w + cell_w / 2 - 8;
                         let y = rect.top + row as i32 * cell_h + cell_h / 2 - 8;
-                        TextOutW(hdc, x, y, &text[..text.len() - 1]);
+                        let _ = TextOutW(hdc, x, y, &text[..text.len() - 1]);
                     }
                 }
 
                 SelectObject(hdc, old_pen);
-                DeleteObject(pen.into());
+                let _ = DeleteObject(pen.into());
             }
         }
     }
@@ -270,7 +270,9 @@ extern "system" fn jump_window_proc(
                 ov.draw(hdc);
                 ov.repaint_requested = false;
             });
-            unsafe { EndPaint(hwnd, ps) };
+            unsafe {
+                let _ = EndPaint(hwnd, ps);
+            };
             LRESULT(0)
         }
         WM_NCHITTEST => LRESULT(HTTRANSPARENT as isize),

--- a/src/jump_overlay.rs
+++ b/src/jump_overlay.rs
@@ -22,6 +22,7 @@ pub struct JumpOverlay {
     grid_size: (u32, u32),
     visible: bool,
     input: String,
+    repaint_requested: bool,
 }
 
 impl JumpOverlay {
@@ -31,6 +32,16 @@ impl JumpOverlay {
             grid_size: (10, 10),
             visible: false,
             input: String::new(),
+            repaint_requested: false,
+        }
+    }
+
+    fn request_repaint(&mut self) {
+        self.repaint_requested = true;
+        if let Some(h) = self.hwnd {
+            unsafe {
+                let _ = InvalidateRect(Some(h), None, BOOL(0));
+            }
         }
     }
 
@@ -86,25 +97,28 @@ impl JumpOverlay {
         self.grid_size = (config.grid_size.width, config.grid_size.height);
         self.create_window();
         self.input.clear();
+        self.repaint_requested = false;
     }
 
     pub fn show(&mut self) {
         if let Some(h) = self.hwnd {
             unsafe {
-                ShowWindow(h, SW_SHOW);
-                UpdateWindow(h);
+                // Use non-activating show mode so jump overlay never steals focus.
+                ShowWindow(h, SW_SHOWNOACTIVATE);
             }
+            self.request_repaint();
             self.visible = true;
         }
     }
 
     pub fn hide(&mut self) {
+        self.input.clear();
         if let Some(h) = self.hwnd {
             unsafe {
                 ShowWindow(h, SW_HIDE);
             }
-            self.visible = false;
         }
+        self.visible = false;
     }
 
     fn draw(&self, hdc: HDC) {
@@ -220,17 +234,7 @@ impl JumpOverlay {
         if let Some(ch) = key.to_char() {
             self.input.push(ch);
             println!("JumpOverlay sequence: {}", self.input);
-            if let Some(hwnd) = self.hwnd {
-                unsafe {
-                    let hdc = GetDC(Some(hwnd));
-                    if hdc.0 == 0 {
-                        println!("GetDC failed: {:?}", GetLastError());
-                    } else {
-                        self.draw(hdc);
-                        ReleaseDC(Some(hwnd), hdc);
-                    }
-                }
-            }
+            self.request_repaint();
             if self.input.len() >= self.expected_len() {
                 let row_len = Self::letters_needed(self.grid_size.1);
                 let row_code: Vec<char> = self.input.chars().take(row_len).collect();
@@ -261,7 +265,11 @@ extern "system" fn jump_window_proc(
         WM_PAINT => {
             let ps = &mut PAINTSTRUCT::default();
             let hdc = unsafe { BeginPaint(hwnd, ps) };
-            JUMP_OVERLAY.with(|overlay| overlay.borrow().draw(hdc));
+            JUMP_OVERLAY.with(|overlay| {
+                let mut ov = overlay.borrow_mut();
+                ov.draw(hdc);
+                ov.repaint_requested = false;
+            });
             unsafe { EndPaint(hwnd, ps) };
             LRESULT(0)
         }
@@ -281,4 +289,37 @@ pub fn show_jump_overlay(config: &Config) {
 
 pub fn hide_jump_overlay() {
     JUMP_OVERLAY.with(|overlay| overlay.borrow_mut().hide());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::JumpOverlay;
+    use crate::keyboard::VirtualKey;
+
+    #[test]
+    fn hiding_clears_input_state() {
+        let mut overlay = JumpOverlay::new();
+        overlay.input.push('A');
+        overlay.visible = true;
+        overlay.hide();
+        assert!(overlay.input.is_empty());
+        assert!(!overlay.visible);
+    }
+
+    #[test]
+    fn key_input_requests_repaint() {
+        let mut overlay = JumpOverlay::new();
+        assert!(!overlay.repaint_requested);
+        let _ = overlay.handle_key(VirtualKey::A);
+        assert!(overlay.repaint_requested);
+    }
+
+    #[test]
+    fn key_handling_does_not_require_window_for_repaint_state() {
+        let mut overlay = JumpOverlay::new();
+        overlay.hwnd = None;
+        let _ = overlay.handle_key(VirtualKey::B);
+        assert_eq!(overlay.input, "B");
+        assert!(overlay.repaint_requested);
+    }
 }

--- a/src/jump_overlay.rs
+++ b/src/jump_overlay.rs
@@ -1,6 +1,6 @@
 use std::cell::RefCell;
 use std::ptr;
-use windows::core::{w, PCWSTR};
+use windows::core::w;
 use windows::Win32::Foundation::*;
 use windows::Win32::Graphics::Gdi::*;
 use windows::Win32::System::LibraryLoader::GetModuleHandleW;
@@ -40,7 +40,7 @@ impl JumpOverlay {
         self.repaint_requested = true;
         if let Some(h) = self.hwnd {
             unsafe {
-                let _ = InvalidateRect(Some(h), None, BOOL(0));
+                let _ = InvalidateRect(Some(h), None, false);
             }
         }
     }
@@ -132,7 +132,7 @@ impl JumpOverlay {
             }
             unsafe {
                 let mut rect = RECT::default();
-                if !GetClientRect(hwnd, &mut rect).as_bool() {
+                if GetClientRect(hwnd, &mut rect).is_err() {
                     println!("GetClientRect failed: {:?}", GetLastError());
                     return;
                 }
@@ -143,7 +143,7 @@ impl JumpOverlay {
 
                 let pen = CreatePen(PS_SOLID, 1, RGB(255, 255, 255));
                 let old_pen = SelectObject(hdc, pen.into());
-                if old_pen.0 == 0 {
+                if old_pen.0.is_null() {
                     println!("SelectObject failed: {:?}", GetLastError());
                     DeleteObject(pen.into());
                     return;
@@ -171,11 +171,11 @@ impl JumpOverlay {
                     for col in 0..self.grid_size.0 {
                         let col_code = Self::index_to_code(col as usize, col_len);
                         let code = format!("{}{}", row_code, col_code);
-                        let mut text: Vec<u16> =
+                        let text: Vec<u16> =
                             code.encode_utf16().chain(std::iter::once(0)).collect();
                         let x = rect.left + col as i32 * cell_w + cell_w / 2 - 8;
                         let y = rect.top + row as i32 * cell_h + cell_h / 2 - 8;
-                        TextOutW(hdc, x, y, PCWSTR(text.as_ptr()), (text.len() - 1) as i32);
+                        TextOutW(hdc, x, y, &text[..text.len() - 1]);
                     }
                 }
 

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -278,6 +278,7 @@ impl VirtualKey {
     }
 
     /// Convert a `VirtualKey` to its virtual key code
+    #[allow(dead_code)]
     pub fn to_vk_code(self) -> u32 {
         match self {
             // Function keys

--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -80,11 +80,11 @@ impl OverlayWindow {
         if let Some(h) = hwnd_ptr {
             unsafe {
                 println!("🔹 Overlay: Showing Window...");
-                ShowWindow(HWND(h as *mut _), SW_SHOW);
+                let _ = ShowWindow(HWND(h as *mut _), SW_SHOW);
                 println!("🔹 Overlay: Updating Window...");
-                UpdateWindow(HWND(h as *mut _));
+                let _ = UpdateWindow(HWND(h as *mut _));
                 println!("🔹 Overlay: Setting Layered Window Attributes...");
-                SetLayeredWindowAttributes(HWND(h as *mut _), COLORREF(0), 255, LWA_ALPHA);
+                let _ = SetLayeredWindowAttributes(HWND(h as *mut _), COLORREF(0), 255, LWA_ALPHA);
             }
         }
 
@@ -112,7 +112,7 @@ impl OverlayWindow {
                 let y = point.y + 5;
 
                 unsafe {
-                    SetWindowPos(
+                    let _ = SetWindowPos(
                         hwnd,
                         Some(HWND_TOPMOST),
                         x,
@@ -154,7 +154,7 @@ impl OverlayWindow {
                 };
                 FillRect(hdc, &rect, hbrush);
 
-                DeleteObject(hbrush.into());
+                let _ = DeleteObject(hbrush.into());
                 ReleaseDC(Some(hwnd), hdc);
             }
         }
@@ -172,7 +172,7 @@ impl OverlayWindow {
                 let y = point.y + 5; // Offset below
 
                 unsafe {
-                    SetWindowPos(
+                    let _ = SetWindowPos(
                         hwnd,
                         Some(HWND_TOPMOST),
                         x,
@@ -186,6 +186,7 @@ impl OverlayWindow {
         }
     }
 
+    #[allow(dead_code)]
     pub fn follow_cursor(&self) {
         let hwnd_arc = Arc::clone(&self.hwnd); // Clone Arc for safe access in the thread
         let is_moving_arc = Arc::new(Mutex::new(false)); // Prevent unnecessary movement updates
@@ -207,7 +208,7 @@ impl OverlayWindow {
                         if *is_moving == false {
                             *is_moving = true;
                             unsafe {
-                                SetWindowPos(
+                                let _ = SetWindowPos(
                                     hwnd,
                                     Some(HWND_TOPMOST),
                                     x,
@@ -236,6 +237,7 @@ impl OverlayWindow {
 }
 
 /// Helper function to create a `COLORREF`
+#[allow(non_snake_case)]
 pub fn RGB(r: u8, g: u8, b: u8) -> COLORREF {
     COLORREF(((b as u32) << 16) | ((g as u32) << 8) | (r as u32))
 }


### PR DESCRIPTION
### Motivation
- Prevent synchronous painting from key handlers and window show paths so rendering happens only on the Win32 paint cycle (`WM_PAINT`).
- Ensure the overlay never steals focus when shown and that callers can request repaints without blocking UI threads.
- Make hide semantics deterministic by clearing the input buffer when the overlay is hidden.
- Provide small, non-UI unit tests that guard state behavior and the new repaint-request path.

### Description
- Replaced direct `UpdateWindow(hwnd)` and `GetDC`/`ReleaseDC` drawing with an invalidate-driven path by adding a `repaint_requested` flag and a `request_repaint()` helper that calls `InvalidateRect(hwnd, None, BOOL(0))` and sets `repaint_requested = true`.
- Updated `show()` to use the non-activating mode `SW_SHOWNOACTIVATE` (documented in a comment) and to call `request_repaint()` instead of forcing synchronous painting; this keeps `show_jump_overlay(config)` minimal (`initialize` + non-activating `show`).
- Removed all direct draw calls from `handle_key()` so it only updates input state and calls `request_repaint()`; input-finalization still clears the buffer and calls `hide()` before returning the target position.
- Confirmed `WM_PAINT` remains the single rendering entry point which performs `BeginPaint` -> `draw` -> `EndPaint`, and clears `repaint_requested` after drawing; `hide()` now always clears the input buffer and sets `visible = false`.
- Added regression unit tests (under `#[cfg(test)]`) that exercise state-only behavior: `hiding_clears_input_state`, `key_input_requests_repaint`, and `key_handling_does_not_require_window_for_repaint_state`.

### Testing
- Added unit tests: `hiding_clears_input_state`, `key_input_requests_repaint`, and `key_handling_does_not_require_window_for_repaint_state` which validate input clearing, repaint request state, and key handling without a real window handle.
- Ran `cargo test -q` in the environment but the run failed due to a missing system dependency for a transitive crate (`x11` requires `xi.pc`), so tests could not complete in this CI environment.
- The new tests are pure state checks and should run successfully in environments with the project build dependencies satisfied (they do not require Win32 window creation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08c4d443f48332b8cc08adf7989fef)