### PR TITLE
Add comprehensive slow-mouse movement regression tests

### DIFF
--- a/src/action_handler.rs
+++ b/src/action_handler.rs
@@ -1848,7 +1848,69 @@ mod tests {
     }
 
     #[test]
-    fn slow_mouse_release_restores_selected_tier_baseline() {
+    fn slow_mouse_fixed_speed_ignores_high_mouse_speed_tier() {
+        let mut config = test_config();
+        config.mouse_speed.default_speed = 9;
+        config.starting_speed = 9;
+        config.slow_mouse.strategy = crate::SlowMouseStrategy::Fixed;
+        config.slow_mouse.fixed_speed = 3;
+        config.slow_mouse.min_speed = 1;
+        config.slow_mouse.max_speed = 12;
+
+        let mut mouse = MouseMaster::new_with_backend(config, FakeBackend::default());
+        let slow_actions = actions(&[Action::MoveRight, Action::SlowMouse]);
+
+        let slow_tick = mouse.tick_movement(&slow_actions, Duration::from_millis(8));
+
+        assert_eq!(slow_tick.speed, 3);
+        assert_eq!(slow_tick.dx, 3.0);
+        assert_eq!(mouse.mouse_speed_baseline, 9);
+        assert_eq!(mouse.current_speed, 9);
+        assert_eq!(mouse.acceleration_counter, 0);
+    }
+
+    #[test]
+    fn slow_mouse_multiplier_clamps_to_configured_max() {
+        let mut config = test_config();
+        config.slow_mouse.strategy = crate::SlowMouseStrategy::Multiplier;
+        config.slow_mouse.multiplier = 3.0;
+        config.slow_mouse.min_speed = 1;
+        config.slow_mouse.max_speed = 6;
+
+        let mut mouse = MouseMaster::new_with_backend(config, FakeBackend::default());
+        let slow_actions = actions(&[Action::MoveRight, Action::SlowMouse]);
+
+        let slow_tick = mouse.tick_movement(&slow_actions, Duration::from_millis(8));
+
+        assert_eq!(slow_tick.speed, 6);
+        assert_eq!(slow_tick.dx, 6.0);
+        assert_eq!(mouse.mouse_speed_baseline, config.mouse_speed.default_speed);
+        assert_eq!(mouse.current_speed, config.mouse_speed.default_speed);
+        assert_eq!(mouse.acceleration_counter, 0);
+    }
+
+    #[test]
+    fn slow_mouse_subtract_clamps_to_min() {
+        let mut config = test_config();
+        config.slow_mouse.strategy = crate::SlowMouseStrategy::Subtract;
+        config.slow_mouse.subtract_speed = 50;
+        config.slow_mouse.min_speed = 2;
+        config.slow_mouse.max_speed = 12;
+
+        let mut mouse = MouseMaster::new_with_backend(config, FakeBackend::default());
+        let slow_actions = actions(&[Action::MoveRight, Action::SlowMouse]);
+
+        let slow_tick = mouse.tick_movement(&slow_actions, Duration::from_millis(8));
+
+        assert_eq!(slow_tick.speed, 2);
+        assert_eq!(slow_tick.dx, 2.0);
+        assert_eq!(mouse.mouse_speed_baseline, config.mouse_speed.default_speed);
+        assert_eq!(mouse.current_speed, config.mouse_speed.default_speed);
+        assert_eq!(mouse.acceleration_counter, 0);
+    }
+
+    #[test]
+    fn slow_mouse_release_uses_slow_tick_then_returns_to_selected_tier_baseline() {
         let mut config = test_config();
         config.mouse_speed.default_speed = 4;
         config.starting_speed = 4;
@@ -1862,6 +1924,30 @@ mod tests {
         assert_eq!(slow_tick.speed, effective_slow_speed(&mouse.config, 4));
         assert_eq!(release_tick.speed, 4);
         assert_eq!(mouse.mouse_speed_baseline, 4);
+        assert_eq!(mouse.current_speed, 4);
+        assert_eq!(mouse.acceleration_counter, 1);
+    }
+
+    #[test]
+    fn slow_mouse_diagonal_movement_uses_slow_speed_magnitude() {
+        let mut config = test_config();
+        config.mouse_speed.default_speed = 7;
+        config.starting_speed = 7;
+        config.slow_mouse.strategy = crate::SlowMouseStrategy::Fixed;
+        config.slow_mouse.fixed_speed = 5;
+        let mut mouse = MouseMaster::new_with_backend(config, FakeBackend::default());
+        let slow_diagonal_actions = actions(&[Action::MoveUp, Action::MoveRight, Action::SlowMouse]);
+
+        let tick = mouse.tick_movement(&slow_diagonal_actions, Duration::from_millis(8));
+        let magnitude = (tick.dx.powi(2) + tick.dy.powi(2)).sqrt();
+
+        assert_eq!(tick.speed, 5);
+        assert!((magnitude - 5.0).abs() < f64::EPSILON);
+        assert!((tick.dx - (5.0 * DIAGONAL_NORMALIZATION)).abs() < f64::EPSILON);
+        assert!((tick.dy + (5.0 * DIAGONAL_NORMALIZATION)).abs() < f64::EPSILON);
+        assert_eq!(mouse.mouse_speed_baseline, 7);
+        assert_eq!(mouse.current_speed, 7);
+        assert_eq!(mouse.acceleration_counter, 0);
     }
 
     #[test]

--- a/src/action_handler.rs
+++ b/src/action_handler.rs
@@ -1856,6 +1856,7 @@ mod tests {
         config.slow_mouse.fixed_speed = 3;
         config.slow_mouse.min_speed = 1;
         config.slow_mouse.max_speed = 12;
+        let expected_baseline = config.mouse_speed.default_speed;
 
         let mut mouse = MouseMaster::new_with_backend(config, FakeBackend::default());
         let slow_actions = actions(&[Action::MoveRight, Action::SlowMouse]);
@@ -1876,6 +1877,7 @@ mod tests {
         config.slow_mouse.multiplier = 3.0;
         config.slow_mouse.min_speed = 1;
         config.slow_mouse.max_speed = 6;
+        let expected_baseline = config.mouse_speed.default_speed;
 
         let mut mouse = MouseMaster::new_with_backend(config, FakeBackend::default());
         let slow_actions = actions(&[Action::MoveRight, Action::SlowMouse]);
@@ -1884,8 +1886,8 @@ mod tests {
 
         assert_eq!(slow_tick.speed, 6);
         assert_eq!(slow_tick.dx, 6.0);
-        assert_eq!(mouse.mouse_speed_baseline, config.mouse_speed.default_speed);
-        assert_eq!(mouse.current_speed, config.mouse_speed.default_speed);
+        assert_eq!(mouse.mouse_speed_baseline, expected_baseline);
+        assert_eq!(mouse.current_speed, expected_baseline);
         assert_eq!(mouse.acceleration_counter, 0);
     }
 
@@ -1896,6 +1898,7 @@ mod tests {
         config.slow_mouse.subtract_speed = 50;
         config.slow_mouse.min_speed = 2;
         config.slow_mouse.max_speed = 12;
+        let expected_baseline = config.mouse_speed.default_speed;
 
         let mut mouse = MouseMaster::new_with_backend(config, FakeBackend::default());
         let slow_actions = actions(&[Action::MoveRight, Action::SlowMouse]);
@@ -1904,8 +1907,8 @@ mod tests {
 
         assert_eq!(slow_tick.speed, 2);
         assert_eq!(slow_tick.dx, 2.0);
-        assert_eq!(mouse.mouse_speed_baseline, config.mouse_speed.default_speed);
-        assert_eq!(mouse.current_speed, config.mouse_speed.default_speed);
+        assert_eq!(mouse.mouse_speed_baseline, expected_baseline);
+        assert_eq!(mouse.current_speed, expected_baseline);
         assert_eq!(mouse.acceleration_counter, 0);
     }
 

--- a/src/action_handler.rs
+++ b/src/action_handler.rs
@@ -1938,6 +1938,8 @@ mod tests {
         config.starting_speed = 7;
         config.slow_mouse.strategy = crate::SlowMouseStrategy::Fixed;
         config.slow_mouse.fixed_speed = 5;
+        config.slow_mouse.min_speed = 1;
+        config.slow_mouse.max_speed = 12;
         let mut mouse = MouseMaster::new_with_backend(config, FakeBackend::default());
         let slow_diagonal_actions = actions(&[Action::MoveUp, Action::MoveRight, Action::SlowMouse]);
 


### PR DESCRIPTION
### Motivation
- Cover regressions and edge cases in slow-mouse behavior for the three slow strategies (`Fixed`, `Multiplier`, `Subtract`) and ensure clamping semantics are correct.
- Strengthen the slow-release regression to verify both tick outputs and that post-release state returns to the selected baseline tier.
- Ensure diagonal slow movement under slow mode preserves intended magnitude and axis normalization while also validating runtime state remains consistent.

### Description
- Added focused unit tests to `src/action_handler.rs`: `slow_mouse_fixed_speed_ignores_high_mouse_speed_tier`, `slow_mouse_multiplier_clamps_to_configured_max`, `slow_mouse_subtract_clamps_to_min`, `slow_mouse_release_uses_slow_tick_then_returns_to_selected_tier_baseline`, and `slow_mouse_diagonal_movement_uses_slow_speed_magnitude` which exercise `tick_movement` using existing deterministic test helpers (`test_config`, `actions`, `FakeBackend`, and the `tick` style helpers).
- Replaced the prior slow-release test with a stronger assertion set that checks the slow tick value, the first post-release tick returns to baseline tier, and that baseline/internal runtime state (`mouse_speed_baseline`, `current_speed`, `acceleration_counter`) is preserved or updated as expected.
- The diagonal test uses the repo’s existing normalization convention (`DIAGONAL_NORMALIZATION`) and floating-point tolerance style (`f64::EPSILON`) to assert both magnitude and per-axis components.

### Testing
- Attempted to run the focused tests with `cargo test slow_mouse_ -- --nocapture` in this environment, but test execution is blocked by a missing system dependency required by the `x11` crate (`xi` pkg-config entry), causing the build to fail before tests ran.
- No repo-level Rust test failures were observed in logic during editing; the failure is environmental (`pkg-config`/X11 `xi` system library) and not due to the new test code itself.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1238dd5c8c8332a69c011d5e062dae)