### PR TITLE
Add Windows UI-hint acquisition module and async query pipeline

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,11 @@
         "Win32_Foundation",
         "Win32_Graphics_Gdi",
         "Win32_Graphics_GdiPlus",
+        "Win32_System_Com",
         "Win32_System_LibraryLoader",
         "Win32_System_Threading",
+        "Win32_System_Variant",
+        "Win32_UI_Accessibility",
         "Win32_UI_Input_KeyboardAndMouse",
         "Win32_UI_WindowsAndMessaging"
     ]}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2914,7 +2914,7 @@ fn execute_app_command(command: AppCommand, debug_diagnostics: bool) {
         }
         AppCommand::UiHintQueryCompleted => {
             let resolution = {
-                let mut app_state = APP_STATE.write().unwrap();
+                let app_state = APP_STATE.write().unwrap();
                 app_state.resolve_jump_overlay()
             };
             sync_jump_overlay(resolution);

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ mod overlay;
 mod screen_capture;
 mod ui_hints;
 mod ui_hint_overlay;
+mod windows_uia;
 
 use action::*;
 use action_handler::*;
@@ -40,6 +41,7 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Mutex, RwLock};
+use std::sync::mpsc::{self, Receiver, Sender, TryRecvError};
 use std::thread::sleep;
 use std::time::{Duration, Instant};
 use std::{env, error::Error, fs, io};
@@ -47,6 +49,12 @@ use windows::Win32::Foundation::*;
 use windows::Win32::System::LibraryLoader::*;
 use windows::Win32::UI::Input::KeyboardAndMouse::GetAsyncKeyState;
 use windows::Win32::UI::WindowsAndMessaging::*;
+
+#[derive(Debug)]
+struct UiHintQueryResult {
+    query_id: u64,
+    result: Result<Vec<windows_uia::RawUiElement>, windows_uia::UiHintQueryError>,
+}
 
 const DEFAULT_POLLING_RATE_MS: u64 = 8;
 const DEFAULT_WHEEL_SPEED_INDICATOR_MS: u64 = 700;
@@ -79,6 +87,7 @@ const APP_DISPLAY_NAME: &str = "Multi MouseMover";
 static HOOK_EVENTS_SEEN: AtomicU64 = AtomicU64::new(0);
 static HOOK_EVENTS_DECODED: AtomicU64 = AtomicU64::new(0);
 static HOOK_EVENTS_SWALLOWED: AtomicU64 = AtomicU64::new(0);
+static UI_HINT_QUERY_ID: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 struct LoopDiagnostics {
@@ -177,6 +186,8 @@ lazy_static! {
     static ref KEY_ACTIONS: RwLock<KeyBindings> = RwLock::new(KeyBindings::new());
     static ref APP_STATE: RwLock<AppState> = RwLock::new(AppState::default());
     static ref CONFIG_WARNINGS: Mutex<Vec<StoredConfigWarning>> = Mutex::new(Vec::new());
+    static ref UI_HINT_QUERY_TX: Mutex<Option<Sender<UiHintQueryResult>>> = Mutex::new(None);
+    static ref UI_HINT_QUERY_RX: Mutex<Option<Receiver<UiHintQueryResult>>> = Mutex::new(None);
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -2182,6 +2193,36 @@ fn process_queued_key_events(debug_diagnostics: bool) -> LoopDiagnostics {
     diagnostics
 }
 
+
+fn process_ui_hint_query_results() {
+    let next = {
+        let guard = UI_HINT_QUERY_RX.lock().unwrap();
+        let Some(rx) = guard.as_ref() else { return; };
+        match rx.try_recv() {
+            Ok(msg) => Some(msg),
+            Err(TryRecvError::Empty) | Err(TryRecvError::Disconnected) => None,
+        }
+    };
+
+    let Some(message) = next else { return; };
+    if message.query_id != UI_HINT_QUERY_ID.load(Ordering::Relaxed) {
+        return;
+    }
+
+    let command = match message.result {
+        Ok(elements) if elements.is_empty() => {
+            help_overlay::show_temporary_tooltip("UI hints", "No targets found", Duration::from_millis(700));
+            AppCommand::UiHintQueryFailed
+        }
+        Ok(_elements) => AppCommand::UiHintQueryCompleted,
+        Err(err) => {
+            eprintln!("[ui-hints] query failed: {err:?}");
+            AppCommand::UiHintQueryFailed
+        }
+    };
+    APP_STATE.write().unwrap().enqueue_command(command);
+}
+
 fn sync_jump_overlay(resolution: JumpOverlayResolution) {
     match resolution {
         JumpOverlayResolution::Hidden => hide_jump_overlay(),
@@ -2712,7 +2753,17 @@ fn execute_app_command(command: AppCommand, debug_diagnostics: bool) {
                 show_jump_overlay(view);
             }
         }
-        AppCommand::EnterUiHintMode { .. } => {}
+        AppCommand::EnterUiHintMode { .. } => {
+            let query_id = UI_HINT_QUERY_ID.fetch_add(1, Ordering::Relaxed) + 1;
+            let config = ACTION_HANDLER.read().unwrap().mouse_master.config.ui_hints.clone();
+            let maybe_tx = UI_HINT_QUERY_TX.lock().unwrap().as_ref().cloned();
+            if let Some(tx) = maybe_tx {
+                std::thread::spawn(move || {
+                    let result = windows_uia::find_ui_hint_targets(&config);
+                    let _ = tx.send(UiHintQueryResult { query_id, result });
+                });
+            }
+        }
         AppCommand::KeyAction { action, is_down } => {
             let resolution = {
                 let mut action_handler = ACTION_HANDLER.write().unwrap();
@@ -2861,8 +2912,22 @@ fn execute_app_command(command: AppCommand, debug_diagnostics: bool) {
                 sync_jump_overlay(resolution);
             }
         }
-        AppCommand::UiHintQueryCompleted => {}
-        AppCommand::UiHintQueryFailed => {}
+        AppCommand::UiHintQueryCompleted => {
+            let resolution = {
+                let mut app_state = APP_STATE.write().unwrap();
+                app_state.resolve_jump_overlay()
+            };
+            sync_jump_overlay(resolution);
+        }
+        AppCommand::UiHintQueryFailed => {
+            help_overlay::show_temporary_tooltip("UI hints", "Query failed", Duration::from_millis(700));
+            let resolution = {
+                let mut app_state = APP_STATE.write().unwrap();
+                app_state.exit_ui_hint_mode();
+                app_state.resolve_jump_overlay()
+            };
+            sync_jump_overlay(resolution);
+        }
     }
 }
 
@@ -3058,6 +3123,9 @@ fn main() {
     let debug_diagnostics = debug_heartbeat_enabled();
     let mut heartbeat = HeartbeatDiagnostics::default();
     let mut last_heartbeat_sample = Instant::now();
+    let (ui_query_tx, ui_query_rx) = mpsc::channel::<UiHintQueryResult>();
+    *UI_HINT_QUERY_TX.lock().unwrap() = Some(ui_query_tx);
+    *UI_HINT_QUERY_RX.lock().unwrap() = Some(ui_query_rx);
 
     loop {
         let mut loop_diagnostics = LoopDiagnostics {
@@ -3066,6 +3134,7 @@ fn main() {
             ..LoopDiagnostics::default()
         };
 
+        process_ui_hint_query_results();
         loop_diagnostics.add(process_queued_key_events(debug_diagnostics));
         {
             let mut action_handler = ACTION_HANDLER.write().unwrap();

--- a/src/windows_uia.rs
+++ b/src/windows_uia.rs
@@ -1,0 +1,105 @@
+use crate::UiHintsConfig;
+use windows::Win32::Foundation::{BOOL, HWND, LPARAM, POINT, RECT};
+use windows::Win32::UI::WindowsAndMessaging::{
+    EnumChildWindows, EnumThreadWindows, GetForegroundWindow, GetWindowRect, GetWindowThreadProcessId,
+    IsWindowVisible, PtInRect, ScreenToClient,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RawUiElement {
+    pub bounds: (i32, i32, i32, i32),
+    pub clickable_point: Option<(i32, i32)>,
+    pub name: String,
+    pub control_type: String,
+}
+
+#[derive(Debug, Clone)]
+pub enum UiHintQueryError {
+    NoForegroundWindow,
+    EnumerationFailed,
+}
+
+pub fn find_ui_hint_targets(config: &UiHintsConfig) -> Result<Vec<RawUiElement>, UiHintQueryError> {
+    let fg = unsafe { GetForegroundWindow() };
+    if fg.0 == 0 {
+        return Err(UiHintQueryError::NoForegroundWindow);
+    }
+
+    let mut windows = vec![fg];
+    if config.include_thread_windows {
+        let thread_id = unsafe { GetWindowThreadProcessId(fg, None) };
+        let mut thread_windows = Vec::<HWND>::new();
+        unsafe {
+            EnumThreadWindows(thread_id, Some(enum_collect_windows), LPARAM((&mut thread_windows as *mut Vec<HWND>) as isize))
+                .map_err(|_| UiHintQueryError::EnumerationFailed)?;
+        }
+        for w in thread_windows {
+            if !windows.iter().any(|existing| existing.0 == w.0) {
+                windows.push(w);
+            }
+        }
+    }
+
+    let mut raw = Vec::new();
+    for hwnd in windows {
+        collect_window_targets(hwnd, &mut raw);
+    }
+
+    raw.retain(|e| e.bounds.2 > 0 && e.bounds.3 > 0);
+    raw.sort_by_key(|e| (e.bounds.1, e.bounds.0, e.bounds.2 * e.bounds.3));
+    raw.dedup_by_key(|e| e.bounds);
+
+    Ok(raw)
+}
+
+fn collect_window_targets(root: HWND, out: &mut Vec<RawUiElement>) {
+    unsafe {
+        let _ = EnumChildWindows(root, Some(enum_collect_elements), LPARAM((out as *mut Vec<RawUiElement>) as isize));
+    }
+}
+
+unsafe extern "system" fn enum_collect_windows(hwnd: HWND, lparam: LPARAM) -> BOOL {
+    let windows = &mut *(lparam.0 as *mut Vec<HWND>);
+    if IsWindowVisible(hwnd).as_bool() {
+        windows.push(hwnd);
+    }
+    BOOL(1)
+}
+
+unsafe extern "system" fn enum_collect_elements(hwnd: HWND, lparam: LPARAM) -> BOOL {
+    if !IsWindowVisible(hwnd).as_bool() {
+        return BOOL(1);
+    }
+
+    let mut rect = RECT::default();
+    if !GetWindowRect(hwnd, &mut rect).as_bool() {
+        return BOOL(1);
+    }
+
+    let width = rect.right - rect.left;
+    let height = rect.bottom - rect.top;
+    if width <= 0 || height <= 0 {
+        return BOOL(1);
+    }
+
+    let mut center = POINT {
+        x: rect.left + (width / 2),
+        y: rect.top + (height / 2),
+    };
+    let click = if PtInRect(&rect, center).as_bool() {
+        Some((center.x.clamp(rect.left, rect.right), center.y.clamp(rect.top, rect.bottom)))
+    } else {
+        None
+    };
+
+    let out = &mut *(lparam.0 as *mut Vec<RawUiElement>);
+    out.push(RawUiElement {
+        bounds: (rect.left, rect.top, width, height),
+        clickable_point: click,
+        name: String::new(),
+        control_type: "interactable".to_string(),
+    });
+
+    let _ = ScreenToClient(hwnd, &mut center);
+    BOOL(1)
+}

--- a/src/windows_uia.rs
+++ b/src/windows_uia.rs
@@ -2,7 +2,7 @@ use crate::UiHintsConfig;
 use windows::Win32::Foundation::{BOOL, HWND, LPARAM, POINT, RECT};
 use windows::Win32::UI::WindowsAndMessaging::{
     EnumChildWindows, EnumThreadWindows, GetForegroundWindow, GetWindowRect, GetWindowThreadProcessId,
-    IsWindowVisible, PtInRect, ScreenToClient,
+    IsWindowVisible,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -21,7 +21,7 @@ pub enum UiHintQueryError {
 
 pub fn find_ui_hint_targets(config: &UiHintsConfig) -> Result<Vec<RawUiElement>, UiHintQueryError> {
     let fg = unsafe { GetForegroundWindow() };
-    if fg.0 == 0 {
+    if fg.0.is_null() {
         return Err(UiHintQueryError::NoForegroundWindow);
     }
 
@@ -29,9 +29,15 @@ pub fn find_ui_hint_targets(config: &UiHintsConfig) -> Result<Vec<RawUiElement>,
     if config.include_thread_windows {
         let thread_id = unsafe { GetWindowThreadProcessId(fg, None) };
         let mut thread_windows = Vec::<HWND>::new();
-        unsafe {
-            EnumThreadWindows(thread_id, Some(enum_collect_windows), LPARAM((&mut thread_windows as *mut Vec<HWND>) as isize))
-                .map_err(|_| UiHintQueryError::EnumerationFailed)?;
+        let ok = unsafe {
+            EnumThreadWindows(
+                thread_id,
+                Some(enum_collect_windows),
+                LPARAM((&mut thread_windows as *mut Vec<HWND>) as isize),
+            )
+        };
+        if !ok.as_bool() {
+            return Err(UiHintQueryError::EnumerationFailed);
         }
         for w in thread_windows {
             if !windows.iter().any(|existing| existing.0 == w.0) {
@@ -54,7 +60,11 @@ pub fn find_ui_hint_targets(config: &UiHintsConfig) -> Result<Vec<RawUiElement>,
 
 fn collect_window_targets(root: HWND, out: &mut Vec<RawUiElement>) {
     unsafe {
-        let _ = EnumChildWindows(root, Some(enum_collect_elements), LPARAM((out as *mut Vec<RawUiElement>) as isize));
+        let _ = EnumChildWindows(
+            Some(root),
+            Some(enum_collect_elements),
+            LPARAM((out as *mut Vec<RawUiElement>) as isize),
+        );
     }
 }
 
@@ -72,7 +82,7 @@ unsafe extern "system" fn enum_collect_elements(hwnd: HWND, lparam: LPARAM) -> B
     }
 
     let mut rect = RECT::default();
-    if !GetWindowRect(hwnd, &mut rect).as_bool() {
+    if GetWindowRect(hwnd, &mut rect).is_err() {
         return BOOL(1);
     }
 
@@ -82,15 +92,14 @@ unsafe extern "system" fn enum_collect_elements(hwnd: HWND, lparam: LPARAM) -> B
         return BOOL(1);
     }
 
-    let mut center = POINT {
+    let center = POINT {
         x: rect.left + (width / 2),
         y: rect.top + (height / 2),
     };
-    let click = if PtInRect(&rect, center).as_bool() {
-        Some((center.x.clamp(rect.left, rect.right), center.y.clamp(rect.top, rect.bottom)))
-    } else {
-        None
-    };
+    let click = Some((
+        center.x.clamp(rect.left, rect.right.saturating_sub(1)),
+        center.y.clamp(rect.top, rect.bottom.saturating_sub(1)),
+    ));
 
     let out = &mut *(lparam.0 as *mut Vec<RawUiElement>);
     out.push(RawUiElement {
@@ -99,7 +108,5 @@ unsafe extern "system" fn enum_collect_elements(hwnd: HWND, lparam: LPARAM) -> B
         name: String::new(),
         control_type: "interactable".to_string(),
     });
-
-    let _ = ScreenToClient(hwnd, &mut center);
     BOOL(1)
 }


### PR DESCRIPTION
### Motivation
- Prevent the keyboard-hook thread from blocking while collecting UI targets by moving Windows UI acquisition into a separate, Windows-only backend and running queries asynchronously. 
- Provide a minimal, maintainable UI hint data model and query API that keeps COM/Win32 specifics contained inside the new module. 

### Description
- Added Windows feature flags to `Cargo.toml` to enable UIA/COM support (`Win32_System_Com`, `Win32_System_Variant`, `Win32_UI_Accessibility`) alongside existing Win32 features. 
- Introduced a new module `src/windows_uia.rs` implementing `RawUiElement`, `UiHintQueryError`, and `find_ui_hint_targets(config: &UiHintsConfig) -> Result<Vec<RawUiElement>, UiHintQueryError>` that collects foreground-window (and optionally thread-owned) child windows, filters invalid geometry, sorts deterministically, and deduplicates results. 
- Wired `mod windows_uia;` into `src/main.rs` and added an async handoff pipeline using `mpsc` channels and a `UiHintQueryResult` struct plus a `UI_HINT_QUERY_ID` to suppress stale responses. 
- Spawned the acquisition work on `AppCommand::EnterUiHintMode` and added a non-blocking poll (`process_ui_hint_query_results`) in the main loop to enqueue `AppCommand::UiHintQueryCompleted` or `AppCommand::UiHintQueryFailed` for UI handling; empty or failed queries produce a short tooltip and cleanly exit UI-hint mode. 

### Testing
- Ran `cargo check` in this environment which failed due to the Linux container missing the X11 `xi` system library required by the `x11` crate, so Rust type/build verification could not complete here. 
- No repository unit tests were changed or newly added for this PR, and no automated tests completed successfully in this environment due to the above system dependency issue.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a135f9f8d4483329e2f1f8a39b0b7a4)