### PR TITLE
Add UI hint query lifecycle state and debug diagnostics

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -78,6 +78,8 @@ key_bindings = [
 
 [ui_hints]
 enabled = true
+debug = false
+debug_fake_targets = false
 selection_keys = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 label_length = 2
 overflow_behavior = "increase_length"

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -91,8 +91,8 @@ pub struct AppState {
 #[derive(Debug)]
 pub enum UiHintState {
     Inactive,
-    Querying { activation_key: VirtualKey },
-    Active { activation_key: VirtualKey },
+    Querying { activation_key: VirtualKey, query_id: u64, foreground_hwnd: isize },
+    Active { activation_key: VirtualKey, query_id: u64, foreground_hwnd: isize },
 }
 
 #[derive(Debug)]
@@ -295,16 +295,36 @@ impl AppState {
     pub fn exit_ui_hint_mode(&mut self) {
         self.ui_hints = UiHintState::Inactive;
     }
-    pub fn enter_ui_hint_querying(&mut self, activation_key: VirtualKey) {
+    pub fn enter_ui_hint_querying(
+        &mut self,
+        activation_key: VirtualKey,
+        query_id: u64,
+        foreground_hwnd: isize,
+    ) {
         self.exit_jump_mode();
         self.exit_grid_mode();
-        self.ui_hints = UiHintState::Querying { activation_key };
+        self.ui_hints = UiHintState::Querying { activation_key, query_id, foreground_hwnd };
     }
 
-    pub fn activate_ui_hint_if_querying(&mut self) {
-        if let UiHintState::Querying { activation_key } = self.ui_hints {
-            self.ui_hints = UiHintState::Active { activation_key };
+    pub fn activate_ui_hint_if_querying(&mut self, query_id: u64) -> bool {
+        if let UiHintState::Querying { activation_key, query_id: active_query_id, foreground_hwnd } = self.ui_hints {
+            if active_query_id == query_id {
+                self.ui_hints = UiHintState::Active { activation_key, query_id, foreground_hwnd };
+                return true;
+            }
         }
+        false
+    }
+
+    pub fn current_ui_hint_query_id(&self) -> Option<u64> {
+        match self.ui_hints {
+            UiHintState::Querying { query_id, .. } | UiHintState::Active { query_id, .. } => Some(query_id),
+            UiHintState::Inactive => None,
+        }
+    }
+
+    pub fn is_ui_hint_active_or_querying(&self) -> bool {
+        self.is_ui_hint_active() || self.is_ui_hint_querying()
     }
 
     pub fn is_exclusive_mode_active(&self) -> bool {
@@ -1036,7 +1056,7 @@ mod tests {
     }
 
     fn enter_ui_hint_mode(state: &mut AppState, activation_key: VirtualKey) {
-        state.ui_hints = UiHintState::Active { activation_key };
+        state.ui_hints = UiHintState::Active { activation_key, query_id: 1, foreground_hwnd: 0 };
     }
 
     fn final_adjust_config(enabled: bool) -> Config {
@@ -1444,6 +1464,8 @@ mod tests {
         let mut state = AppState::default();
         state.ui_hints = UiHintState::Querying {
             activation_key: VirtualKey::U,
+            query_id: 1,
+            foreground_hwnd: 0,
         };
         let event = KeyEvent::new(VirtualKey::Escape, true);
 
@@ -1492,6 +1514,27 @@ mod tests {
         enter_ui_hint_mode(&mut panic_state, VirtualKey::U);
         panic_state.route_key_event(KeyEvent::new(VirtualKey::P, true), Some(Action::PanicReset));
         assert!(!panic_state.is_ui_hint_active());
+    }
+
+    #[test]
+    fn ui_hint_querying_to_active_and_stale_rejection() {
+        let mut state = AppState::default();
+        state.enter_ui_hint_querying(VirtualKey::U, 7, 123);
+        assert_eq!(state.current_ui_hint_query_id(), Some(7));
+        assert!(!state.activate_ui_hint_if_querying(8));
+        assert!(state.is_ui_hint_querying());
+        assert!(state.activate_ui_hint_if_querying(7));
+        assert!(state.is_ui_hint_active());
+    }
+
+    #[test]
+    fn ui_hint_querying_to_inactive() {
+        let mut state = AppState::default();
+        state.enter_ui_hint_querying(VirtualKey::U, 2, 0);
+        assert!(state.is_ui_hint_active_or_querying());
+        state.exit_ui_hint_mode();
+        assert!(!state.is_ui_hint_active_or_querying());
+        assert_eq!(state.current_ui_hint_query_id(), None);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -415,8 +415,6 @@ impl Default for TooltipOverlayEvents {
 #[serde(default)]
 pub struct TooltipOverlayConfig {
     pub enabled: bool,
-    pub debug: bool,
-    pub debug_fake_targets: bool,
     pub show_temporary_tooltips: bool,
     pub show_help: bool,
     pub positioning: TooltipOverlayPositioning,
@@ -2835,7 +2833,7 @@ fn execute_app_command(command: AppCommand, debug_diagnostics: bool) {
             }
             let query_id = UI_HINT_QUERY_ID.fetch_add(1, Ordering::Relaxed) + 1;
             let foreground_hwnd =
-                windows::Win32::UI::WindowsAndMessaging::GetForegroundWindow().map(|h| h.0 as isize).unwrap_or_default();
+                windows::Win32::UI::WindowsAndMessaging::GetForegroundWindow().0 as isize;
             APP_STATE
                 .write()
                 .unwrap()
@@ -3009,9 +3007,9 @@ fn execute_app_command(command: AppCommand, debug_diagnostics: bool) {
                 }
                 UiHintInputUpdate::PrefixChanged => {
                     if ui_hints_debug_enabled() {
-                        let prefix = session.input();
+                        let prefix = session.input.as_str();
                         let matches = session
-                            .visible_hints()
+                            .targets
                             .iter()
                             .filter(|hint| hint.label.starts_with(prefix))
                             .count();
@@ -3179,7 +3177,7 @@ fn execute_app_command(command: AppCommand, debug_diagnostics: bool) {
             if ui_hints_debug_enabled() {
                 eprintln!(
                     "[ui-hints] overlay shown: query_id={query_id} hints={}",
-                    view.hints.len()
+                    view.targets.len()
                 );
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -415,6 +415,8 @@ impl Default for TooltipOverlayEvents {
 #[serde(default)]
 pub struct TooltipOverlayConfig {
     pub enabled: bool,
+    pub debug: bool,
+    pub debug_fake_targets: bool,
     pub show_temporary_tooltips: bool,
     pub show_help: bool,
     pub positioning: TooltipOverlayPositioning,
@@ -464,6 +466,8 @@ impl Default for UiHintsOverlayConfig {
 #[serde(default)]
 pub struct UiHintsConfig {
     pub enabled: bool,
+    pub debug: bool,
+    pub debug_fake_targets: bool,
     pub selection_keys: String,
     pub label_length: i32,
     pub overflow_behavior: UiHintOverflowBehavior,
@@ -480,6 +484,8 @@ impl Default for UiHintsConfig {
     fn default() -> Self {
         Self {
             enabled: true,
+            debug: false,
+            debug_fake_targets: false,
             selection_keys: "ABCDEFGHIJKLMNOPQRSTUVWXYZ".to_string(),
             label_length: 2,
             overflow_behavior: UiHintOverflowBehavior::IncreaseLength,
@@ -2191,6 +2197,13 @@ fn process_queued_key_events(debug_diagnostics: bool) -> LoopDiagnostics {
                 routing_action_label(&event, action.clone())
             );
         }
+        if matches!(action, Some(Action::UiHintMode)) && ui_hints_debug_enabled() {
+            eprintln!(
+                "[ui-hints] key binding routed: key={:?} state={}",
+                event.key,
+                if event.is_down { "down" } else { "up" }
+            );
+        }
 
         APP_STATE.write().unwrap().route_key_event(event, action);
         diagnostics.queued_key_events_processed += 1;
@@ -2242,6 +2255,14 @@ fn process_ui_hint_query_results() {
         }
     };
     APP_STATE.write().unwrap().enqueue_command(command);
+}
+
+fn ui_hints_debug_enabled() -> bool {
+    ACTION_HANDLER
+        .read()
+        .ok()
+        .map(|handler| handler.mouse_master.config.ui_hints.debug)
+        .unwrap_or(false)
 }
 
 fn sync_jump_overlay(resolution: JumpOverlayResolution) {
@@ -2793,6 +2814,9 @@ fn execute_app_command(command: AppCommand, debug_diagnostics: bool) {
             if !config.enabled {
                 return;
             }
+            if config.debug {
+                eprintln!("[ui-hints] enter request: activation_key={activation_key:?}");
+            }
             let tooltip_cfg = ACTION_HANDLER
                 .read()
                 .unwrap()
@@ -2800,10 +2824,7 @@ fn execute_app_command(command: AppCommand, debug_diagnostics: bool) {
                 .config
                 .tooltip_overlay;
             clear_help_for_exclusive_mode(&mut APP_STATE.write().unwrap());
-            APP_STATE
-                .write()
-                .unwrap()
-                .enter_ui_hint_querying(activation_key);
+            APP_STATE.write().unwrap().enter_ui_hint_querying(activation_key, 0, 0);
             *UI_HINT_SESSION.lock().unwrap() = None;
             if ui_hint_tooltip_event_enabled(tooltip_cfg, tooltip_cfg.events.ui_hints_query_start) {
                 help_overlay::show_temporary_tooltip(
@@ -2813,6 +2834,17 @@ fn execute_app_command(command: AppCommand, debug_diagnostics: bool) {
                 );
             }
             let query_id = UI_HINT_QUERY_ID.fetch_add(1, Ordering::Relaxed) + 1;
+            let foreground_hwnd =
+                windows::Win32::UI::WindowsAndMessaging::GetForegroundWindow().map(|h| h.0 as isize).unwrap_or_default();
+            APP_STATE
+                .write()
+                .unwrap()
+                .enter_ui_hint_querying(activation_key, query_id, foreground_hwnd);
+            if config.debug {
+                eprintln!(
+                    "[ui-hints] query start: query_id={query_id} foreground_hwnd={foreground_hwnd}"
+                );
+            }
             let maybe_tx = UI_HINT_QUERY_TX.lock().unwrap().as_ref().cloned();
             if let Some(tx) = maybe_tx {
                 std::thread::spawn(move || {
@@ -2969,10 +3001,25 @@ fn execute_app_command(command: AppCommand, debug_diagnostics: bool) {
             };
             match session.handle_key(event.key) {
                 UiHintInputUpdate::Cancelled => {
+                    if ui_hints_debug_enabled() {
+                        eprintln!("[ui-hints] completion/cancel: cancelled");
+                    }
                     *session_guard = None;
                     APP_STATE.write().unwrap().exit_ui_hint_mode();
                 }
                 UiHintInputUpdate::PrefixChanged => {
+                    if ui_hints_debug_enabled() {
+                        let prefix = session.input();
+                        let matches = session
+                            .visible_hints()
+                            .iter()
+                            .filter(|hint| hint.label.starts_with(prefix))
+                            .count();
+                        eprintln!(
+                            "[ui-hints] input progression: typed={:?} prefix={} matches={matches}",
+                            event.key, prefix
+                        );
+                    }
                     let config = ACTION_HANDLER
                         .read()
                         .unwrap()
@@ -2996,6 +3043,9 @@ fn execute_app_command(command: AppCommand, debug_diagnostics: bool) {
                     });
                 }
                 UiHintInputUpdate::Completed { target } => {
+                    if ui_hints_debug_enabled() {
+                        eprintln!("[ui-hints] completion/cancel: completed");
+                    }
                     let after_select = ACTION_HANDLER
                         .read()
                         .unwrap()
@@ -3016,8 +3066,22 @@ fn execute_app_command(command: AppCommand, debug_diagnostics: bool) {
             }
         }
         AppCommand::UiHintQueryCompleted { query_id, elements } => {
+            {
+                let app_state = APP_STATE.read().unwrap();
+                if !app_state.is_ui_hint_querying()
+                    || app_state.current_ui_hint_query_id() != Some(query_id)
+                {
+                    return;
+                }
+            }
             if query_id != UI_HINT_QUERY_ID.load(Ordering::Relaxed) {
                 return;
+            }
+            if ui_hints_debug_enabled() {
+                eprintln!(
+                    "[ui-hints] query complete: query_id={query_id} raw_elements={}",
+                    elements.len()
+                );
             }
             let config = ACTION_HANDLER
                 .read()
@@ -3049,6 +3113,12 @@ fn execute_app_command(command: AppCommand, debug_diagnostics: bool) {
                 .collect();
             let target_count = build_ui_hint_targets(raw_elements, &hint_config);
             let targets = target_count;
+            if ui_hints_debug_enabled() {
+                eprintln!(
+                    "[ui-hints] target build complete: query_id={query_id} targets={}",
+                    targets.len()
+                );
+            }
             let tooltip_cfg = ACTION_HANDLER
                 .read()
                 .unwrap()
@@ -3097,12 +3167,21 @@ fn execute_app_command(command: AppCommand, debug_diagnostics: bool) {
                 true,
             );
             *UI_HINT_SESSION.lock().unwrap() = Some(session);
-            APP_STATE.write().unwrap().activate_ui_hint_if_querying();
+            APP_STATE
+                .write()
+                .unwrap()
+                .activate_ui_hint_if_querying(query_id);
             UI_HINT_OVERLAY.with(|overlay| {
                 let mut overlay = overlay.borrow_mut();
                 overlay.ensure_window();
                 overlay.render(&view);
             });
+            if ui_hints_debug_enabled() {
+                eprintln!(
+                    "[ui-hints] overlay shown: query_id={query_id} hints={}",
+                    view.hints.len()
+                );
+            }
         }
         AppCommand::UiHintQueryFailed { query_id } => {
             if query_id != UI_HINT_QUERY_ID.load(Ordering::Relaxed) {
@@ -5701,5 +5780,7 @@ mod tests {
     fn ui_hints_defaults_when_section_missing() {
         let config = Config::from_toml("").unwrap();
         assert_eq!(config.ui_hints, UiHintsConfig::default());
+        assert!(!config.ui_hints.debug);
+        assert!(!config.ui_hints.debug_fake_targets);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2832,8 +2832,9 @@ fn execute_app_command(command: AppCommand, debug_diagnostics: bool) {
                 );
             }
             let query_id = UI_HINT_QUERY_ID.fetch_add(1, Ordering::Relaxed) + 1;
-            let foreground_hwnd =
-                windows::Win32::UI::WindowsAndMessaging::GetForegroundWindow().0 as isize;
+            let foreground_hwnd = unsafe {
+                windows::Win32::UI::WindowsAndMessaging::GetForegroundWindow().0 as isize
+            };
             APP_STATE
                 .write()
                 .unwrap()


### PR DESCRIPTION
### Motivation
- Carry per-query metadata and explicit lifecycle state for UI hint discovery so the app can ignore stale query results and make activation decisions deterministically.
- Add opt-in, structured diagnostics for the UI hints workflow to help debug query timing, overlay rendering, and input progression without noisy logs when disabled.

### Description
- Extended `UiHintsConfig` to include `debug: bool` and `debug_fake_targets: bool` with defaults `false` and added matching entries in `config.toml` and `UiHintsConfig::default()`.
- Expanded `UiHintState` to `Inactive`, `Querying { activation_key, query_id, foreground_hwnd }`, and `Active { activation_key, query_id, foreground_hwnd }` and added AppState helpers `enter_ui_hint_querying(...)`, `activate_ui_hint_if_querying(query_id) -> bool`, `current_ui_hint_query_id() -> Option<u64>`, `is_ui_hint_active_or_querying()`, and preserved `exit_ui_hint_mode()`.
- Hardened query result handling by checking the app state is still querying and that `query_id` matches before processing; `activate_ui_hint_if_querying` now only activates when the IDs match.
- Added structured debug logs prefixed with `[ui-hints]` (guarded by `ui_hints.debug`) at key points: key binding routed, enter request, query start, query complete (with raw element count), target build complete, overlay shown, input progression (`typed`, `prefix`, `matches`), and completion/cancel events.
- Added unit tests in `src/app_state.rs` for Querying→Active, Querying→Inactive, and stale query rejection, and added config default assertions verifying `debug` fields default to `false`.

### Testing
- Added unit tests covering `app_state` transitions and config defaults and they are included in the test suite (`ui_hint_querying_to_active_and_stale_rejection`, `ui_hint_querying_to_inactive`, and `ui_hints_defaults_when_section_missing`).
- Attempted to run `cargo test -q` in the container to validate the full test suite, but it failed due to a missing system dependency required by the `x11` crate (`xi` / `xi.pc`) so CI-style test execution could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1380676034833282c628153f931d1b)