### PR TITLE
Add deterministic debug fake UI hint targets and route through normal session flow

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -109,6 +109,20 @@ struct UiHintQueryResult {
     result: Result<Vec<windows_uia::RawUiElement>, windows_uia::UiHintQueryError>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum UiHintQueryBackend {
+    WindowsUia,
+    DebugFakeTargets,
+}
+
+fn ui_hint_query_backend(config: &UiHintsConfig) -> UiHintQueryBackend {
+    if config.debug_fake_targets {
+        UiHintQueryBackend::DebugFakeTargets
+    } else {
+        UiHintQueryBackend::WindowsUia
+    }
+}
+
 const DEFAULT_POLLING_RATE_MS: u64 = 8;
 const DEFAULT_WHEEL_SPEED_INDICATOR_MS: u64 = 700;
 const DEFAULT_MOUSE_SPEED_FLASH_MS: u64 = 700;
@@ -2864,9 +2878,21 @@ fn execute_app_command(command: AppCommand, debug_diagnostics: bool) {
                 .ui_hints
                 .clone();
             if !config.enabled {
-                let tooltip_cfg = ACTION_HANDLER.read().unwrap().mouse_master.config.tooltip_overlay;
-                if ui_hint_tooltip_event_enabled(tooltip_cfg, tooltip_cfg.events.ui_hints_query_fail) {
-                    help_overlay::show_temporary_tooltip("UI Hints", "UI hints are disabled", Duration::from_millis(700));
+                let tooltip_cfg = ACTION_HANDLER
+                    .read()
+                    .unwrap()
+                    .mouse_master
+                    .config
+                    .tooltip_overlay;
+                if ui_hint_tooltip_event_enabled(
+                    tooltip_cfg,
+                    tooltip_cfg.events.ui_hints_query_fail,
+                ) {
+                    help_overlay::show_temporary_tooltip(
+                        "UI Hints",
+                        "UI hints are disabled",
+                        Duration::from_millis(700),
+                    );
                 }
                 exit_ui_hint_mode(UiHintExitReason::Disabled);
                 return;
@@ -2881,7 +2907,10 @@ fn execute_app_command(command: AppCommand, debug_diagnostics: bool) {
                 .config
                 .tooltip_overlay;
             clear_help_for_exclusive_mode(&mut APP_STATE.write().unwrap());
-            APP_STATE.write().unwrap().enter_ui_hint_querying(activation_key, 0, 0);
+            APP_STATE
+                .write()
+                .unwrap()
+                .enter_ui_hint_querying(activation_key, 0, 0);
             if ui_hint_tooltip_event_enabled(tooltip_cfg, tooltip_cfg.events.ui_hints_query_start) {
                 help_overlay::show_temporary_tooltip(
                     "UI Hints",
@@ -2893,10 +2922,11 @@ fn execute_app_command(command: AppCommand, debug_diagnostics: bool) {
             let foreground_hwnd = unsafe {
                 windows::Win32::UI::WindowsAndMessaging::GetForegroundWindow().0 as isize
             };
-            APP_STATE
-                .write()
-                .unwrap()
-                .enter_ui_hint_querying(activation_key, query_id, foreground_hwnd);
+            APP_STATE.write().unwrap().enter_ui_hint_querying(
+                activation_key,
+                query_id,
+                foreground_hwnd,
+            );
             if config.debug {
                 eprintln!(
                     "[ui-hints] query start: query_id={query_id} foreground_hwnd={foreground_hwnd}"
@@ -2905,7 +2935,12 @@ fn execute_app_command(command: AppCommand, debug_diagnostics: bool) {
             let maybe_tx = UI_HINT_QUERY_TX.lock().unwrap().as_ref().cloned();
             if let Some(tx) = maybe_tx {
                 std::thread::spawn(move || {
-                    let result = windows_uia::find_ui_hint_targets(&config);
+                    let result = match ui_hint_query_backend(&config) {
+                        UiHintQueryBackend::DebugFakeTargets => Ok(Vec::new()),
+                        UiHintQueryBackend::WindowsUia => {
+                            windows_uia::find_ui_hint_targets(&config)
+                        }
+                    };
                     let _ = tx.send(UiHintQueryResult { query_id, result });
                 });
             }
@@ -3174,8 +3209,11 @@ fn execute_app_command(command: AppCommand, debug_diagnostics: bool) {
                     clickable_point: e.clickable_point,
                 })
                 .collect();
-            let target_count = build_ui_hint_targets(raw_elements, &hint_config);
-            let targets = target_count;
+            let targets = if config.debug_fake_targets {
+                ui_hints::generate_debug_fake_targets(&hint_config)
+            } else {
+                build_ui_hint_targets(raw_elements, &hint_config)
+            };
             if ui_hints_debug_enabled() {
                 eprintln!(
                     "[ui-hints] target build complete: query_id={query_id} targets={}",
@@ -5850,6 +5888,15 @@ mod tests {
     }
 
     #[test]
+    fn ui_hint_query_backend_uses_windows_uia_when_debug_fake_targets_disabled() {
+        let config = UiHintsConfig::default();
+        assert_eq!(
+            ui_hint_query_backend(&config),
+            UiHintQueryBackend::WindowsUia
+        );
+    }
+
+    #[test]
     fn ui_hint_cleanup_is_idempotent() {
         APP_STATE
             .write()
@@ -5858,7 +5905,10 @@ mod tests {
         *UI_HINT_SESSION.lock().unwrap() = None;
         exit_ui_hint_mode(UiHintExitReason::Cancelled);
         exit_ui_hint_mode(UiHintExitReason::Cancelled);
-        assert!(matches!(APP_STATE.read().unwrap().current_ui_hint_query_id(), None));
+        assert!(matches!(
+            APP_STATE.read().unwrap().current_ui_hint_query_id(),
+            None
+        ));
         assert!(UI_HINT_SESSION.lock().unwrap().is_none());
     }
 
@@ -5881,7 +5931,10 @@ mod tests {
                 .enter_ui_hint_querying(VirtualKey::U, 9, 1);
             *UI_HINT_SESSION.lock().unwrap() = None;
             exit_ui_hint_mode(reason);
-            assert!(matches!(APP_STATE.read().unwrap().current_ui_hint_query_id(), None));
+            assert!(matches!(
+                APP_STATE.read().unwrap().current_ui_hint_query_id(),
+                None
+            ));
             assert!(UI_HINT_SESSION.lock().unwrap().is_none());
         }
     }

--- a/src/ui_hints.rs
+++ b/src/ui_hints.rs
@@ -150,7 +150,10 @@ pub fn generate_ui_hint_labels(
         .collect()
 }
 
-pub fn build_ui_hint_targets(raw_elements: Vec<RawUiElement>, config: &UiHintConfig) -> Vec<UiHintTarget> {
+pub fn build_ui_hint_targets(
+    raw_elements: Vec<RawUiElement>,
+    config: &UiHintConfig,
+) -> Vec<UiHintTarget> {
     let mut elements: Vec<RawUiElement> = raw_elements
         .into_iter()
         .filter(|e| e.width > 0 && e.height > 0)
@@ -200,6 +203,43 @@ pub fn build_ui_hint_targets(raw_elements: Vec<RawUiElement>, config: &UiHintCon
                 target_y,
                 metadata: Some(format!("{}x{}", element.width, element.height)),
             }
+        })
+        .collect()
+}
+
+pub fn generate_debug_fake_targets(config: &UiHintConfig) -> Vec<UiHintTarget> {
+    let labels = generate_ui_hint_labels(
+        5,
+        &config.selection_keys,
+        config.label_length,
+        UiHintOverflowBehavior::IncreaseLength,
+        Some(5),
+    );
+    if labels.len() < 5 {
+        return Vec::new();
+    }
+
+    let center = (960, 540);
+    let spread = 120;
+    let points = [
+        center,
+        (center.0, center.1 - spread),
+        (center.0, center.1 + spread),
+        (center.0 - spread, center.1),
+        (center.0 + spread, center.1),
+    ];
+
+    points
+        .into_iter()
+        .zip(labels)
+        .enumerate()
+        .map(|(index, ((x, y), label))| UiHintTarget {
+            id: (index + 1) as u64,
+            label,
+            bounds: (x - 8, y - 8, 16, 16),
+            target_x: x,
+            target_y: y,
+            metadata: Some("debug_fake".to_string()),
         })
         .collect()
 }
@@ -255,7 +295,16 @@ mod tests {
 
     #[test]
     fn generates_fixed_two_letter_labels() {
-        let labels = generate_ui_hint_labels(27, &['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z'], 2, UiHintOverflowBehavior::Cap, None);
+        let labels = generate_ui_hint_labels(
+            27,
+            &[
+                'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P',
+                'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+            ],
+            2,
+            UiHintOverflowBehavior::Cap,
+            None,
+        );
         assert_eq!(labels[0], "AA");
         assert_eq!(labels[25], "AZ");
         assert_eq!(labels[26], "BA");
@@ -263,7 +312,13 @@ mod tests {
 
     #[test]
     fn increases_label_length_on_overflow() {
-        let labels = generate_ui_hint_labels(5, &['A', 'B'], 2, UiHintOverflowBehavior::IncreaseLength, None);
+        let labels = generate_ui_hint_labels(
+            5,
+            &['A', 'B'],
+            2,
+            UiHintOverflowBehavior::IncreaseLength,
+            None,
+        );
         assert_eq!(labels, vec!["AAA", "AAB", "ABA", "ABB", "BAA"]);
     }
 
@@ -276,30 +331,42 @@ mod tests {
     #[test]
     fn sorts_targets_top_left_to_bottom_right() {
         let config = sample_config();
-        let targets = build_ui_hint_targets(vec![
-            raw(1, 50, 50, 10, 10, None),
-            raw(2, 10, 10, 10, 10, None),
-            raw(3, 20, 10, 10, 10, None),
-        ], &config);
-        assert_eq!(targets.iter().map(|t| t.id).collect::<Vec<_>>(), vec![2, 3, 1]);
+        let targets = build_ui_hint_targets(
+            vec![
+                raw(1, 50, 50, 10, 10, None),
+                raw(2, 10, 10, 10, 10, None),
+                raw(3, 20, 10, 10, 10, None),
+            ],
+            &config,
+        );
+        assert_eq!(
+            targets.iter().map(|t| t.id).collect::<Vec<_>>(),
+            vec![2, 3, 1]
+        );
     }
 
     #[test]
     fn deduplicates_nearby_targets() {
         let mut config = sample_config();
         config.min_hint_spacing_px = 10;
-        let targets = build_ui_hint_targets(vec![
-            raw(1, 0, 0, 10, 10, None),
-            raw(2, 3, 4, 10, 10, None),
-            raw(3, 30, 30, 10, 10, None),
-        ], &config);
+        let targets = build_ui_hint_targets(
+            vec![
+                raw(1, 0, 0, 10, 10, None),
+                raw(2, 3, 4, 10, 10, None),
+                raw(3, 30, 30, 10, 10, None),
+            ],
+            &config,
+        );
         assert_eq!(targets.iter().map(|t| t.id).collect::<Vec<_>>(), vec![1, 3]);
     }
 
     #[test]
     fn exact_label_completes_session() {
         let mut session = UiHintSession::new(vec![target(1, "AA")], vec!['A', 'B']).unwrap();
-        assert_eq!(session.handle_key(VirtualKey::A), UiHintInputUpdate::PrefixChanged);
+        assert_eq!(
+            session.handle_key(VirtualKey::A),
+            UiHintInputUpdate::PrefixChanged
+        );
         match session.handle_key(VirtualKey::A) {
             UiHintInputUpdate::Completed { target } => assert_eq!(target.id, 1),
             other => panic!("unexpected update: {other:?}"),
@@ -308,15 +375,22 @@ mod tests {
 
     #[test]
     fn partial_label_updates_prefix() {
-        let mut session = UiHintSession::new(vec![target(1, "AA"), target(2, "AB")], vec!['A', 'B']).unwrap();
-        assert_eq!(session.handle_key(VirtualKey::A), UiHintInputUpdate::PrefixChanged);
+        let mut session =
+            UiHintSession::new(vec![target(1, "AA"), target(2, "AB")], vec!['A', 'B']).unwrap();
+        assert_eq!(
+            session.handle_key(VirtualKey::A),
+            UiHintInputUpdate::PrefixChanged
+        );
         assert_eq!(session.input, "A");
     }
 
     #[test]
     fn invalid_key_does_not_complete() {
         let mut session = UiHintSession::new(vec![target(1, "AA")], vec!['A', 'B']).unwrap();
-        assert_eq!(session.handle_key(VirtualKey::Num1), UiHintInputUpdate::Consumed);
+        assert_eq!(
+            session.handle_key(VirtualKey::Num1),
+            UiHintInputUpdate::Consumed
+        );
         assert_eq!(session.input, "");
     }
 
@@ -324,19 +398,58 @@ mod tests {
     fn backspace_removes_input() {
         let mut session = UiHintSession::new(vec![target(1, "AA")], vec!['A', 'B']).unwrap();
         session.input = "A".to_string();
-        assert_eq!(session.handle_key(VirtualKey::Backspace), UiHintInputUpdate::PrefixChanged);
+        assert_eq!(
+            session.handle_key(VirtualKey::Backspace),
+            UiHintInputUpdate::PrefixChanged
+        );
         assert_eq!(session.input, "");
     }
 
     #[test]
     fn escape_cancels() {
         let mut session = UiHintSession::new(vec![target(1, "AA")], vec!['A', 'B']).unwrap();
-        assert_eq!(session.handle_key(VirtualKey::Escape), UiHintInputUpdate::Cancelled);
+        assert_eq!(
+            session.handle_key(VirtualKey::Escape),
+            UiHintInputUpdate::Cancelled
+        );
     }
 
     #[test]
     fn empty_target_list_creates_no_session() {
         assert!(UiHintSession::new(Vec::new(), vec!['A']).is_none());
+    }
+
+    #[test]
+    fn debug_fake_target_generator_is_deterministic() {
+        let config = sample_config();
+        let targets = generate_debug_fake_targets(&config);
+        assert_eq!(
+            targets.iter().map(|t| t.label.as_str()).collect::<Vec<_>>(),
+            vec!["AA", "AB", "AC", "AD", "AE"]
+        );
+        assert_eq!(targets[0].target_x, 960);
+        assert_eq!(targets[0].target_y, 540);
+        assert_eq!(targets[1].target_y, 420);
+        assert_eq!(targets[2].target_y, 660);
+        assert_eq!(targets[3].target_x, 840);
+        assert_eq!(targets[4].target_x, 1080);
+    }
+
+    #[test]
+    fn debug_fake_targets_support_prefix_and_completion_flow() {
+        let config = sample_config();
+        let targets = generate_debug_fake_targets(&config);
+        let mut session = UiHintSession::new(targets, vec!['A', 'B', 'C']).unwrap();
+        assert_eq!(
+            session.handle_key(VirtualKey::A),
+            UiHintInputUpdate::PrefixChanged
+        );
+        assert_eq!(
+            session.handle_key(VirtualKey::E),
+            UiHintInputUpdate::Completed {
+                target: session.targets[4].clone()
+            }
+        );
     }
 
     fn sample_config() -> UiHintConfig {
@@ -350,8 +463,22 @@ mod tests {
         }
     }
 
-    fn raw(id: u64, left: i32, top: i32, width: i32, height: i32, clickable_point: Option<(i32, i32)>) -> RawUiElement {
-        RawUiElement { id, left, top, width, height, clickable_point }
+    fn raw(
+        id: u64,
+        left: i32,
+        top: i32,
+        width: i32,
+        height: i32,
+        clickable_point: Option<(i32, i32)>,
+    ) -> RawUiElement {
+        RawUiElement {
+            id,
+            left,
+            top,
+            width,
+            height,
+            clickable_point,
+        }
     }
 
     fn target(id: u64, label: &str) -> UiHintTarget {


### PR DESCRIPTION
### Motivation
- Provide a deterministic, inspectable UI-hints mode for debugging by generating fake targets when `ui_hints.debug_fake_targets` is enabled. 
- Ensure fake targets exercise the same session/overlay pipeline so diagnostics and rendering remain representative. 
- Preserve existing debug logs and tooltip behavior so diagnostics remain valid.

### Description
- Added `generate_debug_fake_targets` in `src/ui_hints.rs` which emits five deterministic targets (center, above, below, left, right) and stable labels derived from the configured selection keyspace. 
- Introduced `UiHintQueryBackend` and `ui_hint_query_backend` in `src/main.rs` and routed the background query thread to either the normal `windows_uia::find_ui_hint_targets` path or to the fake-target path based on `ui_hints.debug_fake_targets`. 
- Injected fake targets at the same target-building step so generated targets flow through `UiHintSession::new`, `build_ui_hint_overlay_view` and the existing overlay rendering pipeline without adding a special-case renderer. 
- Added unit tests for the fake-target generator determinism, a prefix+completion session flow using fake targets, and a backend-selection test to ensure the UIA path is still selected when `debug_fake_targets=false`.

### Testing
- Ran `cargo fmt` successfully to format changes. 
- Attempted to run unit tests (focused `cargo test` runs), but the test build failed in this environment because building dependencies requires the system `xi` library for the `x11` crate (pkg-config error), so automated tests could not be executed to completion here. 
- New/updated tests added: `debug_fake_target_generator_is_deterministic`, `debug_fake_targets_support_prefix_and_completion_flow`, and `ui_hint_query_backend_uses_windows_uia_when_debug_fake_targets_disabled` (located in `src/ui_hints.rs` and `src/main.rs`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a138ce75e908332b409f0b314e4edfb)