### PR TITLE
Refine slow mouse speed resolution and transition behavior

### DIFF
--- a/src/action_handler.rs
+++ b/src/action_handler.rs
@@ -978,7 +978,7 @@ fn effective_slow_speed(config: &Config, baseline_speed: i32) -> i32 {
     let resolved = match config.slow_mouse.strategy {
         crate::SlowMouseStrategy::Fixed => config.slow_mouse.fixed_speed,
         crate::SlowMouseStrategy::Multiplier => {
-            (f64::from(baseline_speed) * config.slow_mouse.multiplier).round() as i32
+            (f64::from(baseline_speed) * f64::from(config.slow_mouse.multiplier)).round() as i32
         }
         crate::SlowMouseStrategy::Subtract => baseline_speed - config.slow_mouse.subtract_speed,
     };

--- a/src/action_handler.rs
+++ b/src/action_handler.rs
@@ -974,6 +974,18 @@ fn debug_diagnostics_enabled() -> bool {
         .unwrap_or(false)
 }
 
+fn effective_slow_speed(config: &Config, baseline_speed: i32) -> i32 {
+    let resolved = match config.slow_mouse.strategy {
+        crate::SlowMouseStrategy::Fixed => config.slow_mouse.fixed_speed,
+        crate::SlowMouseStrategy::Multiplier => {
+            (f64::from(baseline_speed) * config.slow_mouse.multiplier).round() as i32
+        }
+        crate::SlowMouseStrategy::Subtract => baseline_speed - config.slow_mouse.subtract_speed,
+    };
+
+    resolved.clamp(config.slow_mouse.min_speed, config.slow_mouse.max_speed)
+}
+
 fn calculate_movement(
     active_actions: &HashSet<Action>,
     config: &Config,
@@ -1025,7 +1037,7 @@ fn calculate_movement(
     let speed = if active_actions.contains(&Action::SlowMouse) {
         *current_speed = baseline_speed;
         *acceleration_counter = 0;
-        *current_speed
+        effective_slow_speed(config, baseline_speed)
     } else {
         advance_speed(
             config,
@@ -1535,8 +1547,8 @@ mod tests {
             &mut acceleration_counter,
         );
 
-        assert_eq!(movement.speed, config.starting_speed);
-        assert_eq!(movement.dx, f64::from(config.starting_speed));
+        assert_eq!(movement.speed, effective_slow_speed(&config, config.starting_speed));
+        assert_eq!(movement.dx, f64::from(effective_slow_speed(&config, config.starting_speed)));
         assert_eq!(movement.dy, 0.0);
     }
 
@@ -1832,9 +1844,28 @@ mod tests {
         let slow_tick = mouse.tick_movement(&slow_actions, Duration::from_millis(8));
         let release_tick = mouse.tick_movement(&movement_actions, Duration::from_millis(8));
 
-        assert_eq!(slow_tick.speed, 4);
+        assert_eq!(slow_tick.speed, effective_slow_speed(&mouse.config, 4));
         assert_eq!(release_tick.speed, 4);
         assert_eq!(mouse.mouse_speed_baseline, 4);
+    }
+
+    #[test]
+    fn effective_slow_speed_applies_strategy_and_clamps() {
+        let mut config = test_config();
+        config.slow_mouse.min_speed = 2;
+        config.slow_mouse.max_speed = 6;
+
+        config.slow_mouse.strategy = crate::SlowMouseStrategy::Fixed;
+        config.slow_mouse.fixed_speed = 9;
+        assert_eq!(effective_slow_speed(&config, 5), 6);
+
+        config.slow_mouse.strategy = crate::SlowMouseStrategy::Multiplier;
+        config.slow_mouse.multiplier = 0.49;
+        assert_eq!(effective_slow_speed(&config, 9), 4);
+
+        config.slow_mouse.strategy = crate::SlowMouseStrategy::Subtract;
+        config.slow_mouse.subtract_speed = 10;
+        assert_eq!(effective_slow_speed(&config, 9), 2);
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Provide a single helper to resolve slow-mode tick speed from the configured strategy and enforce slow-mode semantics so that holding slow mode only affects emitted movement speed while release resumes the previously-selected baseline tier.
- Preserve existing diagonal normalization and deterministic acceleration/transition behavior so slow-mode doesn't alter runtime baseline or acceleration history unexpectedly.

### Description
- Added `fn effective_slow_speed(config: &Config, baseline_speed: i32) -> i32` that resolves slow speed for `Fixed`, `Multiplier`, and `Subtract` strategies and clamps the result to `slow_mouse.min_speed..=slow_mouse.max_speed`.
- Updated `calculate_movement` so when `Action::SlowMouse` is active it emits the resolved slow tick from `effective_slow_speed(...)`, while keeping `mouse_speed_baseline` (and `current_speed` baseline state) intact and resetting runtime acceleration state for deterministic transitions.
- Kept diagonal normalization and vector scaling unchanged by continuing to compute a scalar `speed` and passing it through the existing normalization logic.
- Adjusted tests to assert the new slow-speed semantics and added `effective_slow_speed_applies_strategy_and_clamps` to validate strategy handling and clamping.

### Testing
- Attempted to run targeted tests with `cargo test slow_mouse` but the build failed in this environment due to a missing system dependency: crate `x11` requires the system `xi` library (`pkg-config` could not find `xi.pc`), so automated tests could not be executed here.
- Unit tests were updated/added in `src/action_handler.rs` to cover slow-mode resolution, clamping, and release semantics (these tests are expected to run successfully in an environment with the required system libraries).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a122739abf08332844d5fdb6b8ec726)