### PR TITLE
Document `slow_mouse` configuration and strategy behavior

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -88,6 +88,38 @@ max_speed = 12
 speed_step = 1
 flash_indicator_ms = 700
 
+# Slow mode is a temporary precision tier triggered by the `slow_mouse` action
+# (LeftShift in this sample config). It is independent from normal [mouse_speed]:
+# [mouse_speed] controls your baseline movement tier, while [slow_mouse] controls
+# only the held slow-mode tier.
+#
+# Strategy reference:
+# - fixed:      use fixed_speed directly (most predictable; recommended default)
+# - multiplier: scale current normal speed by multiplier
+# - subtract:   reduce current normal speed by subtract_speed
+#
+# Recommended defaults for most users:
+# strategy = "fixed", fixed_speed = 1, min_speed = 1, max_speed = 2,
+# acceleration = 0, acceleration_rate = 1
+#
+# Optional preset snippets:
+# Precision-focused preset (high control, no ramp):
+# [slow_mouse]
+# strategy = "fixed"
+# fixed_speed = 1
+# min_speed = 1
+# max_speed = 2
+# acceleration = 0
+# acceleration_rate = 1
+#
+# Scaled slow mode preset (tracks current normal speed):
+# [slow_mouse]
+# strategy = "multiplier"
+# multiplier = 0.35
+# min_speed = 1
+# max_speed = 4
+# acceleration = 0
+# acceleration_rate = 1
 [slow_mouse]
 strategy = "fixed" # fixed | multiplier | subtract
 fixed_speed = 1

--- a/docs/config.md
+++ b/docs/config.md
@@ -17,6 +17,14 @@ Status values used here: Active, Legacy, Deprecated alias, Preview-related.
 | `mouse_speed.max_speed` | integer | `12` | Yes | Active | Upper bound for runtime mouse speed changes. |
 | `mouse_speed.speed_step` | integer | `1` | Yes | Active | Increment used by mouse speed up/down actions. |
 | `mouse_speed.flash_indicator_ms` | integer milliseconds | `700` | Yes | Active | Duration for mouse-speed feedback. |
+| `slow_mouse.strategy` | enum string | `"fixed"` | Yes | Active | Slow-mode speed strategy: `fixed`, `multiplier`, or `subtract`. |
+| `slow_mouse.fixed_speed` | integer | `1` | Yes | Active | Target speed used when `strategy = "fixed"`. |
+| `slow_mouse.multiplier` | float | `0.25` | Yes | Active | Multiplies current normal speed when `strategy = "multiplier"`. |
+| `slow_mouse.subtract_speed` | integer | `4` | Yes | Active | Amount subtracted from current normal speed when `strategy = "subtract"`. |
+| `slow_mouse.min_speed` | integer | `1` | Yes | Active | Lower clamp applied after strategy calculation. |
+| `slow_mouse.max_speed` | integer | `2` | Yes | Active | Upper clamp applied after strategy calculation. |
+| `slow_mouse.acceleration` | integer | `0` | Yes | Active | Slow-mode ramp increment applied while held movement continues. |
+| `slow_mouse.acceleration_rate` | integer polling cycles | `1` | Yes | Active | Slow-mode ramp cadence in polling cycles. |
 | `movement_profiles.*.default_speed` | integer | none | Yes | Active | Optional named movement profile override. |
 | `movement_profiles.*.min_speed` | integer | none | Yes | Active | Optional named movement profile override. |
 | `movement_profiles.*.max_speed` | integer | none | Yes | Active | Optional named movement profile override. |
@@ -151,6 +159,17 @@ Status values used here: Active, Legacy, Deprecated alias, Preview-related.
 | `grid_mode.acceleration` | integer | none | No | Legacy | Mis-scoped old path. Move to top-level `acceleration`. |
 | `grid_mode.acceleration_rate` | integer | none | No | Legacy | Mis-scoped old path. Move to top-level `acceleration_rate`. |
 | `grid_mode.top_speed` | integer | none | No | Legacy | Mis-scoped old path. Move to top-level `top_speed`. |
+
+
+### Slow mouse strategy selection
+
+Slow mode is a separate held-movement tier and is independent from normal `[mouse_speed]` settings. Use `[mouse_speed]` for your regular movement baseline and use `[slow_mouse]` only for the temporary precision tier triggered by the `slow_mouse` action.
+
+- `fixed`: Uses `slow_mouse.fixed_speed` directly (then applies `min_speed`/`max_speed` clamps). Best when you want a predictable precision speed regardless of your current normal speed or profile.
+- `multiplier`: Uses `current_normal_speed * slow_mouse.multiplier` (then clamps). Best when you want slow mode to scale proportionally with whichever normal speed is currently active.
+- `subtract`: Uses `current_normal_speed - slow_mouse.subtract_speed` (then clamps). Best when you want to keep the current speed feel but step down by a consistent amount.
+
+If unsure, start with `fixed` for stable precision behavior, then switch to `multiplier` when you use multiple movement profiles and want consistent relative slowdown.
 
 ## Critical Examples
 


### PR DESCRIPTION
### Motivation

- Improve discoverability and clarity for the slow-mode (precision) held-movement tier by documenting all `slow_mouse.*` fields. 
- Explain the available slow-mode strategies and guidance for choosing between `fixed`, `multiplier`, and `subtract`. 
- Make the checked-in `config.toml` self-explanatory by adding purpose, recommended defaults, and example presets for slow mode. 
- Explicitly state that slow mode is independent from the normal `[mouse_speed]` tier so users understand the separation of concerns.

### Description

- Added `slow_mouse.*` rows to `docs/config.md` covering `strategy`, `fixed_speed`, `multiplier`, `subtract_speed`, `min_speed`, `max_speed`, `acceleration`, and `acceleration_rate` with types, defaults, connected status, and concise behavior notes. 
- Inserted a new `### Slow mouse strategy selection` subsection to `docs/config.md` describing how `fixed`, `multiplier`, and `subtract` work and when each is appropriate, and noting that slow mode is independent from `[mouse_speed]`. 
- Expanded checked-in `config.toml` comments immediately above the `[slow_mouse]` table to document the purpose of slow mode, strategy explanations, recommended defaults, and two optional preset snippets (precision-focused and scaled slow mode). 
- Left the runtime fields for `slow_mouse` intact and unchanged; only documentation and commented examples were added.

### Testing

- No automated tests were executed because this is a documentation and config-comment change only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a122d5ba4208332bbf104917927a983)