### PR TITLE
Add UI hint loading overlay and UIA children-first query strategy with fallback

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -465,7 +465,7 @@ pub enum TooltipOverlayPositioning {
     BottomRight,
 }
 
-#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
 #[serde(default)]
 pub struct TooltipOverlayEvents {
     pub mouse: bool,
@@ -605,7 +605,7 @@ impl Default for UiHintsConfig {
     }
 }
 
-#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum UiHintQueryStrategy {
     #[serde(alias = "default")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,7 @@ use std::sync::{Mutex, RwLock};
 use std::thread::sleep;
 use std::time::{Duration, Instant};
 use std::{env, error::Error, fs, io};
-use ui_hint_overlay::{build_ui_hint_overlay_view, UiHintOverlay};
+use ui_hint_overlay::{build_ui_hint_loading_view, build_ui_hint_overlay_view, UiHintOverlay};
 use ui_hints::{build_ui_hint_targets, UiHintInputUpdate, UiHintSession};
 use windows::Win32::Foundation::*;
 use windows::Win32::System::LibraryLoader::*;
@@ -465,7 +465,7 @@ pub enum TooltipOverlayPositioning {
     BottomRight,
 }
 
-#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq, Default)]
 #[serde(default)]
 pub struct TooltipOverlayEvents {
     pub mouse: bool,
@@ -574,6 +574,9 @@ pub struct UiHintsConfig {
     pub min_hint_spacing_px: i32,
     pub include_thread_windows: bool,
     pub include_owned_popups: bool,
+    pub query_strategy: UiHintQueryStrategy,
+    pub min_targets_before_fallback: i32,
+    pub query_timeout_ms: u64,
     pub target_point: UiHintTargetPoint,
     pub after_select: UiHintAfterSelect,
     pub overlay: UiHintsOverlayConfig,
@@ -592,11 +595,23 @@ impl Default for UiHintsConfig {
             min_hint_spacing_px: 32,
             include_thread_windows: true,
             include_owned_popups: true,
+            query_strategy: UiHintQueryStrategy::Descendants,
+            min_targets_before_fallback: 8,
+            query_timeout_ms: 1200,
             target_point: UiHintTargetPoint::ClickablePoint,
             after_select: UiHintAfterSelect::Move,
             overlay: UiHintsOverlayConfig::default(),
         }
     }
+}
+
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum UiHintQueryStrategy {
+    #[serde(alias = "default")]
+    #[default]
+    Descendants,
+    ChildrenThenDescendants,
 }
 
 impl Default for TooltipOverlayConfig {
@@ -1416,6 +1431,8 @@ impl Config {
             0,
             200,
         );
+        self.ui_hints.min_targets_before_fallback = normalize_i32_range("ui_hints.min_targets_before_fallback", self.ui_hints.min_targets_before_fallback, 1, 5000);
+        self.ui_hints.query_timeout_ms = self.ui_hints.query_timeout_ms.clamp(100, 30_000);
         self.ui_hints.overlay.font_scale = normalize_f32_range(
             "ui_hints.overlay.font_scale",
             self.ui_hints.overlay.font_scale,
@@ -3013,6 +3030,13 @@ fn execute_app_command(command: AppCommand, debug_diagnostics: bool) {
                 .write()
                 .unwrap()
                 .enter_ui_hint_querying(activation_key, 0, 0);
+            UI_HINT_OVERLAY.with(|overlay| {
+                let mut overlay = overlay.borrow_mut();
+                overlay.ensure_window();
+                let loading = build_ui_hint_loading_view(config.overlay.font_scale);
+                overlay.render(&loading);
+                overlay.show();
+            });
             if ui_hint_tooltip_event_enabled(tooltip_cfg, tooltip_cfg.events.ui_hints_query_start) {
                 help_overlay::show_temporary_tooltip(
                     "UI Hints",

--- a/src/ui_hint_overlay.rs
+++ b/src/ui_hint_overlay.rs
@@ -22,6 +22,7 @@ pub enum UiHintLabelPlacement {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct UiHintOverlayView {
+    pub loading: bool,
     pub placement: UiHintLabelPlacement,
     pub input: String,
     pub targets: Vec<UiHintOverlayTarget>,
@@ -92,6 +93,7 @@ pub fn build_ui_hint_overlay_view(
         .collect();
 
     UiHintOverlayView {
+        loading: false,
         placement: UiHintLabelPlacement::Anchor,
         input,
         targets,
@@ -101,6 +103,21 @@ pub fn build_ui_hint_overlay_view(
         offset_y,
         show_background,
         show_border,
+    }
+}
+
+pub fn build_ui_hint_loading_view(font_scale: f32) -> UiHintOverlayView {
+    UiHintOverlayView {
+        loading: true,
+        placement: UiHintLabelPlacement::Anchor,
+        input: String::new(),
+        targets: Vec::new(),
+        dim_non_matching: false,
+        font_scale,
+        offset_x: 0,
+        offset_y: 0,
+        show_background: true,
+        show_border: true,
     }
 }
 
@@ -250,6 +267,12 @@ impl UiHintOverlay {
             );
             let old = SelectObject(hdc, font.into());
             let _ = SetBkMode(hdc, TRANSPARENT);
+
+            if view.loading {
+                let text: Vec<u16> = "Loading UI hints...\0".encode_utf16().collect();
+                let _ = SetTextColor(hdc, RGB(255, 255, 255));
+                let _ = TextOutW(hdc, 40, 40, &text[..text.len().saturating_sub(1)]);
+            }
 
             for target in &view.targets {
                 let (client_x, client_y) =

--- a/src/windows_uia.rs
+++ b/src/windows_uia.rs
@@ -9,7 +9,7 @@ use windows::Win32::System::Com::{
 };
 use windows::Win32::UI::Accessibility::{
     CUIAutomation, IUIAutomation, IUIAutomationCondition, IUIAutomationElement,
-    IUIAutomationElementArray, TreeScope_Descendants,
+    IUIAutomationElementArray, TreeScope_Children, TreeScope_Descendants,
 };
 use windows::Win32::UI::WindowsAndMessaging::{
     EnumThreadWindows, GetWindow, GetWindowRect, GetWindowThreadProcessId, IsWindowVisible,
@@ -56,7 +56,7 @@ pub fn find_ui_hint_targets_for_window(
     let condition = build_interactive_condition(&automation)?;
     let mut raw = Vec::new();
     for hwnd in windows {
-        let mut elements = collect_window_elements(&automation, hwnd, &condition)?;
+        let mut elements = collect_window_elements(&automation, hwnd, &condition, &config)?;
         raw.append(&mut elements);
     }
 
@@ -89,6 +89,15 @@ fn build_interactive_condition(
             .CreateTrueCondition()
             .map_err(|_| UiHintQueryError::UiAutomationQueryFailed)
     }
+}
+
+fn should_fallback_to_descendants(
+    strategy: crate::UiHintQueryStrategy,
+    child_count: i32,
+    min_targets_before_fallback: i32,
+) -> bool {
+    matches!(strategy, crate::UiHintQueryStrategy::ChildrenThenDescendants)
+        && child_count < min_targets_before_fallback
 }
 
 fn discover_windows_in_scope(
@@ -161,17 +170,36 @@ fn collect_window_elements(
     automation: &IUIAutomation,
     hwnd: HWND,
     condition: &IUIAutomationCondition,
+    config: &UiHintsConfig,
 ) -> Result<Vec<RawUiElement>, UiHintQueryError> {
     unsafe {
         let root = automation
             .ElementFromHandle(hwnd)
             .map_err(|_| UiHintQueryError::UiAutomationQueryFailed)?;
-        let arr: IUIAutomationElementArray = root
-            .FindAll(TreeScope_Descendants, condition)
-            .map_err(|_| UiHintQueryError::UiAutomationQueryFailed)?;
-        let len = arr
-            .Length()
-            .map_err(|_| UiHintQueryError::UiAutomationQueryFailed)?;
+        let arr: IUIAutomationElementArray = match config.query_strategy {
+            crate::UiHintQueryStrategy::Descendants => root
+                .FindAll(TreeScope_Descendants, condition)
+                .map_err(|_| UiHintQueryError::UiAutomationQueryFailed)?,
+            crate::UiHintQueryStrategy::ChildrenThenDescendants => {
+                let children = root
+                    .FindAll(TreeScope_Children, condition)
+                    .map_err(|_| UiHintQueryError::UiAutomationQueryFailed)?;
+                let child_len = children
+                    .Length()
+                    .map_err(|_| UiHintQueryError::UiAutomationQueryFailed)?;
+                if !should_fallback_to_descendants(
+                    config.query_strategy,
+                    child_len,
+                    config.min_targets_before_fallback,
+                ) {
+                    children
+                } else {
+                    root.FindAll(TreeScope_Descendants, condition)
+                        .map_err(|_| UiHintQueryError::UiAutomationQueryFailed)?
+                }
+            }
+        };
+        let len = arr.Length().map_err(|_| UiHintQueryError::UiAutomationQueryFailed)?;
         let mut out = Vec::new();
         for i in 0..len {
             if let Ok(el) = arr.GetElement(i) {
@@ -305,5 +333,24 @@ mod tests {
             name: String::new(),
             control_type: String::new()
         }));
+    }
+
+    #[test]
+    fn strategy_fallback_threshold_behavior() {
+        assert!(should_fallback_to_descendants(
+            crate::UiHintQueryStrategy::ChildrenThenDescendants,
+            2,
+            3
+        ));
+        assert!(!should_fallback_to_descendants(
+            crate::UiHintQueryStrategy::ChildrenThenDescendants,
+            3,
+            3
+        ));
+        assert!(!should_fallback_to_descendants(
+            crate::UiHintQueryStrategy::Descendants,
+            0,
+            3
+        ));
     }
 }


### PR DESCRIPTION
### Motivation
- Provide immediate user feedback when UI hint mode starts and make UIA queries more targeted and deterministic to reduce noisy results and cross-process property calls.
- Allow configuration of query strategy and thresholds so the query path can prefer direct children when useful and fall back to full descendants when needed.
- Reduce perceived slowness by showing a loading overlay while the worker enumerates UI elements and make it easy to abort/ignore stale results later (stale-id logic was preserved).

### Description
- Introduced a `loading` flag on `UiHintOverlayView`, a `build_ui_hint_loading_view(...)` helper, and a render branch that draws "Loading UI hints..." to the overlay so the UI immediately shows progress; wired this to show when entering hint-querying state. (files: `src/ui_hint_overlay.rs`, `src/main.rs`).
- Extended `UiHintsConfig` with `query_strategy: UiHintQueryStrategy`, `min_targets_before_fallback`, and `query_timeout_ms`, added defaults, and normalized/clamped these values in config normalization. (file: `src/main.rs`).
- Added `UiHintQueryStrategy` enum with `descendants` and `children_then_descendants` options and implemented children-first then fallback-to-descendants logic in the UIA collection path by passing config into `collect_window_elements(...)`. A helper `should_fallback_to_descendants(...)` centralizes the threshold decision. (file: `src/windows_uia.rs`).
- Updated UIA element collection to optionally call `FindAll(TreeScope_Children, ...)` first and only use `TreeScope_Descendants` when child count is below the configured threshold, keeping the post-filtering deterministic. (file: `src/windows_uia.rs`).
- Added unit test `strategy_fallback_threshold_behavior` to cover the fallback selection helper. (file: `src/windows_uia.rs`).

### Testing
- Attempted to run the test suite with `cargo test -q`, but the run failed in this environment due to a missing system pkg-config dependency required by the `x11` crate build script (error: missing `xi`/`xi.pc`), so tests could not complete here.
- Added a focused unit test (`strategy_fallback_threshold_behavior`) that exercises the new fallback decision logic and should pass in a correctly provisioned environment; no project-level test failures were observed prior to the environment-level build error.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13a24ef8f0833286b6f6370d2c8af8)