### PR TITLE
Add startup validation for feature-to-binding coverage and summary

### DIFF
--- a/src/config_audit.rs
+++ b/src/config_audit.rs
@@ -701,7 +701,9 @@ mod tests {
         let duplicate_warning = report
             .warnings
             .iter()
-            .find(|warning| warning.path == "key_bindings" && warning.message.contains("Duplicate key chord"))
+            .find(|warning| {
+                warning.path == "key_bindings" && warning.message.contains("Duplicate key chord")
+            })
             .expect("expected duplicate key chord warning");
         assert!(duplicate_warning.message.contains("later entry wins"));
         assert!(duplicate_warning.message.contains("key_bindings[0]"));
@@ -733,7 +735,9 @@ mod tests {
 
     #[test]
     fn audit_duplicate_key_chord_warning_text_is_stable_for_regression_fixture() {
-        let report = audit_config_toml(include_str!("../tests/fixtures/config_duplicate_wheel_chord.toml"));
+        let report = audit_config_toml(include_str!(
+            "../tests/fixtures/config_duplicate_wheel_chord.toml"
+        ));
 
         let warning = report
             .warnings

--- a/src/main.rs
+++ b/src/main.rs
@@ -2105,7 +2105,9 @@ impl Config {
 
     fn parse_audited_config(config_str: &str) -> Result<Self, Box<dyn Error>> {
         emit_config_audit_warnings(&audit_config_toml(config_str).warnings);
-        toml::from_str::<Self>(config_str)?.normalize()
+        let config = toml::from_str::<Self>(config_str)?.normalize()?;
+        emit_startup_feature_binding_warnings(&config);
+        Ok(config)
     }
 
     fn runtime_system_bindings(&self) -> Result<RuntimeSystemBindings, Box<dyn Error>> {
@@ -2923,14 +2925,22 @@ fn execute_key_action_command_with_keyboard<B: MouseBackend, K: KeyboardSender>(
     None
 }
 
-fn maybe_emit_surgical_tooltip<B: MouseBackend>(action_handler: &ActionHandler<B>, app_state: &AppState) {
+fn maybe_emit_surgical_tooltip<B: MouseBackend>(
+    action_handler: &ActionHandler<B>,
+    app_state: &AppState,
+) {
     let surgical_active = action_handler.active_keys.contains(&Action::SurgicalMode);
     let mut previous = LAST_SURGICAL_TOOLTIP_ACTIVE.lock().unwrap();
     if !*previous
         && surgical_active
         && ui_hint_tooltip_event_enabled(
             &action_handler.mouse_master.config.tooltip_overlay,
-            action_handler.mouse_master.config.tooltip_overlay.events.surgical,
+            action_handler
+                .mouse_master
+                .config
+                .tooltip_overlay
+                .events
+                .surgical,
         )
         && !app_state.help_visible()
     {
@@ -3847,6 +3857,67 @@ fn print_heartbeat(diagnostics: LoopDiagnostics, hook_diagnostics: HookDiagnosti
     );
 }
 
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+struct StartupFeatureBindingSummary {
+    surgical_mode: usize,
+    scroll_modifier: usize,
+    window_jump: usize,
+    position_history_save: usize,
+    position_history_clear: usize,
+    position_history_mode: usize,
+}
+
+impl StartupFeatureBindingSummary {
+    fn position_history_total(self) -> usize {
+        self.position_history_save + self.position_history_clear + self.position_history_mode
+    }
+}
+
+fn startup_feature_binding_summary(config: &Config) -> StartupFeatureBindingSummary {
+    let mut summary = StartupFeatureBindingSummary::default();
+    for (_, action_str) in &config.key_bindings {
+        let Some(action) = Action::from_string(action_str) else {
+            continue;
+        };
+        match action {
+            Action::SurgicalMode => summary.surgical_mode += 1,
+            Action::ScrollModifier => summary.scroll_modifier += 1,
+            Action::MoveToWindowTopEdge
+            | Action::MoveToWindowBottomEdge
+            | Action::MoveToWindowLeftEdge
+            | Action::MoveToWindowRightEdge
+            | Action::MoveToWindowCenter
+            | Action::MoveToWindowTitlebar => summary.window_jump += 1,
+            Action::SaveMousePosition => summary.position_history_save += 1,
+            Action::ClearMousePositions => summary.position_history_clear += 1,
+            Action::PositionHistoryMode => summary.position_history_mode += 1,
+            _ => {}
+        }
+    }
+    summary
+}
+
+fn emit_startup_feature_binding_warnings(config: &Config) {
+    let bindings = startup_feature_binding_summary(config);
+
+    if config.surgical_mode.enabled && bindings.surgical_mode == 0 {
+        warn_config_normalized(
+            r#"surgical_mode.enabled=true but no key binding targets action "surgical_mode". Add a key_bindings entry like ["RightAlt+S", "surgical_mode"] or disable [surgical_mode].enabled."#,
+        );
+    }
+    if config.scroll_mode.enabled && bindings.scroll_modifier == 0 {
+        warn_config_normalized(
+            r#"scroll_mode.enabled=true but no key binding targets action "scroll_modifier". Add a key_bindings entry like ["LeftAlt", "scroll_modifier"] or disable [scroll_mode].enabled."#,
+        );
+    }
+    if config.window_jump.enabled && bindings.window_jump == 0 {
+        warn_config_normalized("window_jump.enabled=true but no window-jump action bindings were found (move_to_window_top_edge/bottom_edge/left_edge/right_edge/center/titlebar). Add at least one window-jump key_bindings action or disable [window_jump].enabled.");
+    }
+    if config.position_history.enabled && bindings.position_history_total() == 0 {
+        warn_config_normalized("position_history.enabled=true but no position history bindings were found. Add one or more of save_mouse_position, clear_mouse_positions, or position_history_mode to key_bindings, or disable [position_history].enabled.");
+    }
+}
+
 fn startup_summary_line() -> String {
     format!("{APP_DISPLAY_NAME} ({APP_CRATE_ID}) Program Start!")
 }
@@ -3890,6 +3961,29 @@ fn startup_validation_summary(config: &Config, warnings: &[String]) -> String {
             config.jump.profiles.len()
         ),
     ];
+
+    let feature_bindings = startup_feature_binding_summary(config);
+    lines.push("features: [enabled, bindings]".to_string());
+    lines.push(format!(
+        "  surgical_mode: enabled={} bindings={}",
+        config.surgical_mode.enabled, feature_bindings.surgical_mode
+    ));
+    lines.push(format!(
+        "  scroll_mode: enabled={} bindings={}",
+        config.scroll_mode.enabled, feature_bindings.scroll_modifier
+    ));
+    lines.push(format!(
+        "  window_jump: enabled={} bindings={}",
+        config.window_jump.enabled, feature_bindings.window_jump
+    ));
+    lines.push(format!(
+        "  position_history: enabled={} bindings=save:{} clear:{} mode:{} total:{}",
+        config.position_history.enabled,
+        feature_bindings.position_history_save,
+        feature_bindings.position_history_clear,
+        feature_bindings.position_history_mode,
+        feature_bindings.position_history_total()
+    ));
 
     if warnings.is_empty() {
         lines.push("warnings=0".to_string());
@@ -5662,6 +5756,104 @@ mod tests {
     }
 
     #[test]
+    fn feature_binding_validation_warns_when_enabled_features_have_no_bindings() {
+        struct Case {
+            name: &'static str,
+            config_toml: &'static str,
+            expected_substring: &'static str,
+        }
+
+        let cases = [
+            Case {
+                name: "surgical_mode",
+                config_toml: "[surgical_mode]
+enabled = true",
+                expected_substring:
+                    "surgical_mode.enabled=true but no key binding targets action \"surgical_mode\"",
+            },
+            Case {
+                name: "scroll_mode",
+                config_toml: "[scroll_mode]
+enabled = true",
+                expected_substring:
+                    "scroll_mode.enabled=true but no key binding targets action \"scroll_modifier\"",
+            },
+            Case {
+                name: "window_jump",
+                config_toml: "[window_jump]
+enabled = true",
+                expected_substring:
+                    "window_jump.enabled=true but no window-jump action bindings were found",
+            },
+            Case {
+                name: "position_history",
+                config_toml: "[position_history]
+enabled = true",
+                expected_substring:
+                    "position_history.enabled=true but no position history bindings were found",
+            },
+        ];
+
+        for case in cases {
+            let _ = take_config_warnings();
+            let _ = parse_config(case.config_toml);
+            let warnings = take_config_warnings();
+            assert!(
+                warnings
+                    .iter()
+                    .any(|warning| warning.contains(case.expected_substring)),
+                "expected {} warning, got {:?}",
+                case.name,
+                warnings
+            );
+        }
+    }
+
+    #[test]
+    fn feature_binding_validation_does_not_warn_when_enabled_features_have_bindings() {
+        let _ = take_config_warnings();
+        let _ = parse_config(
+            r#"
+            key_bindings = [
+                ["F13", "surgical_mode"],
+                ["F14", "scroll_modifier"],
+                ["F15", "move_to_window_center"],
+                ["F16", "position_history_mode"]
+            ]
+
+            [surgical_mode]
+            enabled = true
+
+            [scroll_mode]
+            enabled = true
+
+            [window_jump]
+            enabled = true
+
+            [position_history]
+            enabled = true
+            "#,
+        );
+        let warnings = take_config_warnings();
+
+        let blocked = [
+            "surgical_mode.enabled=true but no key binding targets action \"surgical_mode\"",
+            "scroll_mode.enabled=true but no key binding targets action \"scroll_modifier\"",
+            "window_jump.enabled=true but no window-jump action bindings were found",
+            "position_history.enabled=true but no position history bindings were found",
+        ];
+
+        for forbidden in blocked {
+            assert!(
+                warnings.iter().all(|warning| !warning.contains(forbidden)),
+                "unexpected warning matched '{}': {:?}",
+                forbidden,
+                warnings
+            );
+        }
+    }
+
+    #[test]
     fn startup_summary_uses_current_crate_id() {
         let summary = startup_summary_line();
 
@@ -5690,6 +5882,12 @@ mod tests {
         assert!(summary.contains("mouse_speed default=1 range=1..12 step=1 profiles=1"));
         assert!(summary.contains("wheel default=3 range=1..12 step=1 tick=8ms"));
         assert!(summary.contains("slow_mouse strategy=Fixed speed=1 (default 1, range 1..2) acceleration=0 every 1 tick(s)"));
+        assert!(summary.contains("features: [enabled, bindings]"));
+        assert!(summary.contains("surgical_mode: enabled=false bindings=0"));
+        assert!(summary.contains("scroll_mode: enabled=false bindings=0"));
+        assert!(summary.contains("window_jump: enabled=false bindings=0"));
+        assert!(summary
+            .contains("position_history: enabled=false bindings=save:0 clear:0 mode:0 total:0"));
         assert!(summary.contains("warnings=1"));
         assert!(summary.contains("warning: wheel.min_speed clamped"));
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5891,7 +5891,7 @@ enabled = true",
         assert!(summary.contains("scroll_mode: enabled=false bindings=0"));
         assert!(summary.contains("window_jump: enabled=true bindings=0"));
         assert!(summary
-            .contains("position_history: enabled=false bindings=save:0 clear:0 mode:0 total:0"));
+            .contains("position_history: enabled=true bindings=save:0 clear:0 mode:0 total:0"));
         assert!(summary.contains("warnings=1"));
         assert!(summary.contains("warning: wheel.min_speed clamped"));
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4239,6 +4239,10 @@ mod tests {
         toml::from_str::<Config>(toml).unwrap().normalize().unwrap()
     }
 
+    fn parse_audited_config_for_test(toml: &str) -> Config {
+        Config::parse_audited_config(toml).unwrap()
+    }
+
     fn parse_config_error(toml: &str) -> String {
         match toml::from_str::<Config>(toml) {
             Ok(config) => config
@@ -5796,7 +5800,7 @@ enabled = true",
 
         for case in cases {
             let _ = take_config_warnings();
-            let _ = parse_config(case.config_toml);
+            let _ = parse_audited_config_for_test(case.config_toml);
             let warnings = take_config_warnings();
             assert!(
                 warnings
@@ -5812,7 +5816,7 @@ enabled = true",
     #[test]
     fn feature_binding_validation_does_not_warn_when_enabled_features_have_bindings() {
         let _ = take_config_warnings();
-        let _ = parse_config(
+        let _ = parse_audited_config_for_test(
             r#"
             key_bindings = [
                 ["F13", "surgical_mode"],
@@ -5885,7 +5889,7 @@ enabled = true",
         assert!(summary.contains("features: [enabled, bindings]"));
         assert!(summary.contains("surgical_mode: enabled=false bindings=0"));
         assert!(summary.contains("scroll_mode: enabled=false bindings=0"));
-        assert!(summary.contains("window_jump: enabled=false bindings=0"));
+        assert!(summary.contains("window_jump: enabled=true bindings=0"));
         assert!(summary
             .contains("position_history: enabled=false bindings=save:0 clear:0 mode:0 total:0"));
         assert!(summary.contains("warnings=1"));


### PR DESCRIPTION
### Motivation
- Ensure runtime features that can be enabled in config (surgical/scroll/window-jump/position-history) actually have key bindings so enabled-but-unbound features are detectable at startup.
- Provide operators actionable, feature-specific remediation hints when misconfiguration is detected.
- Surface a compact, deterministic startup feature summary so operators can quickly audit enabled state and binding coverage during program start.

### Description
- Add `StartupFeatureBindingSummary` and `startup_feature_binding_summary` to count bindings for `surgical_mode`, `scroll_modifier`, window-jump actions, and `position_history` (save/clear/mode). (src/main.rs)
- Add `emit_startup_feature_binding_warnings` that emits actionable warnings via `warn_config_normalized` when features are enabled but corresponding bindings are missing; this is invoked after config parse/normalize in `parse_audited_config`. (src/main.rs)
- Extend `startup_validation_summary` to include a compact "features: [enabled, bindings]" block with counts and a `position_history` breakdown. (src/main.rs)
- Add table-driven unit tests covering enabled-but-missing-binding warning cases and enabled-with-binding no-warning cases, and extend the startup summary formatting test to assert the new feature summary lines. (tests added in src/main.rs)
- Minor formatting adjustment in `src/config_audit.rs` from `cargo fmt` (no behavior change). (src/config_audit.rs)

### Testing
- `cargo fmt` completed successfully to normalize formatting.
- New unit tests were added for the feature-binding validation and startup summary formatting, but running `cargo test` in this environment failed during compilation due to a missing system dependency required by the `x11` crate (pkg-config / `xi`), so the Rust test run could not complete here; the failures are environmental and not related to the new test logic.
- The change invokes the existing audit flow (`audit_config_toml`) and pushes the new validation step into the parsed/config-normalized path, and tests are structured to be deterministic once run in an environment with the required system dependencies (`xi`/pkg-config).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1465b890308332a82eb37a2fb39edb)