### PR TITLE
docs: refine UI Hints mode usage, example binding, and limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,15 +180,18 @@ hide_threshold_px = 0
 
 ## UI Hints Mode
 
-UI Hints mode discovers accessible controls from the foreground app and overlays short labels so you can jump the cursor directly to UI targets. Trigger it with your configured binding (default sample config: `0`).
+UI Hints mode discovers accessible controls from the foreground app and overlays short labels so you can jump the cursor directly to UI targets. Example binding in `config.toml`:
+
+```toml
+["0", "ui_hint_mode"]
+```
 
 Interaction flow:
 
-1. Press the UI Hints binding to start query mode.
-2. Multi MouseMover queries UI Automation (UIA) for visible actionable controls.
-3. Labels are rendered near discovered controls.
-4. Type label characters to narrow candidates; an exact match moves the cursor to the target point.
-5. `Backspace` removes one typed character; `Escape` cancels and exits UI Hints mode.
+1. Press the UI Hints binding.
+2. Labels appear after the UI Automation (UIA) query completes.
+3. Type the label for your target control.
+4. `Escape` cancels and exits UI Hints mode at any point.
 
 Optional tooltip events for query lifecycle can be toggled under `[tooltip_overlay.events]`:
 
@@ -199,9 +202,10 @@ Optional tooltip events for query lifecycle can be toggled under `[tooltip_overl
 
 Limitations and caveats:
 
-- UIA output varies per app and framework, so hint availability is not uniform.
-- If the target app is elevated and Multi MouseMover is not, UIA visibility may be limited.
-- Apps with duplicated/nested controls can produce dense hint clusters; increase `ui_hints.min_hint_spacing_px` to reduce overlap noise.
+- Some apps expose weak or incomplete UIA trees, so hint coverage can be sparse or inconsistent.
+- Elevation boundaries apply: if the foreground app is elevated and Multi MouseMover is not (or vice versa), UIA visibility and interaction can be reduced.
+- Custom-rendered or game UIs often provide little/no actionable UIA metadata, so hints may be missing.
+- High-density UI apps (especially browsers/Electron apps) can generate crowded overlays; tune `ui_hints.min_hint_spacing_px` and `ui_hints.max_hints` to reduce noise.
 
 ## Final Adjust
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -262,13 +262,14 @@ font_scale = 1.1
 - `selection_keys` removes whitespace, uppercases alpha keys, and removes duplicates while preserving first occurrence order.
 - Values outside supported ranges are normalized and logged as config warnings so the mode remains usable.
 - Duplicate and deeply nested UIA controls are common in complex apps; increase `min_hint_spacing_px` to reduce visual crowding.
-- When many controls are visible, results may be capped by `max_hints`; consider larger `selection_keys` and spacing tuning before raising the cap aggressively.
+- When many controls are visible (for example browsers/Electron apps), results may be capped by `max_hints`; consider larger `selection_keys` and spacing tuning before raising the cap aggressively.
 
 ## UI Hints limitations
 
-- UIA dependency variability: each app exposes a different UIA tree, so discoverability and clickable points can vary widely between Explorer, browsers, Electron apps, Office apps, and custom IDE toolkits.
-- Elevation mismatch: an elevated foreground app can block or reduce non-elevated UIA visibility. Run Multi MouseMover at matching integrity level for consistent results.
-- Duplicate/nested controls: many apps surface overlapping descendants; `min_hint_spacing_px` is the primary noise-reduction control for this behavior.
+- Weak UIA trees: each app exposes a different UIA tree, and some expose very little actionable metadata, so discoverability can vary widely.
+- Elevation boundary behavior: an elevated foreground app can block or reduce non-elevated UIA visibility (and vice versa). Run Multi MouseMover at a matching integrity level when possible.
+- Custom-rendered/game UIs: many non-standard UI toolkits and game engines do not provide robust UIA metadata, so hints may be partial or absent.
+- High-density element apps: browsers/Electron apps can expose very large control trees; tune `min_hint_spacing_px` and `max_hints` to keep overlays readable.
 
 ## Migration Notes
 


### PR DESCRIPTION
### Motivation
- Clarify and align documentation for the implemented UI Hints workflow so users know how to trigger and interact with the feature. 
- Surface practical, runtime limitations and tuning guidance to reduce user confusion when UI Automation coverage is uneven or control trees are dense.

### Description
- Updated `README.md` UI Hints Mode with an explicit example binding (`["0", "ui_hint_mode"]`) and a concise usage flow (`press key`, `labels appear`, `type label`, `Escape` cancels). 
- Updated `docs/config.md` UI Hints sections to match README wording, expanded the limitations list to mention weak UIA trees, elevation boundary behavior, custom-rendered/game UIs, and high-density browser/Electron control trees, and tuned related normalization notes. 
- Verified the canonical `ui_hints.*` entries in `docs/config.md` remain marked `Active` and applied the docs edits; changes committed as `docs: refine UI Hints mode usage and limitations`.

### Testing
- Attempted to run the in-repo config/docs validation tests with `cargo test config_audit -- --nocapture`, but the test run failed in this environment because the system library `xi` required by the `x11` crate is missing, preventing the test build from completing. 
- Performed local text/grep verification to confirm updated README and `docs/config.md` content and that `ui_hints.*` paths are documented as `Active` (no doc-only entries left).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a139ab92d18833298aab2e6078057e3)