### PR TITLE
Add position history model, config and action scaffolding

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -485,3 +485,10 @@ width = 10
 height = 8
 visual_context_margin_percent = 0
 zoom_scale = 1.0
+
+[position_history]
+enabled = true
+max_positions = 20
+selection_keys = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+label_length = 2
+show_numbers = false

--- a/docs/config.md
+++ b/docs/config.md
@@ -311,3 +311,16 @@ Suggested bindings:
 - `Alt+Shift+E/S/D/F` => `step_move_large_*`
 
 Note: many apps reserve `Alt` accelerators for menu/navigation. If a binding is intercepted, prefer switching to a less contended modifier combo.
+
+### `[position_history]`
+
+Configures saved mouse-position history and selection labels.
+
+```toml
+[position_history]
+enabled = true
+max_positions = 20
+selection_keys = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+label_length = 2
+show_numbers = false
+```

--- a/src/action.rs
+++ b/src/action.rs
@@ -541,6 +541,22 @@ mod tests {
     fn ui_hint_mode_is_not_continuous() {
         assert!(!Action::UiHintMode.is_continuous());
     }
+
+    #[test]
+    fn parses_position_history_actions() {
+        assert_eq!(
+            Action::from_string("save_mouse_position"),
+            Some(Action::SaveMousePosition)
+        );
+        assert_eq!(
+            Action::from_string("clear_mouse_positions"),
+            Some(Action::ClearMousePositions)
+        );
+        assert_eq!(
+            Action::from_string("position_history_mode"),
+            Some(Action::PositionHistoryMode)
+        );
+    }
 }
 
 /// Manages actions associated with key presses
@@ -596,12 +612,6 @@ impl<B: crate::action_handler::MouseBackend> ActionHandler<B> {
     pub fn tick_movement(&mut self) -> MovementTick {
         self.mouse_master
             .tick_movement(&self.active_keys, Duration::from_millis(0))
-    }
-    #[test]
-    fn parses_position_history_actions() {
-        assert_eq!(Action::from_string("save_mouse_position"), Some(Action::SaveMousePosition));
-        assert_eq!(Action::from_string("clear_mouse_positions"), Some(Action::ClearMousePositions));
-        assert_eq!(Action::from_string("position_history_mode"), Some(Action::PositionHistoryMode));
     }
 
 }

--- a/src/action.rs
+++ b/src/action.rs
@@ -65,6 +65,9 @@ pub enum Action {
     Disable,
     ShowHelp,
     UiHintMode,
+    SaveMousePosition,
+    ClearMousePositions,
+    PositionHistoryMode,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -183,6 +186,9 @@ impl Action {
             "disable" | "disable_app" | "idle_mode" => Some(Self::Disable),
             "show_help" | "help" | "toggle_help" | "hints" | "show_hints" => Some(Self::ShowHelp),
             "ui_hint_mode" | "ui_hints" | "show_ui_hints" | "hint_mode" => Some(Self::UiHintMode),
+            "save_mouse_position" => Some(Self::SaveMousePosition),
+            "clear_mouse_positions" => Some(Self::ClearMousePositions),
+            "position_history_mode" => Some(Self::PositionHistoryMode),
             action
                 if action.starts_with("movement_profile:")
                     || action.starts_with("mouse_profile:")
@@ -591,4 +597,11 @@ impl<B: crate::action_handler::MouseBackend> ActionHandler<B> {
         self.mouse_master
             .tick_movement(&self.active_keys, Duration::from_millis(0))
     }
+    #[test]
+    fn parses_position_history_actions() {
+        assert_eq!(Action::from_string("save_mouse_position"), Some(Action::SaveMousePosition));
+        assert_eq!(Action::from_string("clear_mouse_positions"), Some(Action::ClearMousePositions));
+        assert_eq!(Action::from_string("position_history_mode"), Some(Action::PositionHistoryMode));
+    }
+
 }

--- a/src/action_handler.rs
+++ b/src/action_handler.rs
@@ -330,7 +330,10 @@ impl<B: MouseBackend> MouseMaster<B> {
             | Action::NavigateBack
             | Action::NavigateForward
             | Action::ShowHelp
-            | Action::UiHintMode => {}
+            | Action::UiHintMode
+            | Action::SaveMousePosition
+            | Action::ClearMousePositions
+            | Action::PositionHistoryMode => {}
             Action::Disable => self.set_active_mode(false),
             Action::PanicReset => {
                 self.hard_reset_runtime();

--- a/src/config_audit.rs
+++ b/src/config_audit.rs
@@ -360,6 +360,11 @@ fn is_known_active_path(path: &str) -> bool {
         "ui_hints.overlay.dim_non_matching",
         "ui_hints.overlay.show_background",
         "ui_hints.overlay.show_border",
+        "position_history.enabled",
+        "position_history.max_positions",
+        "position_history.selection_keys",
+        "position_history.label_length",
+        "position_history.show_numbers",
         "jump.mode",
         "jump.cursor_between_stages",
         "jump.start_region",
@@ -781,4 +786,18 @@ mod tests {
         assert_eq!(warning.severity, ConfigAuditSeverity::Warning);
         assert!(warning.message.contains("could not be parsed"));
     }
+    #[test]
+    fn audit_accepts_position_history_paths() {
+        let report = audit_config_toml(r#"
+            [position_history]
+            enabled = true
+            max_positions = 16
+            selection_keys = "ASDF"
+            label_length = 2
+            show_numbers = false
+        "#);
+        assert!(report.warnings.is_empty(), "{:?}", report.warnings);
+    }
+
+
 }

--- a/src/help_overlay.rs
+++ b/src/help_overlay.rs
@@ -820,6 +820,9 @@ fn format_action(action: &Action) -> String {
         Action::Disable => "Disable".to_string(),
         Action::ShowHelp => "Hints / Help".to_string(),
         Action::UiHintMode => "UI Hints".to_string(),
+        Action::SaveMousePosition => "Save mouse position".to_string(),
+        Action::ClearMousePositions => "Clear saved mouse positions".to_string(),
+        Action::PositionHistoryMode => "Position history mode".to_string(),
         Action::StepMove { direction, tier } => {
             let direction = match direction {
                 Direction2D::Up => "up",
@@ -880,7 +883,10 @@ fn action_category(action: &Action) -> HelpBindingCategory {
         | Action::ScreenSelect
         | Action::NavigateBack
         | Action::NavigateForward
-        | Action::UiHintMode => HelpBindingCategory::Jump,
+        | Action::UiHintMode
+        | Action::SaveMousePosition
+        | Action::ClearMousePositions
+        | Action::PositionHistoryMode => HelpBindingCategory::Jump,
         Action::Exit
         | Action::ReloadConfig
         | Action::PanicReset

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ mod key_chord;
 mod keyboard;
 mod monitor;
 mod overlay;
+mod position_history;
 mod screen_capture;
 mod ui_hint_overlay;
 mod ui_hints;
@@ -410,6 +411,7 @@ struct Config {
     status_overlay: StatusOverlayConfig,
     tooltip_overlay: TooltipOverlayConfig,
     ui_hints: UiHintsConfig,
+    position_history: PositionHistoryConfig,
     mouse_speed: MouseSpeedConfig,
     slow_mouse: SlowMouseConfig,
     movement_profiles: HashMap<String, MouseSpeedConfig>,
@@ -438,6 +440,7 @@ impl Default for Config {
             status_overlay: StatusOverlayConfig::default(),
             tooltip_overlay: TooltipOverlayConfig::default(),
             ui_hints: UiHintsConfig::default(),
+            position_history: PositionHistoryConfig::default(),
             mouse_speed: MouseSpeedConfig::default(),
             slow_mouse: SlowMouseConfig::default(),
             movement_profiles: HashMap::new(),
@@ -566,6 +569,28 @@ pub struct TooltipOverlayConfig {
     pub events: TooltipOverlayEvents,
 }
 
+
+#[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
+#[serde(default)]
+pub struct PositionHistoryConfig {
+    pub enabled: bool,
+    pub max_positions: usize,
+    pub selection_keys: String,
+    pub label_length: i32,
+    pub show_numbers: bool,
+}
+
+impl Default for PositionHistoryConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            max_positions: 20,
+            selection_keys: "ABCDEFGHIJKLMNOPQRSTUVWXYZ".to_string(),
+            label_length: 2,
+            show_numbers: false,
+        }
+    }
+}
 #[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum UiHintOverflowBehavior {

--- a/src/position_history.rs
+++ b/src/position_history.rs
@@ -1,0 +1,92 @@
+use crate::ui_hints::{generate_ui_hint_labels, UiHintOverflowBehavior};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SavedMousePosition {
+    pub id: u64,
+    pub x: i32,
+    pub y: i32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PositionHistoryUpdate {
+    Added(SavedMousePosition),
+    Cleared,
+    RemovedOldest(SavedMousePosition),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PositionHistory {
+    max_positions: usize,
+    next_id: u64,
+    positions: Vec<SavedMousePosition>,
+}
+
+impl PositionHistory {
+    pub fn new(max_positions: usize) -> Self {
+        Self { max_positions: max_positions.max(1), next_id: 1, positions: Vec::new() }
+    }
+
+    pub fn add(&mut self, x: i32, y: i32) -> Vec<PositionHistoryUpdate> {
+        let mut updates = Vec::new();
+        if self.positions.len() >= self.max_positions {
+            let removed = self.positions.remove(0);
+            updates.push(PositionHistoryUpdate::RemovedOldest(removed));
+        }
+        let added = SavedMousePosition { id: self.next_id, x, y };
+        self.next_id += 1;
+        self.positions.push(added);
+        updates.push(PositionHistoryUpdate::Added(added));
+        updates
+    }
+
+    pub fn clear(&mut self) -> bool {
+        if self.positions.is_empty() { return false; }
+        self.positions.clear();
+        true
+    }
+
+    pub fn positions(&self) -> &[SavedMousePosition] { &self.positions }
+
+    pub fn labeled_positions(&self, selection_keys: &[char], label_length: usize, show_numbers: bool) -> Vec<(String, SavedMousePosition)> {
+        let labels = generate_ui_hint_labels(self.positions.len(), selection_keys, label_length, UiHintOverflowBehavior::IncreaseLength, Some(self.positions.len()));
+        self.positions.iter().copied().zip(labels).map(|(p, label)| {
+            if show_numbers { (format!("{}:{}", p.id, label), p) } else { (label, p) }
+        }).collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn add_remove_clear_behavior() {
+        let mut h = PositionHistory::new(2);
+        h.add(1, 2);
+        h.add(3, 4);
+        assert_eq!(h.positions().len(), 2);
+        assert!(h.clear());
+        assert!(h.positions().is_empty());
+    }
+
+    #[test]
+    fn evicts_oldest_at_capacity() {
+        let mut h = PositionHistory::new(2);
+        h.add(1, 1);
+        h.add(2, 2);
+        let updates = h.add(3, 3);
+        assert!(matches!(updates[0], PositionHistoryUpdate::RemovedOldest(_)));
+        assert_eq!(h.positions()[0].x, 2);
+        assert_eq!(h.positions()[1].x, 3);
+    }
+
+    #[test]
+    fn label_assignment_is_deterministic() {
+        let mut h = PositionHistory::new(3);
+        h.add(1, 1);
+        h.add(2, 2);
+        let first = h.labeled_positions(&['A', 'B'], 2, false);
+        let second = h.labeled_positions(&['A', 'B'], 2, false);
+        assert_eq!(first, second);
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide core data model and config for saving recent mouse positions and selecting them via label-based UI hints.
- Expose simple actions to save/clear positions and enter a position-history selection mode so higher-level UI wiring can be implemented later.

### Description
- Add `src/position_history.rs` implementing `SavedMousePosition`, a bounded `PositionHistory` store, `PositionHistoryUpdate` events, deterministic label generation using the existing UI-hint label generator, and unit tests for add/remove/clear/eviction/label determinism.
- Add three new actions to `src/action.rs`: `SaveMousePosition`, `ClearMousePositions`, and `PositionHistoryMode`, and include parsing tests for these action strings via `Action::from_string`.
- Add `PositionHistoryConfig` to `src/main.rs` with defaults for `enabled`, `max_positions`, `selection_keys`, `label_length`, and `show_numbers`, and initialize it in `Config::default`.
- Add `[position_history]` example defaults to `config.toml` and document the section in `docs/config.md`.
- Extend `src/config_audit.rs` known-paths and add a unit test to ensure the new `[position_history]` keys are recognized.
- Update `src/action_handler.rs` to treat the new actions as control/no-op actions at the low-level dispatch so they compile and can be handled by higher-level wiring later.

### Testing
- Added unit tests in `src/position_history.rs` covering add/remove/clear behavior, capacity eviction, and deterministic label assignment, and a parser test in `src/action.rs` for new actions.
- Added `src/config_audit.rs` test `audit_accepts_position_history_paths` to validate config-audit support for `position_history` keys.
- Ran `cargo test -q` in the container but the run failed due to a missing system dependency required by the `x11` crate (`pkg-config` could not find `xi.pc`), so full test execution could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a143269f94c8332b6031dcad7cb610b)