### PR TITLE
Add foreground window jump geometry and window snap actions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@
     toml = "0.8.19"
     windows = {version = "0.59.0", features = [
         "Win32_Foundation",
+        "Win32_Graphics_Dwm",
         "Win32_Graphics_Gdi",
         "Win32_Graphics_GdiPlus",
         "Win32_System_Com",

--- a/config.toml
+++ b/config.toml
@@ -423,6 +423,13 @@ ui_hints_query_capped_count = false
 offset_px = 1
 use_work_area = false
 
+[window_jump]
+enabled = true
+use_extended_frame_bounds = true
+edge_offset_px = 1
+titlebar_y_offset_px = 10
+clamp_to_window = true
+
 # ---------------------------------------------------------------------------
 # Profiles
 # ---------------------------------------------------------------------------

--- a/docs/config.md
+++ b/docs/config.md
@@ -169,6 +169,11 @@ Status values used here: Active, Legacy, Deprecated alias, Preview-related.
 | `ui_hints.overlay.show_border` | boolean | `true` | Yes | Active | Draws borders around hint labels. |
 | `edge_jump.offset_px` | integer pixels | `1` | Yes | Active | Offset used by edge-jump actions. |
 | `edge_jump.use_work_area` | boolean | `false` | Yes | Active | Uses monitor work area instead of full bounds. |
+| `window_jump.enabled` | boolean | `true` | Yes | Active | Enables foreground-window snap actions. |
+| `window_jump.use_extended_frame_bounds` | boolean | `true` | Yes | Active | Uses DWM extended frame bounds when available. |
+| `window_jump.edge_offset_px` | integer pixels | `1` | Yes | Active | Inset offset for window edge snap targets. |
+| `window_jump.titlebar_y_offset_px` | integer pixels | `10` | Yes | Active | Y offset from window top for titlebar snap target. |
+| `window_jump.clamp_to_window` | boolean | `true` | Yes | Active | Clamps derived targets into foreground window bounds. |
 | `jump.move_cursor_after_each_stage` | boolean | none | Yes | Deprecated alias | Replace with `jump.cursor_between_stages`. `true` maps to `move_to_region_center`; `false` maps to `none`. |
 | `jump.<stage>.preview_margin_percent` | integer percent | none | Yes | Deprecated alias | Replace with `jump.<stage>.visual_context_margin_percent`. Used only when the new field is absent. |
 | `system_bindings.polling_rate` | integer milliseconds | none | No | Legacy | Mis-scoped old path. Move to top-level `polling_rate`. |

--- a/src/action.rs
+++ b/src/action.rs
@@ -25,6 +25,12 @@ pub enum Action {
     MoveToLeftEdge,
     MoveToRightEdge,
     CenterCurrentMonitor,
+    MoveToWindowTopEdge,
+    MoveToWindowBottomEdge,
+    MoveToWindowLeftEdge,
+    MoveToWindowRightEdge,
+    MoveToWindowCenter,
+    MoveToWindowTitlebar,
 
     // Click actions.
     LeftClick,
@@ -150,6 +156,12 @@ impl Action {
             "move_to_left_edge" => Some(Self::MoveToLeftEdge),
             "move_to_right_edge" => Some(Self::MoveToRightEdge),
             "center_current_monitor" | "center_monitor" => Some(Self::CenterCurrentMonitor),
+            "move_to_window_top_edge" => Some(Self::MoveToWindowTopEdge),
+            "move_to_window_bottom_edge" => Some(Self::MoveToWindowBottomEdge),
+            "move_to_window_left_edge" => Some(Self::MoveToWindowLeftEdge),
+            "move_to_window_right_edge" => Some(Self::MoveToWindowRightEdge),
+            "move_to_window_center" => Some(Self::MoveToWindowCenter),
+            "move_to_window_titlebar" => Some(Self::MoveToWindowTitlebar),
             "left_click" => Some(Self::LeftClick),
             "right_click" => Some(Self::RightClick),
             "middle_click" | "middle_mouse" => Some(Self::MiddleClick),
@@ -290,6 +302,12 @@ mod tests {
             ("move_to_bottom_edge", Action::MoveToBottomEdge),
             ("move_to_left_edge", Action::MoveToLeftEdge),
             ("move_to_right_edge", Action::MoveToRightEdge),
+            ("move_to_window_top_edge", Action::MoveToWindowTopEdge),
+            ("move_to_window_bottom_edge", Action::MoveToWindowBottomEdge),
+            ("move_to_window_left_edge", Action::MoveToWindowLeftEdge),
+            ("move_to_window_right_edge", Action::MoveToWindowRightEdge),
+            ("move_to_window_center", Action::MoveToWindowCenter),
+            ("move_to_window_titlebar", Action::MoveToWindowTitlebar),
             ("grid_mode", Action::GridMode),
             ("screen_select", Action::ScreenSelect),
             ("navigate_back", Action::NavigateBack),
@@ -519,7 +537,10 @@ mod tests {
 
     #[test]
     fn ui_hint_mode_parses() {
-        assert_eq!(Action::from_string("ui_hint_mode"), Some(Action::UiHintMode));
+        assert_eq!(
+            Action::from_string("ui_hint_mode"),
+            Some(Action::UiHintMode)
+        );
     }
 
     #[test]
@@ -529,7 +550,10 @@ mod tests {
 
     #[test]
     fn show_ui_hints_parses() {
-        assert_eq!(Action::from_string("show_ui_hints"), Some(Action::UiHintMode));
+        assert_eq!(
+            Action::from_string("show_ui_hints"),
+            Some(Action::UiHintMode)
+        );
     }
 
     #[test]
@@ -613,5 +637,4 @@ impl<B: crate::action_handler::MouseBackend> ActionHandler<B> {
         self.mouse_master
             .tick_movement(&self.active_keys, Duration::from_millis(0))
     }
-
 }

--- a/src/action_handler.rs
+++ b/src/action_handler.rs
@@ -159,6 +159,7 @@ pub struct MouseMaster<B: MouseBackend = EnigoMouseBackend> {
     wheel_speed_flash_until: Option<Instant>,
     pending_notifications: VecDeque<RuntimeNotification>,
     monitor_rects_provider: fn(bool) -> Vec<MonitorRect>,
+    window_snap_points_provider: fn(bool, i32, i32, bool) -> Option<WindowSnapPoints>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -214,12 +215,21 @@ impl<B: MouseBackend> MouseMaster<B> {
             wheel_speed_flash_until: None,
             pending_notifications: VecDeque::new(),
             monitor_rects_provider: all_monitor_rects,
+            window_snap_points_provider: foreground_window_snap_points,
         }
     }
 
     #[cfg(test)]
     fn set_monitor_rects_provider(&mut self, provider: fn(bool) -> Vec<MonitorRect>) {
         self.monitor_rects_provider = provider;
+    }
+
+    #[cfg(test)]
+    fn set_window_snap_points_provider(
+        &mut self,
+        provider: fn(bool, i32, i32, bool) -> Option<WindowSnapPoints>,
+    ) {
+        self.window_snap_points_provider = provider;
     }
 
     pub fn runtime_snapshot(&self) -> MouseRuntimeSnapshot {
@@ -680,7 +690,7 @@ impl<B: MouseBackend> MouseMaster<B> {
         if !self.config.window_jump.enabled {
             return;
         }
-        if let Some(points) = foreground_window_snap_points(
+        if let Some(points) = (self.window_snap_points_provider)(
             self.config.window_jump.use_extended_frame_bounds,
             self.config.window_jump.edge_offset_px,
             self.config.window_jump.titlebar_y_offset_px,
@@ -1331,6 +1341,22 @@ mod tests {
                 bottom: 900,
             },
         ]
+    }
+
+    fn fake_window_snap_points_provider(
+        _use_extended_frame_bounds: bool,
+        _edge_offset_px: i32,
+        _titlebar_y_offset_px: i32,
+        _clamp_to_window: bool,
+    ) -> Option<WindowSnapPoints> {
+        Some(WindowSnapPoints {
+            top_edge: (10, 11),
+            bottom_edge: (20, 21),
+            left_edge: (30, 31),
+            right_edge: (40, 41),
+            center: (50, 51),
+            titlebar: (60, 61),
+        })
     }
 
     fn actions(actions: &[Action]) -> HashSet<Action> {
@@ -2394,6 +2420,37 @@ mod tests {
             Some((11, 12))
         );
         assert_eq!(window_snap_for_action(&Action::MoveUp, p), None);
+    }
+
+    #[test]
+    fn window_snap_actions_dispatch_to_expected_absolute_points() {
+        let actions = [
+            (Action::MoveToWindowTopEdge, (10, 11)),
+            (Action::MoveToWindowBottomEdge, (20, 21)),
+            (Action::MoveToWindowLeftEdge, (30, 31)),
+            (Action::MoveToWindowRightEdge, (40, 41)),
+            (Action::MoveToWindowCenter, (50, 51)),
+            (Action::MoveToWindowTitlebar, (60, 61)),
+        ];
+
+        for (action, expected) in actions {
+            let mut mouse = MouseMaster::new_with_backend(test_config(), FakeBackend::default());
+            mouse.set_window_snap_points_provider(fake_window_snap_points_provider);
+            mouse.handle_action(action);
+            assert_eq!(mouse.backend.moves, vec![expected]);
+        }
+    }
+
+    #[test]
+    fn window_snap_actions_do_not_move_when_feature_disabled() {
+        let mut config = test_config();
+        config.window_jump.enabled = false;
+        let mut mouse = MouseMaster::new_with_backend(config, FakeBackend::default());
+        mouse.set_window_snap_points_provider(fake_window_snap_points_provider);
+
+        mouse.handle_action(Action::MoveToWindowCenter);
+
+        assert!(mouse.backend.moves.is_empty());
     }
 
     #[test]

--- a/src/action_handler.rs
+++ b/src/action_handler.rs
@@ -2396,30 +2396,33 @@ mod tests {
             titlebar: (11, 12),
         };
         assert_eq!(
-            Self::window_snap_for_action(&Action::MoveToWindowTopEdge, p),
+            MouseMaster::<FakeBackend>::window_snap_for_action(&Action::MoveToWindowTopEdge, p),
             Some((1, 2))
         );
         assert_eq!(
-            Self::window_snap_for_action(&Action::MoveToWindowBottomEdge, p),
+            MouseMaster::<FakeBackend>::window_snap_for_action(&Action::MoveToWindowBottomEdge, p),
             Some((3, 4))
         );
         assert_eq!(
-            Self::window_snap_for_action(&Action::MoveToWindowLeftEdge, p),
+            MouseMaster::<FakeBackend>::window_snap_for_action(&Action::MoveToWindowLeftEdge, p),
             Some((5, 6))
         );
         assert_eq!(
-            Self::window_snap_for_action(&Action::MoveToWindowRightEdge, p),
+            MouseMaster::<FakeBackend>::window_snap_for_action(&Action::MoveToWindowRightEdge, p),
             Some((7, 8))
         );
         assert_eq!(
-            Self::window_snap_for_action(&Action::MoveToWindowCenter, p),
+            MouseMaster::<FakeBackend>::window_snap_for_action(&Action::MoveToWindowCenter, p),
             Some((9, 10))
         );
         assert_eq!(
-            Self::window_snap_for_action(&Action::MoveToWindowTitlebar, p),
+            MouseMaster::<FakeBackend>::window_snap_for_action(&Action::MoveToWindowTitlebar, p),
             Some((11, 12))
         );
-        assert_eq!(Self::window_snap_for_action(&Action::MoveUp, p), None);
+        assert_eq!(
+            MouseMaster::<FakeBackend>::window_snap_for_action(&Action::MoveUp, p),
+            None
+        );
     }
 
     #[test]

--- a/src/action_handler.rs
+++ b/src/action_handler.rs
@@ -2396,30 +2396,30 @@ mod tests {
             titlebar: (11, 12),
         };
         assert_eq!(
-            window_snap_for_action(&Action::MoveToWindowTopEdge, p),
+            Self::window_snap_for_action(&Action::MoveToWindowTopEdge, p),
             Some((1, 2))
         );
         assert_eq!(
-            window_snap_for_action(&Action::MoveToWindowBottomEdge, p),
+            Self::window_snap_for_action(&Action::MoveToWindowBottomEdge, p),
             Some((3, 4))
         );
         assert_eq!(
-            window_snap_for_action(&Action::MoveToWindowLeftEdge, p),
+            Self::window_snap_for_action(&Action::MoveToWindowLeftEdge, p),
             Some((5, 6))
         );
         assert_eq!(
-            window_snap_for_action(&Action::MoveToWindowRightEdge, p),
+            Self::window_snap_for_action(&Action::MoveToWindowRightEdge, p),
             Some((7, 8))
         );
         assert_eq!(
-            window_snap_for_action(&Action::MoveToWindowCenter, p),
+            Self::window_snap_for_action(&Action::MoveToWindowCenter, p),
             Some((9, 10))
         );
         assert_eq!(
-            window_snap_for_action(&Action::MoveToWindowTitlebar, p),
+            Self::window_snap_for_action(&Action::MoveToWindowTitlebar, p),
             Some((11, 12))
         );
-        assert_eq!(window_snap_for_action(&Action::MoveUp, p), None);
+        assert_eq!(Self::window_snap_for_action(&Action::MoveUp, p), None);
     }
 
     #[test]

--- a/src/action_handler.rs
+++ b/src/action_handler.rs
@@ -2,7 +2,13 @@ use crate::monitor::{
     all_monitor_rects, current_monitor_rect_for_cursor, monitor_containing_point,
     next_monitor_with_wrap, MonitorEdge, MonitorRect,
 };
-use crate::{action, app_state::KeyEvent, keyboard::VirtualKey, Config, FinalAdjustConfig};
+use crate::{
+    action,
+    app_state::KeyEvent,
+    keyboard::VirtualKey,
+    window_geometry::{foreground_window_snap_points, WindowSnapPoints},
+    Config, FinalAdjustConfig,
+};
 use action::{Action, Direction2D, StepMoveTier};
 use enigo::*;
 use std::collections::{HashSet, VecDeque};
@@ -283,6 +289,12 @@ impl<B: MouseBackend> MouseMaster<B> {
             Action::MoveToLeftEdge => self.move_to_monitor_edge(MonitorEdge::Left),
             Action::MoveToRightEdge => self.move_to_monitor_edge(MonitorEdge::Right),
             Action::CenterCurrentMonitor => self.center_current_monitor(),
+            Action::MoveToWindowTopEdge => self.move_to_window_snap(|p| p.top_edge),
+            Action::MoveToWindowBottomEdge => self.move_to_window_snap(|p| p.bottom_edge),
+            Action::MoveToWindowLeftEdge => self.move_to_window_snap(|p| p.left_edge),
+            Action::MoveToWindowRightEdge => self.move_to_window_snap(|p| p.right_edge),
+            Action::MoveToWindowCenter => self.move_to_window_snap(|p| p.center),
+            Action::MoveToWindowTitlebar => self.move_to_window_snap(|p| p.titlebar),
             Action::ScreenSelect => self.select_next_screen(),
             Action::StepMove { direction, tier } => self.step_move(direction, tier),
             Action::ClickThenDisable => {
@@ -648,6 +660,33 @@ impl<B: MouseBackend> MouseMaster<B> {
     pub fn move_to_monitor_edge(&mut self, edge: MonitorEdge) {
         if let Some(rect) = current_monitor_rect_for_cursor(self.config.edge_jump.use_work_area) {
             let (x, y) = edge_target(rect, edge, self.config.edge_jump.offset_px);
+            self.move_mouse_to(x, y);
+        }
+    }
+
+    fn window_snap_for_action(action: &Action, points: WindowSnapPoints) -> Option<(i32, i32)> {
+        match action {
+            Action::MoveToWindowTopEdge => Some(points.top_edge),
+            Action::MoveToWindowBottomEdge => Some(points.bottom_edge),
+            Action::MoveToWindowLeftEdge => Some(points.left_edge),
+            Action::MoveToWindowRightEdge => Some(points.right_edge),
+            Action::MoveToWindowCenter => Some(points.center),
+            Action::MoveToWindowTitlebar => Some(points.titlebar),
+            _ => None,
+        }
+    }
+
+    fn move_to_window_snap(&mut self, map: fn(WindowSnapPoints) -> (i32, i32)) {
+        if !self.config.window_jump.enabled {
+            return;
+        }
+        if let Some(points) = foreground_window_snap_points(
+            self.config.window_jump.use_extended_frame_bounds,
+            self.config.window_jump.edge_offset_px,
+            self.config.window_jump.titlebar_y_offset_px,
+            self.config.window_jump.clamp_to_window,
+        ) {
+            let (x, y) = map(points);
             self.move_mouse_to(x, y);
         }
     }
@@ -1637,8 +1676,14 @@ mod tests {
             &mut acceleration_counter,
         );
 
-        assert_eq!(movement.speed, effective_slow_speed(&config, config.starting_speed));
-        assert_eq!(movement.dx, f64::from(effective_slow_speed(&config, config.starting_speed)));
+        assert_eq!(
+            movement.speed,
+            effective_slow_speed(&config, config.starting_speed)
+        );
+        assert_eq!(
+            movement.dx,
+            f64::from(effective_slow_speed(&config, config.starting_speed))
+        );
         assert_eq!(movement.dy, 0.0);
     }
 
@@ -2017,7 +2062,8 @@ mod tests {
         config.slow_mouse.min_speed = 1;
         config.slow_mouse.max_speed = 12;
         let mut mouse = MouseMaster::new_with_backend(config, FakeBackend::default());
-        let slow_diagonal_actions = actions(&[Action::MoveUp, Action::MoveRight, Action::SlowMouse]);
+        let slow_diagonal_actions =
+            actions(&[Action::MoveUp, Action::MoveRight, Action::SlowMouse]);
 
         let tick = mouse.tick_movement(&slow_diagonal_actions, Duration::from_millis(8));
         let magnitude = (tick.dx.powi(2) + tick.dy.powi(2)).sqrt();
@@ -2311,6 +2357,43 @@ mod tests {
             tier: StepMoveTier::Large,
         });
         assert_eq!(mouse.backend.moves, vec![(299, 95)]);
+    }
+
+    #[test]
+    fn window_snap_actions_map_to_expected_points() {
+        let p = WindowSnapPoints {
+            top_edge: (1, 2),
+            bottom_edge: (3, 4),
+            left_edge: (5, 6),
+            right_edge: (7, 8),
+            center: (9, 10),
+            titlebar: (11, 12),
+        };
+        assert_eq!(
+            window_snap_for_action(&Action::MoveToWindowTopEdge, p),
+            Some((1, 2))
+        );
+        assert_eq!(
+            window_snap_for_action(&Action::MoveToWindowBottomEdge, p),
+            Some((3, 4))
+        );
+        assert_eq!(
+            window_snap_for_action(&Action::MoveToWindowLeftEdge, p),
+            Some((5, 6))
+        );
+        assert_eq!(
+            window_snap_for_action(&Action::MoveToWindowRightEdge, p),
+            Some((7, 8))
+        );
+        assert_eq!(
+            window_snap_for_action(&Action::MoveToWindowCenter, p),
+            Some((9, 10))
+        );
+        assert_eq!(
+            window_snap_for_action(&Action::MoveToWindowTitlebar, p),
+            Some((11, 12))
+        );
+        assert_eq!(window_snap_for_action(&Action::MoveUp, p), None);
     }
 
     #[test]

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -67,8 +67,13 @@ pub enum AppCommand {
     JumpInput(KeyEvent, Option<Action>),
     GridInput(KeyEvent, Option<Action>),
     UiHintInput(KeyEvent),
-    UiHintQueryCompleted { query_id: u64, elements: Vec<crate::windows_uia::RawUiElement> },
-    UiHintQueryFailed { query_id: u64 },
+    UiHintQueryCompleted {
+        query_id: u64,
+        elements: Vec<crate::windows_uia::RawUiElement>,
+    },
+    UiHintQueryFailed {
+        query_id: u64,
+    },
 }
 
 #[derive(Debug)]
@@ -91,8 +96,16 @@ pub struct AppState {
 #[derive(Debug)]
 pub enum UiHintState {
     Inactive,
-    Querying { activation_key: VirtualKey, query_id: u64, foreground_hwnd: isize },
-    Active { activation_key: VirtualKey, query_id: u64, foreground_hwnd: isize },
+    Querying {
+        activation_key: VirtualKey,
+        query_id: u64,
+        foreground_hwnd: isize,
+    },
+    Active {
+        activation_key: VirtualKey,
+        query_id: u64,
+        foreground_hwnd: isize,
+    },
 }
 
 #[derive(Debug)]
@@ -303,13 +316,26 @@ impl AppState {
     ) {
         self.exit_jump_mode();
         self.exit_grid_mode();
-        self.ui_hints = UiHintState::Querying { activation_key, query_id, foreground_hwnd };
+        self.ui_hints = UiHintState::Querying {
+            activation_key,
+            query_id,
+            foreground_hwnd,
+        };
     }
 
     pub fn activate_ui_hint_if_querying(&mut self, query_id: u64) -> bool {
-        if let UiHintState::Querying { activation_key, query_id: active_query_id, foreground_hwnd } = self.ui_hints {
+        if let UiHintState::Querying {
+            activation_key,
+            query_id: active_query_id,
+            foreground_hwnd,
+        } = self.ui_hints
+        {
             if active_query_id == query_id {
-                self.ui_hints = UiHintState::Active { activation_key, query_id, foreground_hwnd };
+                self.ui_hints = UiHintState::Active {
+                    activation_key,
+                    query_id,
+                    foreground_hwnd,
+                };
                 return true;
             }
         }
@@ -318,7 +344,9 @@ impl AppState {
 
     pub fn current_ui_hint_query_id(&self) -> Option<u64> {
         match self.ui_hints {
-            UiHintState::Querying { query_id, .. } | UiHintState::Active { query_id, .. } => Some(query_id),
+            UiHintState::Querying { query_id, .. } | UiHintState::Active { query_id, .. } => {
+                Some(query_id)
+            }
             UiHintState::Inactive => None,
         }
     }
@@ -1068,7 +1096,11 @@ mod tests {
     }
 
     fn enter_ui_hint_mode(state: &mut AppState, activation_key: VirtualKey) {
-        state.ui_hints = UiHintState::Active { activation_key, query_id: 1, foreground_hwnd: 0 };
+        state.ui_hints = UiHintState::Active {
+            activation_key,
+            query_id: 1,
+            foreground_hwnd: 0,
+        };
     }
 
     fn final_adjust_config(enabled: bool) -> Config {
@@ -2237,7 +2269,10 @@ mod tests {
         ] {
             let event = KeyEvent::new(key, true);
             state.route_key_event(event, action.clone());
-            assert_eq!(state.pop_command(), Some(AppCommand::GridInput(event, action)));
+            assert_eq!(
+                state.pop_command(),
+                Some(AppCommand::GridInput(event, action))
+            );
         }
     }
 

--- a/src/config_audit.rs
+++ b/src/config_audit.rs
@@ -275,6 +275,11 @@ fn is_known_active_path(path: &str) -> bool {
         "wheel_profiles.*.horizontal_multiplier",
         "edge_jump.offset_px",
         "edge_jump.use_work_area",
+        "window_jump.enabled",
+        "window_jump.use_extended_frame_bounds",
+        "window_jump.edge_offset_px",
+        "window_jump.titlebar_y_offset_px",
+        "window_jump.clamp_to_window",
         "final_adjust.enabled",
         "final_adjust.small_step_px",
         "final_adjust.large_step_px",
@@ -788,16 +793,16 @@ mod tests {
     }
     #[test]
     fn audit_accepts_position_history_paths() {
-        let report = audit_config_toml(r#"
+        let report = audit_config_toml(
+            r#"
             [position_history]
             enabled = true
             max_positions = 16
             selection_keys = "ASDF"
             label_length = 2
             show_numbers = false
-        "#);
+        "#,
+        );
         assert!(report.warnings.is_empty(), "{:?}", report.warnings);
     }
-
-
 }

--- a/src/help_overlay.rs
+++ b/src/help_overlay.rs
@@ -785,6 +785,12 @@ fn format_action(action: &Action) -> String {
         Action::MoveToBottomEdge => "Jump to bottom edge".to_string(),
         Action::MoveToLeftEdge => "Jump to left edge".to_string(),
         Action::MoveToRightEdge => "Jump to right edge".to_string(),
+        Action::MoveToWindowTopEdge => "Jump to window top edge".to_string(),
+        Action::MoveToWindowBottomEdge => "Jump to window bottom edge".to_string(),
+        Action::MoveToWindowLeftEdge => "Jump to window left edge".to_string(),
+        Action::MoveToWindowRightEdge => "Jump to window right edge".to_string(),
+        Action::MoveToWindowCenter => "Jump to window center".to_string(),
+        Action::MoveToWindowTitlebar => "Jump to window titlebar".to_string(),
         Action::CenterCurrentMonitor => "Center current monitor".to_string(),
         Action::LeftClick => "Left click".to_string(),
         Action::RightClick => "Right click".to_string(),
@@ -876,6 +882,12 @@ fn action_category(action: &Action) -> HelpBindingCategory {
         | Action::MoveToBottomEdge
         | Action::MoveToLeftEdge
         | Action::MoveToRightEdge
+        | Action::MoveToWindowTopEdge
+        | Action::MoveToWindowBottomEdge
+        | Action::MoveToWindowLeftEdge
+        | Action::MoveToWindowRightEdge
+        | Action::MoveToWindowCenter
+        | Action::MoveToWindowTitlebar
         | Action::CenterCurrentMonitor
         | Action::JumpMode
         | Action::JumpModeProfile(_)

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ mod position_history;
 mod screen_capture;
 mod ui_hint_overlay;
 mod ui_hints;
+mod window_geometry;
 mod windows_uia;
 
 use action::*;
@@ -418,6 +419,7 @@ struct Config {
     wheel: WheelConfig,
     wheel_profiles: HashMap<String, WheelProfileConfig>,
     edge_jump: EdgeJumpConfig,
+    window_jump: WindowJumpConfig,
     // Legacy compatibility alias for the movement baseline. New configs should use
     // [mouse_speed].default_speed; normalization keeps starting_speed synchronized.
     starting_speed: i32,
@@ -447,6 +449,7 @@ impl Default for Config {
             wheel: WheelConfig::default(),
             wheel_profiles: HashMap::new(),
             edge_jump: EdgeJumpConfig::default(),
+            window_jump: WindowJumpConfig::default(),
             starting_speed: 1,
             acceleration: 2,
             acceleration_rate: 1,
@@ -568,7 +571,6 @@ pub struct TooltipOverlayConfig {
     pub help_max_bindings: i32,
     pub events: TooltipOverlayEvents,
 }
-
 
 #[derive(Debug, Deserialize, Clone, PartialEq, Eq)]
 #[serde(default)]
@@ -821,6 +823,28 @@ impl Default for FinalAdjustConfig {
 pub struct EdgeJumpConfig {
     offset_px: i32,
     use_work_area: bool,
+}
+
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(default)]
+pub struct WindowJumpConfig {
+    enabled: bool,
+    use_extended_frame_bounds: bool,
+    edge_offset_px: i32,
+    titlebar_y_offset_px: i32,
+    clamp_to_window: bool,
+}
+
+impl Default for WindowJumpConfig {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            use_extended_frame_bounds: true,
+            edge_offset_px: 1,
+            titlebar_y_offset_px: 10,
+            clamp_to_window: true,
+        }
+    }
 }
 
 impl Default for EdgeJumpConfig {
@@ -1431,6 +1455,7 @@ impl Config {
         self.normalize_wheel_config();
         self.normalize_runtime_profiles();
         self.normalize_edge_jump_config();
+        self.normalize_window_jump_config();
         self.normalize_tooltip_overlay_config();
         self.normalize_ui_hints_config();
         // Keep the legacy field stable for downstream code and diagnostics after the
@@ -1541,7 +1566,12 @@ impl Config {
             0,
             200,
         );
-        self.ui_hints.min_targets_before_fallback = normalize_i32_range("ui_hints.min_targets_before_fallback", self.ui_hints.min_targets_before_fallback, 1, 5000);
+        self.ui_hints.min_targets_before_fallback = normalize_i32_range(
+            "ui_hints.min_targets_before_fallback",
+            self.ui_hints.min_targets_before_fallback,
+            1,
+            5000,
+        );
         self.ui_hints.query_timeout_ms = self.ui_hints.query_timeout_ms.clamp(100, 30_000);
         self.ui_hints.overlay.font_scale = normalize_f32_range(
             "ui_hints.overlay.font_scale",
@@ -1549,6 +1579,17 @@ impl Config {
             0.25,
             4.0,
         );
+    }
+
+    fn normalize_window_jump_config(&mut self) {
+        self.window_jump.edge_offset_px = self
+            .window_jump
+            .edge_offset_px
+            .clamp(0, MAX_EDGE_JUMP_OFFSET_PX);
+        self.window_jump.titlebar_y_offset_px = self
+            .window_jump
+            .titlebar_y_offset_px
+            .clamp(0, MAX_EDGE_JUMP_OFFSET_PX);
     }
 
     fn normalize_final_adjust_config(&mut self) {
@@ -1589,8 +1630,12 @@ impl Config {
     }
 
     fn normalize_step_move_config(&mut self) {
-        self.step_move.small_step_px =
-            normalize_i32_range("step_move.small_step_px", self.step_move.small_step_px, 1, 5000);
+        self.step_move.small_step_px = normalize_i32_range(
+            "step_move.small_step_px",
+            self.step_move.small_step_px,
+            1,
+            5000,
+        );
         self.step_move.normal_step_px = normalize_i32_range(
             "step_move.normal_step_px",
             self.step_move.normal_step_px,
@@ -3157,7 +3202,7 @@ fn execute_app_command(command: AppCommand, debug_diagnostics: bool) {
             let query_request = UiHintQueryRequest {
                 query_id: UI_HINT_QUERY_ID.fetch_add(1, Ordering::Relaxed) + 1,
                 foreground_hwnd: unsafe {
-                windows::Win32::UI::WindowsAndMessaging::GetForegroundWindow().0 as isize
+                    windows::Win32::UI::WindowsAndMessaging::GetForegroundWindow().0 as isize
                 },
             };
             APP_STATE.write().unwrap().enter_ui_hint_querying(
@@ -3397,7 +3442,13 @@ fn execute_app_command(command: AppCommand, debug_diagnostics: bool) {
                     if ui_hints_debug_enabled() {
                         eprintln!("[ui-hints] completion/cancel: completed");
                     }
-                    let config = ACTION_HANDLER.read().unwrap().mouse_master.config.ui_hints.clone();
+                    let config = ACTION_HANDLER
+                        .read()
+                        .unwrap()
+                        .mouse_master
+                        .config
+                        .ui_hints
+                        .clone();
                     let action = resolve_ui_hint_completion_action(&config, &event);
                     {
                         let mut handler = ACTION_HANDLER.write().unwrap();
@@ -3407,26 +3458,40 @@ fn execute_app_command(command: AppCommand, debug_diagnostics: bool) {
                                 && last.action != UiHintCompletionAction::MoveOnly
                                 && Instant::now() <= last.expires_at
                             {
-                                handler.mouse_master.move_mouse_to(last.target_x, last.target_y);
+                                handler
+                                    .mouse_master
+                                    .move_mouse_to(last.target_x, last.target_y);
                                 match last.action {
-                                    UiHintCompletionAction::LeftClick => handler.mouse_master.left_click_once(),
-                                    UiHintCompletionAction::RightClick => handler.mouse_master.right_click_once(),
-                                    UiHintCompletionAction::MiddleClick => handler.mouse_master.middle_click_once(),
+                                    UiHintCompletionAction::LeftClick => {
+                                        handler.mouse_master.left_click_once()
+                                    }
+                                    UiHintCompletionAction::RightClick => {
+                                        handler.mouse_master.right_click_once()
+                                    }
+                                    UiHintCompletionAction::MiddleClick => {
+                                        handler.mouse_master.middle_click_once()
+                                    }
                                     UiHintCompletionAction::MoveOnly => {}
                                 }
                                 replayed = true;
                             }
                         }
                         if !replayed {
-                            handler.mouse_master.move_mouse_to(target.target_x, target.target_y);
+                            handler
+                                .mouse_master
+                                .move_mouse_to(target.target_x, target.target_y);
                             match action {
                                 UiHintCompletionAction::LeftClick => {
                                     if !handler.mouse_master.left_button_held() {
                                         handler.mouse_master.left_click_once();
                                     }
                                 }
-                                UiHintCompletionAction::RightClick => handler.mouse_master.right_click_once(),
-                                UiHintCompletionAction::MiddleClick => handler.mouse_master.middle_click_once(),
+                                UiHintCompletionAction::RightClick => {
+                                    handler.mouse_master.right_click_once()
+                                }
+                                UiHintCompletionAction::MiddleClick => {
+                                    handler.mouse_master.middle_click_once()
+                                }
                                 UiHintCompletionAction::MoveOnly => {}
                             }
                         }
@@ -3435,7 +3500,8 @@ fn execute_app_command(command: AppCommand, debug_diagnostics: bool) {
                             target_x: target.target_x,
                             target_y: target.target_y,
                             action,
-                            expires_at: Instant::now() + Duration::from_millis(config.repeat_click_window_ms),
+                            expires_at: Instant::now()
+                                + Duration::from_millis(config.repeat_click_window_ms),
                         });
                         if action == UiHintCompletionAction::MoveOnly {
                             let _ = LAST_UI_HINT_COMPLETION.lock().unwrap().take();
@@ -3485,7 +3551,9 @@ fn execute_app_command(command: AppCommand, debug_diagnostics: bool) {
                 min_hint_spacing_px: config.min_hint_spacing_px,
                 target_point: match config.target_point {
                     UiHintTargetPoint::Center => ui_hints::UiHintTargetPoint::Center,
-                    UiHintTargetPoint::ClickablePoint => ui_hints::UiHintTargetPoint::ClickablePoint,
+                    UiHintTargetPoint::ClickablePoint => {
+                        ui_hints::UiHintTargetPoint::ClickablePoint
+                    }
                 },
             };
             let discovered_count = elements.len();
@@ -6203,7 +6271,10 @@ mod tests {
         assert_eq!(config.ui_hints.label_length, 5);
         assert_eq!(config.ui_hints.max_hints, 2000);
         assert_eq!(config.ui_hints.min_hint_spacing_px, 0);
-        assert_eq!(config.ui_hints.overflow_behavior, UiHintOverflowBehavior::Cap);
+        assert_eq!(
+            config.ui_hints.overflow_behavior,
+            UiHintOverflowBehavior::Cap
+        );
         assert_eq!(config.ui_hints.target_point, UiHintTargetPoint::Center);
         assert_eq!(
             config.ui_hints.after_select,
@@ -6221,17 +6292,32 @@ mod tests {
     fn ui_hint_after_select_and_modifier_resolution() {
         let mut cfg = UiHintsConfig::default();
         cfg.after_select = UiHintAfterSelect::MoveAndLeftClick;
-        assert_eq!(resolve_ui_hint_completion_action(&cfg, &KeyEvent::new(VirtualKey::A, true)), UiHintCompletionAction::LeftClick);
+        assert_eq!(
+            resolve_ui_hint_completion_action(&cfg, &KeyEvent::new(VirtualKey::A, true)),
+            UiHintCompletionAction::LeftClick
+        );
 
-        cfg.browse_modifier = Some(UiHintModifierConfig { shift: true, ..UiHintModifierConfig::default() });
+        cfg.browse_modifier = Some(UiHintModifierConfig {
+            shift: true,
+            ..UiHintModifierConfig::default()
+        });
         let mut ev = KeyEvent::new(VirtualKey::A, true);
         ev.shift_down = true;
-        assert_eq!(resolve_ui_hint_completion_action(&cfg, &ev), UiHintCompletionAction::MoveOnly);
+        assert_eq!(
+            resolve_ui_hint_completion_action(&cfg, &ev),
+            UiHintCompletionAction::MoveOnly
+        );
 
-        cfg.right_click_modifier = Some(UiHintModifierConfig { ctrl: true, ..UiHintModifierConfig::default() });
+        cfg.right_click_modifier = Some(UiHintModifierConfig {
+            ctrl: true,
+            ..UiHintModifierConfig::default()
+        });
         let mut ev2 = KeyEvent::new(VirtualKey::A, true);
         ev2.ctrl_down = true;
-        assert_eq!(resolve_ui_hint_completion_action(&cfg, &ev2), UiHintCompletionAction::RightClick);
+        assert_eq!(
+            resolve_ui_hint_completion_action(&cfg, &ev2),
+            UiHintCompletionAction::RightClick
+        );
     }
 
     #[test]

--- a/src/position_history.rs
+++ b/src/position_history.rs
@@ -23,7 +23,11 @@ pub struct PositionHistory {
 
 impl PositionHistory {
     pub fn new(max_positions: usize) -> Self {
-        Self { max_positions: max_positions.max(1), next_id: 1, positions: Vec::new() }
+        Self {
+            max_positions: max_positions.max(1),
+            next_id: 1,
+            positions: Vec::new(),
+        }
     }
 
     pub fn add(&mut self, x: i32, y: i32) -> Vec<PositionHistoryUpdate> {
@@ -32,7 +36,11 @@ impl PositionHistory {
             let removed = self.positions.remove(0);
             updates.push(PositionHistoryUpdate::RemovedOldest(removed));
         }
-        let added = SavedMousePosition { id: self.next_id, x, y };
+        let added = SavedMousePosition {
+            id: self.next_id,
+            x,
+            y,
+        };
         self.next_id += 1;
         self.positions.push(added);
         updates.push(PositionHistoryUpdate::Added(added));
@@ -40,18 +48,42 @@ impl PositionHistory {
     }
 
     pub fn clear(&mut self) -> bool {
-        if self.positions.is_empty() { return false; }
+        if self.positions.is_empty() {
+            return false;
+        }
         self.positions.clear();
         true
     }
 
-    pub fn positions(&self) -> &[SavedMousePosition] { &self.positions }
+    pub fn positions(&self) -> &[SavedMousePosition] {
+        &self.positions
+    }
 
-    pub fn labeled_positions(&self, selection_keys: &[char], label_length: usize, show_numbers: bool) -> Vec<(String, SavedMousePosition)> {
-        let labels = generate_ui_hint_labels(self.positions.len(), selection_keys, label_length, UiHintOverflowBehavior::IncreaseLength, Some(self.positions.len()));
-        self.positions.iter().copied().zip(labels).map(|(p, label)| {
-            if show_numbers { (format!("{}:{}", p.id, label), p) } else { (label, p) }
-        }).collect()
+    pub fn labeled_positions(
+        &self,
+        selection_keys: &[char],
+        label_length: usize,
+        show_numbers: bool,
+    ) -> Vec<(String, SavedMousePosition)> {
+        let labels = generate_ui_hint_labels(
+            self.positions.len(),
+            selection_keys,
+            label_length,
+            UiHintOverflowBehavior::IncreaseLength,
+            Some(self.positions.len()),
+        );
+        self.positions
+            .iter()
+            .copied()
+            .zip(labels)
+            .map(|(p, label)| {
+                if show_numbers {
+                    (format!("{}:{}", p.id, label), p)
+                } else {
+                    (label, p)
+                }
+            })
+            .collect()
     }
 }
 
@@ -75,7 +107,10 @@ mod tests {
         h.add(1, 1);
         h.add(2, 2);
         let updates = h.add(3, 3);
-        assert!(matches!(updates[0], PositionHistoryUpdate::RemovedOldest(_)));
+        assert!(matches!(
+            updates[0],
+            PositionHistoryUpdate::RemovedOldest(_)
+        ));
         assert_eq!(h.positions()[0].x, 2);
         assert_eq!(h.positions()[1].x, 3);
     }

--- a/src/ui_hints.rs
+++ b/src/ui_hints.rs
@@ -448,7 +448,10 @@ mod tests {
     #[test]
     fn supports_custom_symbol_keyset_input() {
         let mut session = UiHintSession::new(vec![target(1, "A;")], vec!['A', ';']).unwrap();
-        assert_eq!(session.handle_key(VirtualKey::A), UiHintInputUpdate::PrefixChanged);
+        assert_eq!(
+            session.handle_key(VirtualKey::A),
+            UiHintInputUpdate::PrefixChanged
+        );
         assert_eq!(
             session.handle_key(VirtualKey::Oem1),
             UiHintInputUpdate::Completed {
@@ -460,7 +463,10 @@ mod tests {
     #[test]
     fn supports_digit_keyset_input() {
         let mut session = UiHintSession::new(vec![target(1, "12")], vec!['1', '2']).unwrap();
-        assert_eq!(session.handle_key(VirtualKey::Num1), UiHintInputUpdate::PrefixChanged);
+        assert_eq!(
+            session.handle_key(VirtualKey::Num1),
+            UiHintInputUpdate::PrefixChanged
+        );
         assert_eq!(
             session.handle_key(VirtualKey::Num2),
             UiHintInputUpdate::Completed {
@@ -473,11 +479,18 @@ mod tests {
     fn collapses_duplicate_bounds_and_sorts_deterministically() {
         let config = sample_config();
         let targets = build_ui_hint_targets(
-            vec![raw(5, 10, 10, 10, 10, None), raw(2, 10, 10, 10, 10, None), raw(3, 20, 10, 10, 10, None)],
+            vec![
+                raw(5, 10, 10, 10, 10, None),
+                raw(2, 10, 10, 10, 10, None),
+                raw(3, 20, 10, 10, 10, None),
+            ],
             &config,
         );
         assert_eq!(targets.iter().map(|t| t.id).collect::<Vec<_>>(), vec![2, 3]);
-        assert_eq!(targets.iter().map(|t| t.label.clone()).collect::<Vec<_>>(), vec!["AA", "AB"]);
+        assert_eq!(
+            targets.iter().map(|t| t.label.clone()).collect::<Vec<_>>(),
+            vec!["AA", "AB"]
+        );
     }
 
     #[test]

--- a/src/window_geometry.rs
+++ b/src/window_geometry.rs
@@ -97,7 +97,9 @@ fn client_rect_in_screen(hwnd: HWND) -> Option<WindowRect> {
         x: client.left,
         y: client.top,
     };
-    unsafe { ClientToScreen(hwnd, &mut origin) }.ok()?;
+    if unsafe { ClientToScreen(hwnd, &mut origin) }.is_err() {
+        return None;
+    }
     Some(WindowRect {
         left: origin.x,
         top: origin.y,

--- a/src/window_geometry.rs
+++ b/src/window_geometry.rs
@@ -1,8 +1,7 @@
 use windows::Win32::Foundation::{HWND, POINT, RECT};
 use windows::Win32::Graphics::Dwm::{DwmGetWindowAttribute, DWMWA_EXTENDED_FRAME_BOUNDS};
-use windows::Win32::UI::WindowsAndMessaging::{
-    ClientToScreen, GetClientRect, GetForegroundWindow, GetWindowRect,
-};
+use windows::Win32::Graphics::Gdi::ClientToScreen;
+use windows::Win32::UI::WindowsAndMessaging::{GetClientRect, GetForegroundWindow, GetWindowRect};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct WindowRect {
@@ -41,7 +40,7 @@ pub fn foreground_window_snap_points(
     clamp_to_window: bool,
 ) -> Option<WindowSnapPoints> {
     let hwnd = unsafe { GetForegroundWindow() };
-    if hwnd.0 == 0 {
+    if hwnd.0.is_null() {
         return None;
     }
     let rect = foreground_rect(hwnd, use_extended_frame_bounds)?;
@@ -64,8 +63,8 @@ fn foreground_rect(hwnd: HWND, use_extended_frame_bounds: bool) -> Option<Window
 
 fn window_rect(hwnd: HWND) -> Option<WindowRect> {
     let mut rect = RECT::default();
-    let ok = unsafe { GetWindowRect(hwnd, &mut rect) }.as_bool();
-    ok.then_some(from_win_rect(rect))
+    unsafe { GetWindowRect(hwnd, &mut rect) }.ok()?;
+    Some(from_win_rect(rect))
 }
 
 fn extended_frame_bounds(hwnd: HWND) -> Option<WindowRect> {
@@ -93,16 +92,12 @@ fn from_win_rect(rect: RECT) -> WindowRect {
 #[allow(dead_code)]
 fn client_rect_in_screen(hwnd: HWND) -> Option<WindowRect> {
     let mut client = RECT::default();
-    if !unsafe { GetClientRect(hwnd, &mut client) }.as_bool() {
-        return None;
-    }
+    unsafe { GetClientRect(hwnd, &mut client) }.ok()?;
     let mut origin = POINT {
         x: client.left,
         y: client.top,
     };
-    if !unsafe { ClientToScreen(hwnd, &mut origin) }.as_bool() {
-        return None;
-    }
+    unsafe { ClientToScreen(hwnd, &mut origin) }.ok()?;
     Some(WindowRect {
         left: origin.x,
         top: origin.y,

--- a/src/window_geometry.rs
+++ b/src/window_geometry.rs
@@ -1,0 +1,182 @@
+use windows::Win32::Foundation::{HWND, POINT, RECT};
+use windows::Win32::Graphics::Dwm::{DwmGetWindowAttribute, DWMWA_EXTENDED_FRAME_BOUNDS};
+use windows::Win32::UI::WindowsAndMessaging::{
+    ClientToScreen, GetClientRect, GetForegroundWindow, GetWindowRect,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WindowRect {
+    pub left: i32,
+    pub top: i32,
+    pub right: i32,
+    pub bottom: i32,
+}
+
+impl WindowRect {
+    pub fn width(self) -> i32 {
+        self.right - self.left
+    }
+    pub fn height(self) -> i32 {
+        self.bottom - self.top
+    }
+    pub fn center(self) -> (i32, i32) {
+        (self.left + self.width() / 2, self.top + self.height() / 2)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WindowSnapPoints {
+    pub top_edge: (i32, i32),
+    pub bottom_edge: (i32, i32),
+    pub left_edge: (i32, i32),
+    pub right_edge: (i32, i32),
+    pub center: (i32, i32),
+    pub titlebar: (i32, i32),
+}
+
+pub fn foreground_window_snap_points(
+    use_extended_frame_bounds: bool,
+    edge_offset_px: i32,
+    titlebar_y_offset_px: i32,
+    clamp_to_window: bool,
+) -> Option<WindowSnapPoints> {
+    let hwnd = unsafe { GetForegroundWindow() };
+    if hwnd.0 == 0 {
+        return None;
+    }
+    let rect = foreground_rect(hwnd, use_extended_frame_bounds)?;
+    Some(derive_snap_points(
+        rect,
+        edge_offset_px,
+        titlebar_y_offset_px,
+        clamp_to_window,
+    ))
+}
+
+fn foreground_rect(hwnd: HWND, use_extended_frame_bounds: bool) -> Option<WindowRect> {
+    if use_extended_frame_bounds {
+        if let Some(r) = extended_frame_bounds(hwnd) {
+            return Some(r);
+        }
+    }
+    window_rect(hwnd)
+}
+
+fn window_rect(hwnd: HWND) -> Option<WindowRect> {
+    let mut rect = RECT::default();
+    let ok = unsafe { GetWindowRect(hwnd, &mut rect) }.as_bool();
+    ok.then_some(from_win_rect(rect))
+}
+
+fn extended_frame_bounds(hwnd: HWND) -> Option<WindowRect> {
+    let mut rect = RECT::default();
+    let hr = unsafe {
+        DwmGetWindowAttribute(
+            hwnd,
+            DWMWA_EXTENDED_FRAME_BOUNDS,
+            &mut rect as *mut _ as *mut _,
+            std::mem::size_of::<RECT>() as u32,
+        )
+    };
+    hr.is_ok().then_some(from_win_rect(rect))
+}
+
+fn from_win_rect(rect: RECT) -> WindowRect {
+    WindowRect {
+        left: rect.left,
+        top: rect.top,
+        right: rect.right,
+        bottom: rect.bottom,
+    }
+}
+
+#[allow(dead_code)]
+fn client_rect_in_screen(hwnd: HWND) -> Option<WindowRect> {
+    let mut client = RECT::default();
+    if !unsafe { GetClientRect(hwnd, &mut client) }.as_bool() {
+        return None;
+    }
+    let mut origin = POINT {
+        x: client.left,
+        y: client.top,
+    };
+    if !unsafe { ClientToScreen(hwnd, &mut origin) }.as_bool() {
+        return None;
+    }
+    Some(WindowRect {
+        left: origin.x,
+        top: origin.y,
+        right: origin.x + (client.right - client.left),
+        bottom: origin.y + (client.bottom - client.top),
+    })
+}
+
+pub fn derive_snap_points(
+    rect: WindowRect,
+    edge_offset_px: i32,
+    titlebar_y_offset_px: i32,
+    clamp_to_window: bool,
+) -> WindowSnapPoints {
+    let offset = edge_offset_px.max(0);
+    let title_off = titlebar_y_offset_px.max(0);
+    let (cx, cy) = rect.center();
+    let mut points = WindowSnapPoints {
+        top_edge: (cx, rect.top + offset),
+        bottom_edge: (cx, rect.bottom - 1 - offset),
+        left_edge: (rect.left + offset, cy),
+        right_edge: (rect.right - 1 - offset, cy),
+        center: (cx, cy),
+        titlebar: (cx, rect.top + title_off),
+    };
+    if clamp_to_window {
+        let clamp = |(x, y): (i32, i32)| {
+            (
+                x.clamp(rect.left, rect.right - 1),
+                y.clamp(rect.top, rect.bottom - 1),
+            )
+        };
+        points.top_edge = clamp(points.top_edge);
+        points.bottom_edge = clamp(points.bottom_edge);
+        points.left_edge = clamp(points.left_edge);
+        points.right_edge = clamp(points.right_edge);
+        points.titlebar = clamp(points.titlebar);
+    }
+    points
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn derive_edges_center_and_titlebar() {
+        let rect = WindowRect {
+            left: 100,
+            top: 200,
+            right: 500,
+            bottom: 700,
+        };
+        let p = derive_snap_points(rect, 10, 30, true);
+        assert_eq!(p.top_edge, (300, 210));
+        assert_eq!(p.bottom_edge, (300, 689));
+        assert_eq!(p.left_edge, (110, 450));
+        assert_eq!(p.right_edge, (489, 450));
+        assert_eq!(p.center, (300, 450));
+        assert_eq!(p.titlebar, (300, 230));
+    }
+
+    #[test]
+    fn clamp_prevents_out_of_bounds_offsets() {
+        let rect = WindowRect {
+            left: 0,
+            top: 0,
+            right: 10,
+            bottom: 10,
+        };
+        let p = derive_snap_points(rect, 999, 999, true);
+        assert_eq!(p.top_edge, (5, 9));
+        assert_eq!(p.bottom_edge, (5, 0));
+        assert_eq!(p.left_edge, (9, 5));
+        assert_eq!(p.right_edge, (0, 5));
+        assert_eq!(p.titlebar, (5, 9));
+    }
+}

--- a/src/window_geometry.rs
+++ b/src/window_geometry.rs
@@ -97,7 +97,7 @@ fn client_rect_in_screen(hwnd: HWND) -> Option<WindowRect> {
         x: client.left,
         y: client.top,
     };
-    if unsafe { ClientToScreen(hwnd, &mut origin) }.is_err() {
+    if !unsafe { ClientToScreen(hwnd, &mut origin) }.as_bool() {
         return None;
     }
     Some(WindowRect {

--- a/src/windows_uia.rs
+++ b/src/windows_uia.rs
@@ -96,8 +96,10 @@ fn should_fallback_to_descendants(
     child_count: i32,
     min_targets_before_fallback: i32,
 ) -> bool {
-    matches!(strategy, crate::UiHintQueryStrategy::ChildrenThenDescendants)
-        && child_count < min_targets_before_fallback
+    matches!(
+        strategy,
+        crate::UiHintQueryStrategy::ChildrenThenDescendants
+    ) && child_count < min_targets_before_fallback
 }
 
 fn discover_windows_in_scope(
@@ -199,7 +201,9 @@ fn collect_window_elements(
                 }
             }
         };
-        let len = arr.Length().map_err(|_| UiHintQueryError::UiAutomationQueryFailed)?;
+        let len = arr
+            .Length()
+            .map_err(|_| UiHintQueryError::UiAutomationQueryFailed)?;
         let mut out = Vec::new();
         for i in 0..len {
             if let Ok(el) = arr.GetElement(i) {


### PR DESCRIPTION
### Motivation
- Provide helpers to compute snap targets on the current foreground window so the cursor can jump to window edges, center, and a titlebar anchor with configurable offsets and clamping.  
- Prefer DWM extended frame bounds when available but fall back to `GetWindowRect`, and expose tunable behavior via config for reliable cross-app snapping.

### Description
- Added `src/window_geometry.rs` implementing `WindowRect`, `WindowSnapPoints`, `foreground_window_snap_points`, `derive_snap_points`, a client->screen helper, and unit tests for snap math/clamping.  
- Added a `window_jump` config section in `src/main.rs` and the bundled `config.toml` with fields `enabled`, `use_extended_frame_bounds`, `edge_offset_px`, `titlebar_y_offset_px`, and `clamp_to_window`, plus a normalization function `normalize_window_jump_config`.  
- Added six new actions and parser entries in `src/action.rs`: `move_to_window_top_edge`, `move_to_window_bottom_edge`, `move_to_window_left_edge`, `move_to_window_right_edge`, `move_to_window_center`, and `move_to_window_titlebar`.  
- Implemented dispatch in `src/action_handler.rs` to compute a foreground-window snap target via `foreground_window_snap_points` and emit an absolute move when the feature is enabled, respecting offsets and clamp settings; added mapping helper and unit test that each action maps to the expected `WindowSnapPoints` member.  
- Updated `src/config_audit.rs` to include `window_jump.*` known paths and updated `docs/config.md` with `window_jump` entries and `config.toml` example defaults.  

### Testing
- Ran `cargo fmt` successfully.  
- Attempted `cargo test`, but the test run failed in this environment due to a missing system dependency required by the `x11` crate (`xi` / `xi.pc`), so the automated test suite could not be executed here; unit tests were added for `derive_snap_points` and for action parsing/mapping but could not be verified end-to-end in this container.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14364438b083328240a0b6faa003b3)