### PR TITLE
Add config-audit tests for slow_mouse config paths

### DIFF
--- a/src/config_audit.rs
+++ b/src/config_audit.rs
@@ -638,6 +638,54 @@ mod tests {
     }
 
     #[test]
+    fn audit_treats_slow_mouse_paths_as_known_and_active() {
+        let report = audit_config_toml(
+            r#"
+            [slow_mouse]
+            strategy = "fixed"
+            fixed_speed = 1
+            multiplier = 0.75
+            subtract_speed = 1
+            min_speed = 1
+            max_speed = 5
+            acceleration = 1
+            acceleration_rate = 1
+            "#,
+        );
+
+        for path in [
+            "slow_mouse.strategy",
+            "slow_mouse.fixed_speed",
+            "slow_mouse.multiplier",
+            "slow_mouse.subtract_speed",
+            "slow_mouse.min_speed",
+            "slow_mouse.max_speed",
+            "slow_mouse.acceleration",
+            "slow_mouse.acceleration_rate",
+        ] {
+            assert!(
+                !report.warnings.iter().any(|warning| warning.path == path),
+                "expected {path} to be known/active, warnings: {:?}",
+                report.warnings
+            );
+        }
+    }
+
+    #[test]
+    fn audit_keeps_slow_mouse_typo_path_unknown() {
+        let report = audit_config_toml(
+            r#"
+            [slow_mouse]
+            multiplyer = 0.75
+            "#,
+        );
+
+        let warning = warning_for(&report, "slow_mouse.multiplyer");
+        assert_eq!(warning.severity, ConfigAuditSeverity::Warning);
+        assert!(warning.message.contains("Unknown config path"));
+    }
+
+    #[test]
     fn audit_parses_invalid_toml_gracefully() {
         let report = audit_config_toml("[jump\nmode = \"precision\"");
 


### PR DESCRIPTION
### Motivation
- Ensure all `slow_mouse.*` config keys are recognized as active and do not trigger unknown-path warnings in the config auditor.
- Provide a negative control to ensure nearby-typo keys (e.g. `slow_mouse.multiplyer`) remain flagged as unknown.

### Description
- Added two unit tests to `src/config_audit.rs`: `audit_treats_slow_mouse_paths_as_known_and_active` and `audit_keeps_slow_mouse_typo_path_unknown` that validate knownness and typo behavior for `slow_mouse` keys.
- The new positive test asserts that the following paths do not produce unknown-path warnings: `slow_mouse.strategy`, `slow_mouse.fixed_speed`, `slow_mouse.multiplier`, `slow_mouse.subtract_speed`, `slow_mouse.min_speed`, `slow_mouse.max_speed`, `slow_mouse.acceleration`, and `slow_mouse.acceleration_rate`.
- The new negative test asserts that `slow_mouse.multiplyer` is still reported as an unknown config path with `Warning` severity.
- Changes are contained in `src/config_audit.rs` (unit test additions) and rely on the existing `is_known_active_path` logic which includes the `slow_mouse.*` entries.

### Testing
- Ran `cargo test -q config_audit` to exercise the updated unit tests.
- Test execution was blocked by a build failure unrelated to the tests: missing system library `xi` required by crate `x11` (pkg-config reported `Package xi was not found`), so the test run did not complete successfully in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a122bd3cd6c83329ee8a065155ba213)