### PR TITLE
Refactor jump-mode input state machine and activation-key session handling

### DIFF
--- a/src/action_handler.rs
+++ b/src/action_handler.rs
@@ -1,3 +1,4 @@
+use crate::keyboard::VirtualKey;
 use crate::overlay::OVERLAY;
 use crate::{action, Config};
 use action::Action;
@@ -12,6 +13,8 @@ pub struct MouseMaster {
     pub top_speed: i32,
     pub left_click_held: bool,
     pub jump_active: bool,
+    pub activation_key: Option<VirtualKey>,
+    pub activation_key_released: bool,
 }
 
 #[derive(Debug, PartialEq)]
@@ -32,6 +35,8 @@ impl MouseMaster {
             top_speed: config.top_speed,
             left_click_held: false,
             jump_active: false,
+            activation_key: None,
+            activation_key_released: true,
         }
     }
 
@@ -224,7 +229,7 @@ impl MouseMaster {
 
     /// Activates jump mode
     fn activate_jump_mode(&mut self) {
-        use crate::jump_overlay::{show_jump_overlay, hide_jump_overlay};
+        use crate::jump_overlay::{hide_jump_overlay, show_jump_overlay};
         if self.jump_active {
             hide_jump_overlay();
             self.jump_active = false;

--- a/src/jump_overlay.rs
+++ b/src/jump_overlay.rs
@@ -17,6 +17,15 @@ thread_local! {
     pub static JUMP_OVERLAY: RefCell<JumpOverlay> = RefCell::new(JumpOverlay::new());
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum JumpKeyResult {
+    Ignored,
+    Consumed,
+    Cancelled,
+    Completed { x: i32, y: i32 },
+    Invalid,
+}
+
 pub struct JumpOverlay {
     hwnd: Option<HWND>,
     grid_size: (u32, u32),
@@ -230,28 +239,55 @@ impl JumpOverlay {
         }
     }
 
-    pub fn handle_key(&mut self, key: VirtualKey) -> Option<(i32, i32)> {
-        if let Some(ch) = key.to_char() {
-            self.input.push(ch);
-            println!("JumpOverlay sequence: {}", self.input);
-            self.request_repaint();
-            if self.input.len() >= self.expected_len() {
-                let row_len = Self::letters_needed(self.grid_size.1);
-                let row_code: Vec<char> = self.input.chars().take(row_len).collect();
-                let col_code: Vec<char> = self
-                    .input
-                    .chars()
-                    .skip(row_len)
-                    .take(Self::letters_needed(self.grid_size.0))
-                    .collect();
-                let row = Self::code_to_index(&row_code);
-                let col = Self::code_to_index(&col_code);
+    pub fn handle_key(&mut self, key: VirtualKey, is_keydown: bool) -> JumpKeyResult {
+        if !is_keydown {
+            return JumpKeyResult::Ignored;
+        }
+
+        match key {
+            VirtualKey::Escape => {
                 self.input.clear();
-                self.hide();
-                return self.target_position(row, col);
+                JumpKeyResult::Cancelled
+            }
+            VirtualKey::Backspace => {
+                self.input.pop();
+                self.request_repaint();
+                JumpKeyResult::Consumed
+            }
+            _ => {
+                if let Some(ch) = key.to_char() {
+                    self.input.push(ch);
+                    println!("JumpOverlay sequence: {}", self.input);
+                    self.request_repaint();
+                    if self.input.len() >= self.expected_len() {
+                        let row_len = Self::letters_needed(self.grid_size.1);
+                        let row_code: Vec<char> = self.input.chars().take(row_len).collect();
+                        let col_code: Vec<char> = self
+                            .input
+                            .chars()
+                            .skip(row_len)
+                            .take(Self::letters_needed(self.grid_size.0))
+                            .collect();
+                        let row = Self::code_to_index(&row_code);
+                        let col = Self::code_to_index(&col_code);
+
+                        if let Some((x, y)) = self.target_position(row, col) {
+                            self.input.clear();
+                            self.hide();
+                            return JumpKeyResult::Completed { x, y };
+                        }
+
+                        self.input.clear();
+                        self.request_repaint();
+                        return JumpKeyResult::Invalid;
+                    }
+                    return JumpKeyResult::Consumed;
+                }
+
+                // Policy: unsupported keys are ignored so they do not mutate jump input state.
+                JumpKeyResult::Ignored
             }
         }
-        None
     }
 }
 
@@ -291,11 +327,65 @@ pub fn show_jump_overlay(config: &Config) {
 
 pub fn hide_jump_overlay() {
     JUMP_OVERLAY.with(|overlay| overlay.borrow_mut().hide());
+
+    #[test]
+    fn key_up_is_ignored() {
+        let mut overlay = JumpOverlay::new();
+        assert_eq!(
+            overlay.handle_key(VirtualKey::A, false),
+            JumpKeyResult::Ignored
+        );
+        assert!(overlay.input.is_empty());
+    }
+
+    #[test]
+    fn escape_cancels() {
+        let mut overlay = JumpOverlay::new();
+        overlay.input.push('A');
+        assert_eq!(
+            overlay.handle_key(VirtualKey::Escape, true),
+            JumpKeyResult::Cancelled
+        );
+        assert!(overlay.input.is_empty());
+    }
+
+    #[test]
+    fn valid_two_letter_code_completes() {
+        let mut overlay = JumpOverlay::new();
+        overlay.grid_size = (10, 10);
+        assert_eq!(
+            overlay.handle_key(VirtualKey::A, true),
+            JumpKeyResult::Consumed
+        );
+        match overlay.handle_key(VirtualKey::A, true) {
+            JumpKeyResult::Completed { .. } => {}
+            other => panic!("expected completed, got {:?}", other),
+        }
+        assert!(overlay.input.is_empty());
+        assert!(!overlay.visible);
+    }
+
+    #[test]
+    fn invalid_code_returns_invalid_and_stays_visible() {
+        let mut overlay = JumpOverlay::new();
+        overlay.grid_size = (27, 10);
+        overlay.visible = true;
+        assert_eq!(
+            overlay.handle_key(VirtualKey::A, true),
+            JumpKeyResult::Consumed
+        );
+        assert_eq!(
+            overlay.handle_key(VirtualKey::Z, true),
+            JumpKeyResult::Invalid
+        );
+        assert!(overlay.visible);
+        assert!(overlay.input.is_empty());
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::JumpOverlay;
+    use super::{JumpKeyResult, JumpOverlay};
     use crate::keyboard::VirtualKey;
 
     #[test]
@@ -312,7 +402,7 @@ mod tests {
     fn key_input_requests_repaint() {
         let mut overlay = JumpOverlay::new();
         assert!(!overlay.repaint_requested);
-        let _ = overlay.handle_key(VirtualKey::A);
+        let _ = overlay.handle_key(VirtualKey::A, true);
         assert!(overlay.repaint_requested);
     }
 
@@ -320,7 +410,7 @@ mod tests {
     fn key_handling_does_not_require_window_for_repaint_state() {
         let mut overlay = JumpOverlay::new();
         overlay.hwnd = None;
-        let _ = overlay.handle_key(VirtualKey::B);
+        let _ = overlay.handle_key(VirtualKey::B, true);
         assert_eq!(overlay.input, "B");
         assert!(overlay.repaint_requested);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ mod overlay;
 
 use action::*;
 use action_handler::*;
-use jump_overlay::{hide_jump_overlay, JUMP_OVERLAY};
+use jump_overlay::{hide_jump_overlay, JumpKeyResult, JUMP_OVERLAY};
 use keyboard::*;
 use lazy_static::lazy_static;
 use overlay::OVERLAY;
@@ -197,17 +197,38 @@ unsafe extern "system" fn keyboard_hook(code: i32, w_param: WPARAM, l_param: LPA
             let is_keydown = w_param.0 as u32 == WM_KEYDOWN || w_param.0 as u32 == WM_SYSKEYDOWN;
 
             if action_handler.mouse_master.jump_active {
-                if virtual_key == VirtualKey::Escape && is_keydown {
-                    hide_jump_overlay();
-                    action_handler.mouse_master.jump_active = false;
-                    return LRESULT(1);
+                if let Some(activation_key) = action_handler.mouse_master.activation_key {
+                    if virtual_key == activation_key {
+                        if is_keydown && !action_handler.mouse_master.activation_key_released {
+                            return LRESULT(1);
+                        }
+                        if !is_keydown {
+                            action_handler.mouse_master.activation_key_released = true;
+                            return LRESULT(1);
+                        }
+                    }
                 }
 
-                if let Some((x, y)) =
-                    JUMP_OVERLAY.with(|overlay| overlay.borrow_mut().handle_key(virtual_key))
-                {
-                    action_handler.mouse_master.move_mouse_to(x, y);
-                    action_handler.mouse_master.jump_active = false;
+                let jump_result = JUMP_OVERLAY
+                    .with(|overlay| overlay.borrow_mut().handle_key(virtual_key, is_keydown));
+
+                match jump_result {
+                    JumpKeyResult::Ignored | JumpKeyResult::Consumed => {}
+                    JumpKeyResult::Cancelled => {
+                        hide_jump_overlay();
+                        action_handler.mouse_master.jump_active = false;
+                        action_handler.mouse_master.activation_key = None;
+                        action_handler.mouse_master.activation_key_released = true;
+                    }
+                    JumpKeyResult::Completed { x, y } => {
+                        action_handler.mouse_master.move_mouse_to(x, y);
+                        action_handler.mouse_master.jump_active = false;
+                        action_handler.mouse_master.activation_key = None;
+                        action_handler.mouse_master.activation_key_released = true;
+                    }
+                    JumpKeyResult::Invalid => {
+                        action_handler.mouse_master.jump_active = true;
+                    }
                 }
                 return LRESULT(1);
             }
@@ -240,6 +261,22 @@ unsafe extern "system" fn keyboard_hook(code: i32, w_param: WPARAM, l_param: LPA
             if action_handler.mouse_master.current_mode == ModeState::Idle {
                 println!("[DEBUG] Idle Mode active: Ignoring key event...");
                 return CallNextHookEx(None, code, w_param, l_param);
+            }
+
+            if is_keydown {
+                if let Some(action) = key_actions.get_action(virtual_key) {
+                    if *action == Action::JumpMode {
+                        action_handler.process_active_keys(*action, true);
+                        if action_handler.mouse_master.jump_active {
+                            action_handler.mouse_master.activation_key = Some(virtual_key);
+                            action_handler.mouse_master.activation_key_released = false;
+                        } else {
+                            action_handler.mouse_master.activation_key = None;
+                            action_handler.mouse_master.activation_key_released = true;
+                        }
+                        return LRESULT(1);
+                    }
+                }
             }
 
             // ✅ Normal key processing


### PR DESCRIPTION
### Motivation
- Make jump overlay key handling deterministic by replacing the opaque `Option<(i32, i32)>` result with an explicit result enum and by accounting for key direction.
- Prevent the app from becoming invisible/stuck after invalid jump codes and support clear activation-key session semantics.
- Add unit tests that cover pure jump-input state transitions so the jump flow is verifiable in isolation.

### Description
- Introduce `JumpKeyResult` (`Ignored`, `Consumed`, `Cancelled`, `Completed { x, y }`, `Invalid`) and change `JumpOverlay::handle_key` to `fn handle_key(&mut self, key: VirtualKey, is_keydown: bool) -> JumpKeyResult` in `src/jump_overlay.rs`.
- Implement per-key behavior: key-up => `Ignored`, `Escape` key-down => `Cancelled`, `Backspace` key-down => remove char + `Consumed`, `A..Z` key-down => append uppercase + `Consumed`/`Completed`, and unsupported keys are documented as `Ignored` to avoid mutating input state.
- Fix invalid-code flow so validation happens before hiding and an invalid entry clears the input, requests a repaint, keeps overlay visible, and returns `Invalid` rather than hiding the overlay.
- Add jump session tracking in `MouseMaster` (`activation_key: Option<VirtualKey>` and `activation_key_released: bool`) and update the keyboard hook in `src/main.rs` to suppress repeated activation-key down events until the first release and to handle every `JumpKeyResult` variant with explicit `jump_active`/session transitions.
- Add unit tests in `src/jump_overlay.rs` for jump-only transitions: key-up ignored, `Escape` cancels, valid two-letter code completes, and invalid code returns `Invalid` while remaining active and clearing input.

### Testing
- Ran `cargo fmt` and then `cargo test -q`; the test run failed in this environment due to a missing system `xi`/X11 pkg-config dependency required by a transitive `x11` crate, which prevented running the test suite here (failure is an external system dependency, not logic changes).
- The new unit tests are included in `src/jump_overlay.rs` and should pass once system test dependencies are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08c91389908332bfa11967d7a1713a)