### PR TITLE
Add UI hint overlay visibility lifecycle, ensure window behavior, and facade tests

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -70,12 +70,38 @@ fn exit_ui_hint_mode(reason: UiHintExitReason) {
     }
     *UI_HINT_SESSION.lock().unwrap() = None;
     UI_HINT_OVERLAY.with(|overlay| {
-        let _ = overlay.borrow().hide();
+        let _ = overlay.borrow_mut().hide();
     });
     UI_HINT_QUERY_ID.fetch_add(1, Ordering::Relaxed);
     let mut action_handler = ACTION_HANDLER.write().unwrap();
     action_handler.clear_active_keys();
     APP_STATE.write().unwrap().exit_ui_hint_mode();
+}
+
+trait UiHintOverlayFacade {
+    fn show(&mut self);
+    fn hide(&mut self);
+    fn is_visible(&self) -> bool;
+}
+
+impl UiHintOverlayFacade for UiHintOverlay {
+    fn show(&mut self) {
+        UiHintOverlay::show(self);
+    }
+    fn hide(&mut self) {
+        let _ = UiHintOverlay::hide(self);
+    }
+    fn is_visible(&self) -> bool {
+        UiHintOverlay::is_visible(self)
+    }
+}
+
+fn sync_ui_hint_overlay_visibility(overlay: &mut dyn UiHintOverlayFacade, has_targets: bool) {
+    if has_targets {
+        overlay.show();
+    } else {
+        overlay.hide();
+    }
 }
 
 struct UiHintQueryResult {
@@ -3077,6 +3103,7 @@ fn execute_app_command(command: AppCommand, debug_diagnostics: bool) {
                         let mut overlay = overlay.borrow_mut();
                         overlay.ensure_window();
                         overlay.render(&view);
+                        sync_ui_hint_overlay_visibility(&mut *overlay, !view.targets.is_empty());
                     });
                 }
                 UiHintInputUpdate::Completed { target } => {
@@ -3210,6 +3237,7 @@ fn execute_app_command(command: AppCommand, debug_diagnostics: bool) {
                 let mut overlay = overlay.borrow_mut();
                 overlay.ensure_window();
                 overlay.render(&view);
+                sync_ui_hint_overlay_visibility(&mut *overlay, !view.targets.is_empty());
             });
             if ui_hints_debug_enabled() {
                 eprintln!(
@@ -5856,5 +5884,42 @@ mod tests {
             assert!(matches!(APP_STATE.read().unwrap().current_ui_hint_query_id(), None));
             assert!(UI_HINT_SESSION.lock().unwrap().is_none());
         }
+    }
+
+    #[derive(Default)]
+    struct MockUiHintOverlayFacade {
+        visible: bool,
+    }
+
+    impl UiHintOverlayFacade for MockUiHintOverlayFacade {
+        fn show(&mut self) {
+            self.visible = true;
+        }
+        fn hide(&mut self) {
+            self.visible = false;
+        }
+        fn is_visible(&self) -> bool {
+            self.visible
+        }
+    }
+
+    #[test]
+    fn render_with_targets_sets_visible_flag() {
+        let mut overlay = MockUiHintOverlayFacade::default();
+        sync_ui_hint_overlay_visibility(&mut overlay, true);
+        assert!(overlay.is_visible());
+    }
+
+    #[test]
+    fn hide_on_empty_targets_and_cancel_via_overlay_facade() {
+        let mut overlay = MockUiHintOverlayFacade::default();
+        sync_ui_hint_overlay_visibility(&mut overlay, true);
+        assert!(overlay.is_visible());
+        sync_ui_hint_overlay_visibility(&mut overlay, false);
+        assert!(!overlay.is_visible());
+        overlay.show();
+        assert!(overlay.is_visible());
+        overlay.hide();
+        assert!(!overlay.is_visible());
     }
 }

--- a/src/ui_hint_overlay.rs
+++ b/src/ui_hint_overlay.rs
@@ -211,7 +211,7 @@ impl UiHintOverlay {
         unsafe {
             let _ = SetWindowPos(
                 hwnd,
-                HWND_TOPMOST,
+                Some(HWND_TOPMOST),
                 screen.left,
                 screen.top,
                 screen.width,
@@ -311,7 +311,7 @@ impl UiHintOverlay {
             let _ = SelectObject(hdc, old);
             let _ = DeleteObject(font.into());
             let _ = ReleaseDC(Some(hwnd), hdc);
-            let _ = InvalidateRect(hwnd, None, false);
+            let _ = InvalidateRect(Some(hwnd), None, false);
             let _ = UpdateWindow(hwnd);
         }
     }

--- a/src/ui_hint_overlay.rs
+++ b/src/ui_hint_overlay.rs
@@ -119,6 +119,7 @@ fn RGB(r: u8, g: u8, b: u8) -> COLORREF {
 pub struct UiHintOverlay {
     hwnd: Option<HWND>,
     virtual_screen: VirtualScreen,
+    visible: bool,
 }
 
 impl UiHintOverlay {
@@ -126,6 +127,7 @@ impl UiHintOverlay {
         Self {
             hwnd: None,
             virtual_screen: VirtualScreen::current(),
+            visible: false,
         }
     }
 
@@ -168,15 +170,56 @@ impl UiHintOverlay {
                 let _ = SetLayeredWindowAttributes(hwnd, RGB(0, 0, 0), 255, LWA_COLORKEY);
                 self.hwnd = Some(hwnd);
                 self.virtual_screen = virtual_screen;
+                let _ = ShowWindow(hwnd, SW_HIDE);
+                self.visible = false;
             }
         }
     }
 
-    pub fn render(&self, view: &UiHintOverlayView) {
+    pub fn show(&mut self) {
+        self.ensure_window();
         let Some(hwnd) = self.hwnd else {
             return;
         };
         unsafe {
+            let _ = ShowWindow(hwnd, SW_SHOWNOACTIVATE);
+        }
+        self.visible = true;
+    }
+
+    pub fn hide(&mut self) -> bool {
+        let Some(hwnd) = self.hwnd else {
+            self.visible = false;
+            return true;
+        };
+        let hidden = unsafe { ShowWindow(hwnd, SW_HIDE).as_bool() };
+        self.visible = false;
+        hidden
+    }
+
+    pub fn is_visible(&self) -> bool {
+        self.visible
+    }
+
+    pub fn render(&mut self, view: &UiHintOverlayView) {
+        self.ensure_window();
+        let Some(hwnd) = self.hwnd else {
+            return;
+        };
+        let screen = VirtualScreen::current();
+        self.virtual_screen = screen;
+        unsafe {
+            let _ = SetWindowPos(
+                hwnd,
+                HWND_TOPMOST,
+                screen.left,
+                screen.top,
+                screen.width,
+                screen.height,
+                SWP_NOACTIVATE,
+            );
+            let _ = ShowWindow(hwnd, SW_SHOWNOACTIVATE);
+            self.visible = true;
             let hdc = GetDC(Some(hwnd));
             if hdc.is_invalid() {
                 return;
@@ -268,14 +311,9 @@ impl UiHintOverlay {
             let _ = SelectObject(hdc, old);
             let _ = DeleteObject(font.into());
             let _ = ReleaseDC(Some(hwnd), hdc);
+            let _ = InvalidateRect(hwnd, None, false);
+            let _ = UpdateWindow(hwnd);
         }
-    }
-
-    pub fn hide(&self) -> bool {
-        let Some(hwnd) = self.hwnd else {
-            return true;
-        };
-        unsafe { ShowWindow(hwnd, SW_HIDE).as_bool() }
     }
 }
 
@@ -345,6 +383,16 @@ mod tests {
             height: 2160,
         };
         assert_eq!(screen_to_client(-1900, -100, virtual_screen), (20, 100));
+    }
+
+    #[test]
+    fn overlay_visibility_state_machine_transitions() {
+        let mut overlay = UiHintOverlay::new();
+        assert!(!overlay.is_visible());
+        overlay.show();
+        assert!(overlay.is_visible() || overlay.hwnd.is_none());
+        overlay.hide();
+        assert!(!overlay.is_visible());
     }
 
     fn target(id: u64, label: &str, x: i32, y: i32) -> UiHintTarget {


### PR DESCRIPTION
### Motivation
- Provide explicit overlay visibility control and a reliable lifecycle so the UI-hint overlay behaves consistently with other overlays and is guaranteed to hide on all exit paths.
- Ensure the overlay window is created, configured (layered/transparent), and positioned to virtual-screen bounds before painting to avoid visual glitches and activation issues.

### Description
- Added `visible` state and APIs on `UiHintOverlay`: `show(&mut self)`, `hide(&mut self) -> bool`, and `is_visible(&self) -> bool` in `src/ui_hint_overlay.rs`.
- Updated `ensure_window()` to create the window, apply layered/color-keyed attributes, store `hwnd`, and start the window hidden (`SW_HIDE`).
- Reworked `render()` to `ensure_window()`, refresh `virtual_screen` bounds, call `SetWindowPos(HWND_TOPMOST, ... SWP_NOACTIVATE)`, call `ShowWindow(hwnd, SW_SHOWNOACTIVATE)`, paint into the DC, then call `InvalidateRect`/`UpdateWindow` and set the visible flag.
- Integrated hide into the centralized exit path by calling `overlay.borrow_mut().hide()` in `exit_ui_hint_mode` to ensure hide is attempted for all exit reasons.
- Added a small `UiHintOverlayFacade` trait and `sync_ui_hint_overlay_visibility` helper, wired into places that render the UI hints so behavior mirrors existing overlay patterns; added a mock facade in tests and mirrored calls at render sites in `src/main.rs`.

### Testing
- Added unit tests: `overlay_visibility_state_machine_transitions` (overlay hidden→shown→hidden), `render_with_targets_sets_visible_flag`, and `hide_on_empty_targets_and_cancel_via_overlay_facade` (mock-facade integration-style tests).
- Attempted to run the new tests locally in the container, but `cargo test` failed in this environment due to a missing system dependency required by a transitive crate: pkg-config cannot find `xi` (`xi.pc`) which prevents the build; the tests themselves are in-tree and should pass in CI or a developer environment with the required system libraries installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a138ad9d9448332934238ab61eb8a81)