### PR TITLE
Add session-only position-history runtime store, commands, and routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ Action bindings run only while active mode is enabled:
 | `F` | Jump mode |
 | `G` | Grid mode |
 | `C` | Screen select |
+| `RightAlt+M` | Save current cursor position (session only) |
+| `RightAlt+Backspace` | Clear saved cursor positions (session only) |
+| `RightAlt+J` | Enter position-history selection mode |
 | `H` | Navigate back |
 | `Y` | Navigate forward |
 | `Q` / `P` | Switch to idle |
@@ -262,3 +265,14 @@ For input-pipeline regressions, run the diagnostic smoke test in [docs/smoke_tes
 ## License
 
 This project is licensed under the terms of the MIT license. See [LICENSE](LICENSE) for details.
+
+
+## Position History (Session Only)
+
+Position history is in-memory for this phase (no disk persistence).
+
+Flow:
+1. Press `RightAlt+M` to save the current cursor location.
+2. Press `RightAlt+J` to enter selection mode and type the shown label.
+3. The cursor jumps to the selected saved position.
+4. Press `RightAlt+Backspace` to clear all saved positions.

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -439,11 +439,7 @@ impl AppState {
             return ModeContext::Inactive;
         }
         if self.is_position_history_active() {
-            if self.is_position_history_activation_key_event(&event) {
-                return;
-            }
-            self.enqueue_command(AppCommand::PositionHistoryInput(event));
-            return;
+            return ModeContext::UiHintActive;
         }
 
         if self.is_jump_active() {

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -67,6 +67,12 @@ pub enum AppCommand {
     JumpInput(KeyEvent, Option<Action>),
     GridInput(KeyEvent, Option<Action>),
     UiHintInput(KeyEvent),
+    SaveMousePosition,
+    ClearMousePositions,
+    EnterPositionHistoryMode {
+        activation_key: VirtualKey,
+    },
+    PositionHistoryInput(KeyEvent),
     UiHintQueryCompleted {
         query_id: u64,
         elements: Vec<crate::windows_uia::RawUiElement>,
@@ -86,6 +92,7 @@ pub struct AppState {
     jump: JumpState,
     grid: GridState,
     ui_hints: UiHintState,
+    position_history: PositionHistoryState,
     active_mode: bool,
     preserve_global_shortcuts: bool,
     system_bindings: RuntimeSystemBindings,
@@ -105,6 +112,15 @@ pub enum UiHintState {
         activation_key: VirtualKey,
         query_id: u64,
         foreground_hwnd: isize,
+    },
+}
+
+
+#[derive(Debug)]
+pub enum PositionHistoryState {
+    Inactive,
+    Active {
+        activation_key: VirtualKey,
     },
 }
 
@@ -197,6 +213,7 @@ impl Default for AppState {
             jump: JumpState::Inactive,
             grid: GridState::Inactive,
             ui_hints: UiHintState::Inactive,
+            position_history: PositionHistoryState::Inactive,
             active_mode: true,
             preserve_global_shortcuts: true,
             system_bindings: RuntimeSystemBindings::default(),
@@ -265,6 +282,7 @@ impl AppState {
         self.exit_jump_mode();
         self.exit_grid_mode();
         self.exit_ui_hint_mode();
+        self.exit_position_history_mode();
     }
 
     pub fn set_system_bindings(&mut self, system_bindings: RuntimeSystemBindings) {
@@ -313,6 +331,18 @@ impl AppState {
 
     pub fn is_ui_hint_querying(&self) -> bool {
         matches!(self.ui_hints, UiHintState::Querying { .. })
+    }
+
+    pub fn is_position_history_active(&self) -> bool {
+        matches!(self.position_history, PositionHistoryState::Active { .. })
+    }
+
+    pub fn enter_position_history_mode(&mut self, activation_key: VirtualKey) {
+        self.position_history = PositionHistoryState::Active { activation_key };
+    }
+
+    pub fn exit_position_history_mode(&mut self) {
+        self.position_history = PositionHistoryState::Inactive;
     }
 
     pub fn exit_ui_hint_mode(&mut self) {
@@ -408,6 +438,14 @@ impl AppState {
         if !self.active_mode {
             return ModeContext::Inactive;
         }
+        if self.is_position_history_active() {
+            if self.is_position_history_activation_key_event(&event) {
+                return;
+            }
+            self.enqueue_command(AppCommand::PositionHistoryInput(event));
+            return;
+        }
+
         if self.is_jump_active() {
             return ModeContext::Jump;
         }
@@ -784,6 +822,7 @@ impl AppState {
 
         if self.active_mode && event.is_down && matches!(action.as_ref(), Some(Action::Disable)) {
             self.exit_ui_hint_mode();
+        self.exit_position_history_mode();
             self.enqueue_command(AppCommand::SetActiveMode { active: false });
             return;
         }
@@ -800,8 +839,17 @@ impl AppState {
             ) && event.is_down
             {
                 self.exit_ui_hint_mode();
+        self.exit_position_history_mode();
             }
             self.enqueue_command(AppCommand::UiHintInput(event));
+            return;
+        }
+
+        if self.is_position_history_active() {
+            if self.is_position_history_activation_key_event(&event) {
+                return;
+            }
+            self.enqueue_command(AppCommand::PositionHistoryInput(event));
             return;
         }
 
@@ -852,12 +900,14 @@ impl AppState {
 
         if event.is_down && matches!(action.as_ref(), Some(Action::ReloadConfig)) {
             self.exit_ui_hint_mode();
+        self.exit_position_history_mode();
             self.enqueue_command(AppCommand::ReloadConfig);
             return;
         }
 
         if event.is_down && matches!(action.as_ref(), Some(Action::PanicReset)) {
             self.exit_ui_hint_mode();
+        self.exit_position_history_mode();
             self.enqueue_command(AppCommand::PanicReset);
             return;
         }
@@ -888,6 +938,23 @@ impl AppState {
 
         if event.is_down && matches!(action.as_ref(), Some(Action::UiHintMode)) {
             self.enqueue_command(AppCommand::EnterUiHintMode {
+                activation_key: event.key,
+            });
+            return;
+        }
+
+        if event.is_down && matches!(action.as_ref(), Some(Action::SaveMousePosition)) {
+            self.enqueue_command(AppCommand::SaveMousePosition);
+            return;
+        }
+
+        if event.is_down && matches!(action.as_ref(), Some(Action::ClearMousePositions)) {
+            self.enqueue_command(AppCommand::ClearMousePositions);
+            return;
+        }
+
+        if event.is_down && matches!(action.as_ref(), Some(Action::PositionHistoryMode)) {
+            self.enqueue_command(AppCommand::EnterPositionHistoryMode {
                 activation_key: event.key,
             });
             return;
@@ -947,6 +1014,14 @@ impl AppState {
         }
 
         false
+    }
+
+    fn is_position_history_activation_key_event(&mut self, event: &KeyEvent) -> bool {
+        let PositionHistoryState::Active { activation_key } = &self.position_history else {
+            return false;
+        };
+
+        event.key == *activation_key
     }
 
     fn is_grid_activation_key_event(&mut self, event: &KeyEvent) -> bool {
@@ -2852,4 +2927,19 @@ mod tests {
             ]
         );
     }
+    #[test]
+    fn position_history_actions_route_to_explicit_commands() {
+        let mut state = AppState::default();
+        state.set_bound_keys([VirtualKey::M, VirtualKey::J, VirtualKey::Backspace]);
+
+        state.route_key_event(KeyEvent::new(VirtualKey::M, true), Some(Action::SaveMousePosition));
+        assert_eq!(collect_commands(&mut state), vec![AppCommand::SaveMousePosition]);
+
+        state.route_key_event(KeyEvent::new(VirtualKey::Backspace, true), Some(Action::ClearMousePositions));
+        assert_eq!(collect_commands(&mut state), vec![AppCommand::ClearMousePositions]);
+
+        state.route_key_event(KeyEvent::new(VirtualKey::J, true), Some(Action::PositionHistoryMode));
+        assert_eq!(collect_commands(&mut state), vec![AppCommand::EnterPositionHistoryMode { activation_key: VirtualKey::J }]);
+    }
+
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3555,7 +3555,7 @@ fn execute_app_command(command: AppCommand, debug_diagnostics: bool) {
             }
         }
         AppCommand::SaveMousePosition => {
-            let mut handler = ACTION_HANDLER.write().unwrap();
+            let handler = ACTION_HANDLER.write().unwrap();
             let cfg = handler.mouse_master.config.position_history.clone();
             if !cfg.enabled {
                 return;

--- a/src/main.rs
+++ b/src/main.rs
@@ -5946,7 +5946,7 @@ enabled = true"#,
                 config_toml: r#"key_bindings = []
 
 [position_history]
-enabled = true",
+enabled = true"#,
                 expected_substring:
                     "position_history.enabled=true but no position history bindings were found",
             },

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,6 +39,7 @@ use key_chord::{KeyChord, RuntimeSystemBindings};
 use keyboard::*;
 use lazy_static::lazy_static;
 use overlay::{StatusOverlayConfig, OVERLAY};
+use position_history::PositionHistory;
 use serde::Deserialize;
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -168,6 +169,8 @@ static UI_HINT_QUERY_ID: AtomicU64 = AtomicU64::new(0);
 lazy_static! {
     static ref LAST_UI_HINT_COMPLETION: Mutex<Option<UiHintCompletionState>> = Mutex::new(None);
     static ref LAST_SURGICAL_TOOLTIP_ACTIVE: Mutex<bool> = Mutex::new(false);
+    static ref POSITION_HISTORY_STORE: Mutex<PositionHistory> =
+        Mutex::new(PositionHistory::new(PositionHistoryConfig::default().max_positions));
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -489,6 +492,9 @@ fn default_key_bindings() -> Vec<(String, String)> {
         ("F", "jump_mode"),
         ("G", "grid_mode"),
         ("C", "screen_select"),
+        ("RightAlt+M", "save_mouse_position"),
+        ("RightAlt+Backspace", "clear_mouse_positions"),
+        ("RightAlt+J", "position_history_mode"),
         ("H", "navigate_back"),
         ("Y", "navigate_forward"),
         ("Q", "disable"),
@@ -2990,6 +2996,11 @@ fn reload_config() -> Result<(), Box<dyn Error>> {
     };
     config.initialize_bindings();
     config.initialize_system_bindings()?;
+    POSITION_HISTORY_STORE
+        .lock()
+        .unwrap()
+        .reset_with_max_positions(config.position_history.max_positions);
+    APP_STATE.write().unwrap().exit_position_history_mode();
     sync_jump_overlay(resolution);
     println!("[reload] config reloaded");
     Ok(())
@@ -3127,6 +3138,18 @@ fn execute_app_command(command: AppCommand, debug_diagnostics: bool) {
                     event.key,
                     if event.is_down { "down" } else { "up" },
                     action
+                )
+            }
+            AppCommand::SaveMousePosition => println!("[command] SaveMousePosition"),
+            AppCommand::ClearMousePositions => println!("[command] ClearMousePositions"),
+            AppCommand::EnterPositionHistoryMode { activation_key } => {
+                println!("[command] EnterPositionHistoryMode key={activation_key:?}")
+            }
+            AppCommand::PositionHistoryInput(event) => {
+                println!(
+                    "[command] PositionHistoryInput key={:?} state={}",
+                    event.key,
+                    if event.is_down { "down" } else { "up" }
                 )
             }
             AppCommand::UiHintInput(event) => {
@@ -3529,6 +3552,94 @@ fn execute_app_command(command: AppCommand, debug_diagnostics: bool) {
                     sync_jump_overlay(resolution);
                 }
                 None => {}
+            }
+        }
+        AppCommand::SaveMousePosition => {
+            let mut handler = ACTION_HANDLER.write().unwrap();
+            let cfg = handler.mouse_master.config.position_history.clone();
+            if !cfg.enabled {
+                return;
+            }
+            if let Ok((x, y)) = handler.mouse_master.backend.location() {
+                POSITION_HISTORY_STORE.lock().unwrap().add(x, y);
+            }
+        }
+        AppCommand::ClearMousePositions => {
+            POSITION_HISTORY_STORE.lock().unwrap().clear();
+            APP_STATE.write().unwrap().exit_position_history_mode();
+            UI_HINT_OVERLAY.with(|overlay| {
+                let _ = overlay.borrow_mut().hide();
+            });
+        }
+        AppCommand::EnterPositionHistoryMode { activation_key } => {
+            let cfg = ACTION_HANDLER
+                .read()
+                .unwrap()
+                .mouse_master
+                .config
+                .position_history
+                .clone();
+            if !cfg.enabled {
+                return;
+            }
+            let selection_keys: Vec<char> = cfg.selection_keys.chars().collect();
+            let entries = POSITION_HISTORY_STORE.lock().unwrap().labeled_positions(
+                &selection_keys,
+                cfg.label_length as usize,
+                cfg.show_numbers,
+            );
+            let targets: Vec<ui_hints::UiHintTarget> = entries
+                .into_iter()
+                .map(|(label, p)| ui_hints::UiHintTarget {
+                    id: p.id,
+                    label,
+                    bounds: (p.x - 2, p.y - 2, p.x + 2, p.y + 2),
+                    target_x: p.x,
+                    target_y: p.y,
+                    metadata: Some("history".to_string()),
+                })
+                .collect();
+            let Some(session) = UiHintSession::new(targets, selection_keys) else {
+                return;
+            };
+            APP_STATE
+                .write()
+                .unwrap()
+                .enter_position_history_mode(activation_key);
+            *UI_HINT_SESSION.lock().unwrap() = Some(session);
+        }
+        AppCommand::PositionHistoryInput(event) => {
+            if !event.is_down {
+                return;
+            }
+            let update = {
+                let mut guard = UI_HINT_SESSION.lock().unwrap();
+                let Some(session) = guard.as_mut() else {
+                    return;
+                };
+                session.handle_key(event.key)
+            };
+            match update {
+                UiHintInputUpdate::Completed { target } => {
+                    ACTION_HANDLER
+                        .write()
+                        .unwrap()
+                        .mouse_master
+                        .move_mouse_to(target.target_x, target.target_y);
+                    APP_STATE.write().unwrap().exit_position_history_mode();
+                    UI_HINT_OVERLAY.with(|overlay| {
+                        let _ = overlay.borrow_mut().hide();
+                    });
+                }
+                UiHintInputUpdate::Cancelled => {
+                    APP_STATE.write().unwrap().exit_position_history_mode();
+                    UI_HINT_OVERLAY.with(|overlay| {
+                        let _ = overlay.borrow_mut().hide();
+                    });
+                }
+                UiHintInputUpdate::Consumed
+                | UiHintInputUpdate::Invalid
+                | UiHintInputUpdate::PrefixChanged => {}
             }
         }
         AppCommand::UiHintInput(event) => {
@@ -4069,6 +4180,8 @@ fn main() {
         eprintln!("❌ System Binding Initialization Failed: {e}");
         std::process::exit(1);
     }
+    *POSITION_HISTORY_STORE.lock().unwrap() =
+        PositionHistory::new(config.position_history.max_positions);
 
     if let Err(e) = unsafe { install_keyboard_hook() } {
         eprintln!("❌ Keyboard Hook Failed to Install: {e}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -5943,7 +5943,9 @@ enabled = true"#,
             },
             Case {
                 name: "position_history",
-                config_toml: "[position_history]
+                config_toml: r#"key_bindings = []
+
+[position_history]
 enabled = true",
                 expected_substring:
                     "position_history.enabled=true but no position history bindings were found",
@@ -6043,7 +6045,7 @@ enabled = true",
         assert!(summary.contains("scroll_mode: enabled=false bindings=0"));
         assert!(summary.contains("window_jump: enabled=true bindings=6"));
         assert!(summary
-            .contains("position_history: enabled=true bindings=save:0 clear:0 mode:0 total:0"));
+            .contains("position_history: enabled=true bindings=save:1 clear:1 mode:1 total:3"));
         assert!(summary.contains("warnings=1"));
         assert!(summary.contains("warning: wheel.min_speed clamped"));
     }

--- a/src/position_history.rs
+++ b/src/position_history.rs
@@ -59,6 +59,29 @@ impl PositionHistory {
         &self.positions
     }
 
+    pub fn reset_with_max_positions(&mut self, max_positions: usize) {
+        self.max_positions = max_positions.max(1);
+        while self.positions.len() > self.max_positions {
+            self.positions.remove(0);
+        }
+    }
+
+    pub fn index_for_label(
+        &self,
+        label: &str,
+        selection_keys: &[char],
+        label_length: usize,
+    ) -> Option<usize> {
+        let labels = generate_ui_hint_labels(
+            self.positions.len(),
+            selection_keys,
+            label_length,
+            UiHintOverflowBehavior::IncreaseLength,
+            Some(self.positions.len()),
+        );
+        labels.iter().position(|candidate| candidate == label)
+    }
+
     pub fn labeled_positions(
         &self,
         selection_keys: &[char],
@@ -116,6 +139,12 @@ mod tests {
     }
 
     #[test]
+    fn clear_returns_false_when_already_empty() {
+        let mut h = PositionHistory::new(2);
+        assert!(!h.clear());
+    }
+
+    #[test]
     fn label_assignment_is_deterministic() {
         let mut h = PositionHistory::new(3);
         h.add(1, 1);
@@ -123,5 +152,20 @@ mod tests {
         let first = h.labeled_positions(&['A', 'B'], 2, false);
         let second = h.labeled_positions(&['A', 'B'], 2, false);
         assert_eq!(first, second);
+    }
+}
+
+
+#[cfg(test)]
+mod mapping_tests {
+    use super::*;
+
+    #[test]
+    fn maps_label_to_index() {
+        let mut h = PositionHistory::new(4);
+        h.add(10, 10);
+        h.add(20, 20);
+        let idx = h.index_for_label("B", &['A', 'B', 'C'], 1);
+        assert_eq!(idx, Some(1));
     }
 }


### PR DESCRIPTION
### Motivation

- Provide an in-memory position history so users can save and recall cursor positions during a session without changing app architecture or overlays.  
- Reuse existing UI-hints/overlay selection flow for label-based selection to minimize new UI code and keep persistence deferred.  
- Expose explicit commands and safe default bindings so position-history actions are first-class runtime features and not handled as generic no-op actions.

### Description

- Added `PositionHistory` helpers in `src/position_history.rs`, including `reset_with_max_positions` and `index_for_label` and extended unit tests for eviction, clear semantics, and label->index mapping.  
- Added explicit `AppCommand` variants (`SaveMousePosition`, `ClearMousePositions`, `EnterPositionHistoryMode`, `PositionHistoryInput`) and a `PositionHistoryState` into `src/app_state.rs`, with input routing so keys map to these commands instead of falling through generic handlers.  
- Integrated a runtime store `POSITION_HISTORY_STORE` in `src/main.rs`, initialized at startup and reconciled on config reload via `reset_with_max_positions`, and implemented command execution that reuses `UiHintSession` targets for selection-driven jumps.  
- Added safe default key bindings (`RightAlt+M`, `RightAlt+Backspace`, `RightAlt+J`) to `default_key_bindings()` and documented usage + session-only persistence in `README.md`.

### Testing

- Added unit tests in `src/position_history.rs` (eviction, clear semantics, label mapping) and a routing test in `src/app_state.rs` for `SaveMousePosition` / `ClearMousePositions` / `PositionHistoryMode`.  
- Attempted to run `cargo test -q`; the run failed in this environment due to a missing system dependency (`xi.pc` for the `x11` crate pkg-config), which is unrelated to the new logic and prevented full test execution here.  
- The added tests are source-present and will run under normal development CI/desktop environments once the system X11/XI pkg-config dependency is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a148cbd91d483329ec584317e14f303)