### PR TITLE
Add tests for action-mapped grid movement and remapped routing

### DIFF
--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -1994,7 +1994,7 @@ mod tests {
             (VirtualKey::Escape, None),
         ] {
             let event = KeyEvent::new(key, true);
-            state.route_key_event(event, action);
+            state.route_key_event(event, action.clone());
             assert_eq!(
                 state.pop_command(),
                 Some(AppCommand::GridInput(event, action)),
@@ -2015,7 +2015,7 @@ mod tests {
             (VirtualKey::D, Some(Action::MoveRight)),
         ] {
             let event = KeyEvent::new(key, true);
-            state.route_key_event(event, action);
+            state.route_key_event(event, action.clone());
             assert_eq!(state.pop_command(), Some(AppCommand::GridInput(event, action)));
         }
     }
@@ -2062,9 +2062,6 @@ mod tests {
 
     #[test]
     fn grid_movement_uses_action_mapping_for_all_directions() {
-        let mut state = AppState::default();
-        enter_grid_mode(&mut state, VirtualKey::G);
-
         let cases = [
             (
                 VirtualKey::F,
@@ -2109,8 +2106,9 @@ mod tests {
         ];
 
         for (key, action, expected_region) in cases {
-            let mut case_state = state.clone();
-            let update = case_state.handle_grid_input(KeyEvent::new(key, true), Some(action));
+            let mut state = AppState::default();
+            enter_grid_mode(&mut state, VirtualKey::G);
+            let update = state.handle_grid_input(KeyEvent::new(key, true), Some(action));
             assert_eq!(
                 update,
                 Some(GridInputUpdate::Updated {

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -1981,25 +1981,42 @@ mod tests {
     }
 
     #[test]
-    fn grid_mode_owns_wasd_escape_and_backspace() {
+    fn grid_mode_owns_directional_actions_plus_escape_and_backspace_keys() {
         let mut state = AppState::default();
         enter_grid_mode(&mut state, VirtualKey::G);
 
-        for key in [
-            VirtualKey::W,
-            VirtualKey::A,
-            VirtualKey::S,
-            VirtualKey::D,
-            VirtualKey::Backspace,
-            VirtualKey::Escape,
+        for (key, action) in [
+            (VirtualKey::F, Some(Action::MoveRight)),
+            (VirtualKey::J, Some(Action::MoveLeft)),
+            (VirtualKey::I, Some(Action::MoveUp)),
+            (VirtualKey::K, Some(Action::MoveDown)),
+            (VirtualKey::Backspace, None),
+            (VirtualKey::Escape, None),
         ] {
             let event = KeyEvent::new(key, true);
-            state.route_key_event(event, Some(Action::MoveLeft));
+            state.route_key_event(event, action);
             assert_eq!(
                 state.pop_command(),
-                Some(AppCommand::GridInput(event, Some(Action::MoveLeft))),
+                Some(AppCommand::GridInput(event, action)),
                 "{key:?}"
             );
+        }
+    }
+
+    #[test]
+    fn grid_mode_still_owns_wasd_when_default_action_mapping_is_used() {
+        let mut state = AppState::default();
+        enter_grid_mode(&mut state, VirtualKey::G);
+
+        for (key, action) in [
+            (VirtualKey::W, Some(Action::MoveUp)),
+            (VirtualKey::A, Some(Action::MoveLeft)),
+            (VirtualKey::S, Some(Action::MoveDown)),
+            (VirtualKey::D, Some(Action::MoveRight)),
+        ] {
+            let event = KeyEvent::new(key, true);
+            state.route_key_event(event, action);
+            assert_eq!(state.pop_command(), Some(AppCommand::GridInput(event, action)));
         }
     }
 
@@ -2044,6 +2061,79 @@ mod tests {
     }
 
     #[test]
+    fn grid_movement_uses_action_mapping_for_all_directions() {
+        let mut state = AppState::default();
+        enter_grid_mode(&mut state, VirtualKey::G);
+
+        let cases = [
+            (
+                VirtualKey::F,
+                Action::MoveRight,
+                JumpRegion {
+                    left: 50,
+                    top: 0,
+                    width: 50,
+                    height: 100,
+                },
+            ),
+            (
+                VirtualKey::J,
+                Action::MoveLeft,
+                JumpRegion {
+                    left: 0,
+                    top: 0,
+                    width: 50,
+                    height: 100,
+                },
+            ),
+            (
+                VirtualKey::I,
+                Action::MoveUp,
+                JumpRegion {
+                    left: 0,
+                    top: 0,
+                    width: 100,
+                    height: 50,
+                },
+            ),
+            (
+                VirtualKey::K,
+                Action::MoveDown,
+                JumpRegion {
+                    left: 0,
+                    top: 50,
+                    width: 100,
+                    height: 50,
+                },
+            ),
+        ];
+
+        for (key, action, expected_region) in cases {
+            let mut case_state = state.clone();
+            let update = case_state.handle_grid_input(KeyEvent::new(key, true), Some(action));
+            assert_eq!(
+                update,
+                Some(GridInputUpdate::Updated {
+                    region: expected_region,
+                    move_cursor: true,
+                }),
+                "{key:?} should map via {action:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn grid_input_non_movement_action_is_consumed_without_splitting() {
+        let mut state = AppState::default();
+        enter_grid_mode(&mut state, VirtualKey::G);
+
+        assert_eq!(
+            state.handle_grid_input(KeyEvent::new(VirtualKey::F, true), Some(Action::ShowHelp)),
+            Some(GridInputUpdate::Consumed)
+        );
+    }
+
+    #[test]
     fn grid_completion_clears_active_keys_when_exiting() {
         let mut state = AppState::default();
         assert!(state.enter_grid_mode(
@@ -2083,6 +2173,40 @@ mod tests {
 
         assert!(!state.has_active_action_keys());
         assert_eq!(state.resolve_jump_overlay(), JumpOverlayResolution::Hidden);
+    }
+
+    #[test]
+    fn grid_completion_triggers_with_remapped_movement_action() {
+        let mut state = AppState::default();
+        assert!(state.enter_grid_mode(
+            jump_region(),
+            JumpRegion {
+                left: 50,
+                top: 0,
+                width: 50,
+                height: 100,
+            },
+            25,
+            25,
+            true,
+            true,
+            true,
+            VirtualKey::G,
+        ));
+
+        assert_eq!(
+            state.handle_grid_input(KeyEvent::new(VirtualKey::F, true), Some(Action::MoveRight)),
+            Some(GridInputUpdate::Completed {
+                x: 88,
+                y: 50,
+                region: JumpRegion {
+                    left: 75,
+                    top: 0,
+                    width: 25,
+                    height: 100,
+                },
+            })
+        );
     }
 
     #[test]

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -2108,7 +2108,7 @@ mod tests {
         for (key, action, expected_region) in cases {
             let mut state = AppState::default();
             enter_grid_mode(&mut state, VirtualKey::G);
-            let update = state.handle_grid_input(KeyEvent::new(key, true), Some(action));
+            let update = state.handle_grid_input(KeyEvent::new(key, true), Some(action.clone()));
             assert_eq!(
                 update,
                 Some(GridInputUpdate::Updated {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3679,6 +3679,21 @@ mod tests {
         );
 
         assert_eq!(
+            app_state.handle_grid_input(
+                KeyEvent::new(VirtualKey::F, true),
+                Some(Action::MoveRight)
+            ),
+            Some(GridInputUpdate::Updated {
+                region: JumpRegion {
+                    left: 50,
+                    top: 0,
+                    width: 50,
+                    height: 100,
+                },
+                move_cursor: true,
+            })
+        );
+        assert_eq!(
             app_state.handle_grid_input(KeyEvent::new(VirtualKey::Backspace, true), None),
             Some(GridInputUpdate::Updated {
                 region: JumpRegion {

--- a/src/main.rs
+++ b/src/main.rs
@@ -3612,6 +3612,90 @@ mod tests {
     }
 
     #[test]
+    fn remapped_grid_movement_routes_by_action_with_wasd_unbound() {
+        let config = parse_config(
+            r#"
+            key_bindings = [
+                ["F", "move_right"],
+                ["J", "move_left"],
+                ["I", "move_up"],
+                ["K", "move_down"]
+            ]
+            "#,
+        );
+
+        let mut bindings = KeyBindings::new();
+        for (key, action) in &config.key_bindings {
+            let chord = KeyChord::parse(key).unwrap();
+            let action = Action::from_string(action).unwrap();
+            bindings.add_chord_binding(chord, action);
+        }
+
+        let mut app_state = AppState::default();
+        assert!(app_state.enter_grid_mode(
+            JumpRegion {
+                left: 0,
+                top: 0,
+                width: 100,
+                height: 100,
+            },
+            JumpRegion {
+                left: 0,
+                top: 0,
+                width: 100,
+                height: 100,
+            },
+            25,
+            25,
+            true,
+            true,
+            true,
+            VirtualKey::G,
+        ));
+
+        for (key, expected_action) in [
+            (VirtualKey::F, Action::MoveRight),
+            (VirtualKey::J, Action::MoveLeft),
+            (VirtualKey::I, Action::MoveUp),
+            (VirtualKey::K, Action::MoveDown),
+        ] {
+            let event = KeyEvent::new(key, true);
+            let resolved = bindings.get_action_for_event(&event);
+            app_state.route_key_event(event, resolved);
+            assert_eq!(
+                app_state.pop_command(),
+                Some(AppCommand::GridInput(event, Some(expected_action)))
+            );
+        }
+
+        assert_eq!(
+            bindings.get_action_for_event(&KeyEvent::new(VirtualKey::W, true)),
+            None
+        );
+        assert_eq!(
+            app_state.handle_grid_input(KeyEvent::new(VirtualKey::W, true), None),
+            Some(GridInputUpdate::Consumed)
+        );
+
+        assert_eq!(
+            app_state.handle_grid_input(KeyEvent::new(VirtualKey::Backspace, true), None),
+            Some(GridInputUpdate::Updated {
+                region: JumpRegion {
+                    left: 0,
+                    top: 0,
+                    width: 100,
+                    height: 100,
+                },
+                move_cursor: true,
+            })
+        );
+        assert_eq!(
+            app_state.handle_grid_input(KeyEvent::new(VirtualKey::Escape, true), None),
+            Some(GridInputUpdate::Cancelled)
+        );
+    }
+
+    #[test]
     fn invalid_system_binding_fails_normalization() {
         let config = toml::from_str::<Config>(
             r#"

--- a/src/main.rs
+++ b/src/main.rs
@@ -2997,6 +2997,7 @@ fn main() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::jump_session::JumpRegion;
     use enigo::{Axis, Button};
 
     const LEGACY_PACKAGE_NAME: &str = concat!("Learn", "ing", "_", "Ru", "st");


### PR DESCRIPTION
### Motivation
- Ensure grid navigation is driven by resolved movement *actions* (not by hard-coded WASD keys) so remapped keys still narrow/split the grid.
- Preserve key-based semantics for `Escape` (cancel) and `Backspace` (undo) regardless of movement remapping.
- Verify command routing carries the resolved `Action` into the enqueued `GridInput` and that non-movement actions do not split the grid.
- Add an integration-style config test to exercise parsing + action resolution so remapped movement keys still drive grid splits even if WASD are unbound.

### Description
- Updated unit tests in `src/app_state.rs` to be action-centric: replaced the old `grid_mode_owns_wasd_escape_and_backspace` with `grid_mode_owns_directional_actions_plus_escape_and_backspace_keys` and added `grid_mode_still_owns_wasd_when_default_action_mapping_is_used` to preserve legacy coverage.
- Added table-driven unit tests in `src/app_state.rs` covering all four directions via remapped keys (`F/J/I/K`) in `grid_movement_uses_action_mapping_for_all_directions`, a negative test `grid_input_non_movement_action_is_consumed_without_splitting`, and `grid_completion_triggers_with_remapped_movement_action` to assert `GridInputUpdate::Completed` via remapped actions.
- Extended routing/config tests in `src/main.rs` with `remapped_grid_movement_routes_by_action_with_wasd_unbound` which parses a sample config remapping movement keys, builds `KeyBindings`, resolves actions for events, routes through `AppState::route_key_event`, and asserts enqueued `AppCommand::GridInput` contains the resolved action and that `Backspace`/`Escape` semantics remain intact.

### Testing
- Attempted to run the focused test run with `cargo test grid_ -- --nocapture` in this environment, but the build failed during dependency compilation because the system X11 XI development pkg-config file (`xi.pc`) required by the `x11` crate was missing; as a result the new tests could not be executed here.
- No automated test assertions were reported as run successfully in this environment due to the external system dependency failure. If the system `xi` dev package is installed (so `xi.pc` is available on `PKG_CONFIG_PATH`), running `cargo test` will execute the new unit and integration-style tests added in `src/app_state.rs` and `src/main.rs`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12e71fd9c083328b85cbb39406b7fe)