### PR TITLE
Add scroll_mode config, default scroll_modifier binding, docs, and tests

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -30,6 +30,7 @@ key_bindings = [
     ["D", "move_down"],
     ["F", "move_right"],
     ["LeftShift", "slow_mouse"],
+    ["LeftAlt", "scroll_modifier"],
     ["B", "surgical_mode"],
 
     ["J", "left_click"],
@@ -192,6 +193,21 @@ min_speed = 1
 max_speed = 10
 speed_step = 1
 flash_indicator_ms = 700
+
+
+# ---------------------------------------------------------------------------
+# Scroll mode
+# ---------------------------------------------------------------------------
+[scroll_mode]
+# Hold the modifier action to remap movement keys into wheel directions.
+enabled = false
+modifier_action = "scroll_modifier"
+# If true, click actions release the modifier for predictable one-shot scrolling.
+exit_on_click = true
+# Reserved/experimental toggles (parsed but currently not enforced at runtime).
+exclusive_with_jump_mode = true
+exclusive_with_grid_mode = true
+exclusive_with_ui_hint_mode = true
 
 # ---------------------------------------------------------------------------
 # Grid mode

--- a/docs/config.md
+++ b/docs/config.md
@@ -19,6 +19,33 @@ key_bindings = [
 ]
 ```
 
+### Scroll mode behavior mapping
+
+When `scroll_mode.enabled = true` and the configured `scroll_mode.modifier_action` is held, movement actions are remapped to wheel actions for that tick:
+
+- `move_up` -> `wheel_up` (vertical wheel negative delta; typical content moves up).
+- `move_down` -> `wheel_down` (vertical wheel positive delta; typical content moves down).
+- `move_left` -> `wheel_left` (horizontal wheel negative delta; typical content moves left).
+- `move_right` -> `wheel_right` (horizontal wheel positive delta; typical content moves right).
+
+Example with held modifier (`LeftAlt` bound to `scroll_modifier`):
+
+```toml
+key_bindings = [
+  ["E", "move_up"],
+  ["S", "move_left"],
+  ["D", "move_down"],
+  ["F", "move_right"],
+  ["LeftAlt", "scroll_modifier"],
+]
+
+[scroll_mode]
+enabled = true
+modifier_action = "scroll_modifier"
+```
+
+Holding `LeftAlt+E` emits `wheel_up` instead of moving the cursor; releasing `LeftAlt` restores normal movement.
+
 ## Config Paths
 
 | Config path | Type | Default | Connected? | Status | Notes |
@@ -80,8 +107,8 @@ key_bindings = [
 | `scroll_mode.enabled` | boolean | `false` | Yes | Active | Enables movement-to-wheel remapping while modifier is held. |
 | `scroll_mode.modifier_action` | action string | `"scroll_modifier"` | Yes | Active | Continuous action that activates scroll mode. |
 | `scroll_mode.exit_on_click` | boolean | `true` | Yes | Active | Releasing scroll modifier on click for deterministic exit behavior. |
-| `scroll_mode.exclusive_with_jump_mode` | boolean | `true` | Yes | Active | Reserved exclusivity toggle for jump mode transitions. |
-| `scroll_mode.exclusive_with_grid_mode` | boolean | `true` | Yes | Active | Reserved exclusivity toggle for grid mode transitions. |
+| `scroll_mode.exclusive_with_jump_mode` | boolean | `true` | Yes | Active | Reserved/experimental parse-only toggle; not currently enforced in runtime mode arbitration. |
+| `scroll_mode.exclusive_with_grid_mode` | boolean | `true` | Yes | Active | Reserved/experimental parse-only toggle; not currently enforced in runtime mode arbitration. |
 | `scroll_mode.exclusive_with_ui_hint_mode` | boolean | `true` | Yes | Active | Reserved exclusivity toggle for UI hint mode transitions. |
 | `jump.mode` | enum string | `"precision"` | Yes | Active | `single` uses coarse only; `precision` can use coarse, fine, and precise stages. |
 | `jump.cursor_between_stages` | enum string | `"none"` | Yes | Active | One of `none`, `move_to_region_center`, `preview_only`, `warp_and_continue`. |

--- a/src/action_handler.rs
+++ b/src/action_handler.rs
@@ -2598,6 +2598,33 @@ mod tests {
             Some(FinalAdjustControl::Back)
         );
     }
+
+    #[test]
+    fn effective_actions_remap_all_movement_directions_when_scroll_modifier_active() {
+        let mut cfg = test_config();
+        cfg.scroll_mode.enabled = true;
+        cfg.scroll_mode.modifier_action = "scroll_modifier".to_string();
+        let mouse = MouseMaster::new_with_backend(cfg, FakeBackend::default());
+
+        let actions = HashSet::from([
+            Action::MoveUp,
+            Action::MoveDown,
+            Action::MoveLeft,
+            Action::MoveRight,
+            Action::ScrollModifier,
+        ]);
+        let effective = mouse.effective_actions_for_tick(&actions);
+
+        assert!(!effective.contains(&Action::MoveUp));
+        assert!(!effective.contains(&Action::MoveDown));
+        assert!(!effective.contains(&Action::MoveLeft));
+        assert!(!effective.contains(&Action::MoveRight));
+        assert!(effective.contains(&Action::WheelUp));
+        assert!(effective.contains(&Action::WheelDown));
+        assert!(effective.contains(&Action::WheelLeft));
+        assert!(effective.contains(&Action::WheelRight));
+    }
+
     #[test]
     fn movement_with_modifier_yields_wheel_and_no_move_event() {
         let mut backend = FakeBackend::default();

--- a/src/main.rs
+++ b/src/main.rs
@@ -5760,6 +5760,25 @@ mod tests {
     }
 
     #[test]
+    fn scroll_mode_defaults_and_exclusivity_fields_parse() {
+        let config: Config = toml::from_str("[scroll_mode]\nenabled = true").unwrap();
+        assert!(config.scroll_mode.enabled);
+        assert_eq!(config.scroll_mode.modifier_action, "scroll_modifier");
+        assert!(config.scroll_mode.exit_on_click);
+        assert!(config.scroll_mode.exclusive_with_jump_mode);
+        assert!(config.scroll_mode.exclusive_with_grid_mode);
+        assert!(config.scroll_mode.exclusive_with_ui_hint_mode);
+
+        let config: Config = toml::from_str(
+            "[scroll_mode]\nenabled=true\nexclusive_with_jump_mode=false\nexclusive_with_grid_mode=false\nexclusive_with_ui_hint_mode=false",
+        )
+        .unwrap();
+        assert!(!config.scroll_mode.exclusive_with_jump_mode);
+        assert!(!config.scroll_mode.exclusive_with_grid_mode);
+        assert!(!config.scroll_mode.exclusive_with_ui_hint_mode);
+    }
+
+    #[test]
     fn feature_binding_validation_warns_when_enabled_features_have_no_bindings() {
         struct Case {
             name: &'static str,


### PR DESCRIPTION
### Motivation
- Provide a first-class `[scroll_mode]` block so users can opt into remapping movement keys to wheel actions while holding a modifier. 
- Ship a safe, non-conflicting default binding for the scroll modifier so sample configs work out-of-the-box. 
- Document exact movement->wheel mapping and avoid claiming runtime exclusivity behavior that is not yet implemented. 

### Description
- Added a `[scroll_mode]` section in `config.toml` with conservative defaults: `enabled = false`, `modifier_action = "scroll_modifier"`, `exit_on_click = true`, and the three `exclusive_with_*` boolean fields present and defaulting to `true` for compatibility/parse-only purposes. 
- Inserted a non-conflicting default binding `[

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14690c43788332b3ec4c7562072daf)