### PR TITLE
Add one-shot bookmark actions and Bookmarks help section

### DIFF
--- a/src/action.rs
+++ b/src/action.rs
@@ -78,6 +78,8 @@ pub enum Action {
     PositionHistoryMode,
     BookmarkMode,
     BookmarkSlot(u8),
+    ClearBookmarkSlot(u8),
+    ClearAllBookmarks,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -208,14 +210,33 @@ impl Action {
             "clear_mouse_positions" => Some(Self::ClearMousePositions),
             "position_history_mode" => Some(Self::PositionHistoryMode),
             "bookmark_mode" => Some(Self::BookmarkMode),
+            "clear_all_bookmarks" => Some(Self::ClearAllBookmarks),
             action if action.starts_with("bookmark_slot_") => {
                 action
                     .trim_start_matches("bookmark_slot_")
                     .parse::<u8>()
                     .ok()
-                    .filter(|slot| (1..=99).contains(slot))
+                    .filter(|slot| (1..=9).contains(slot))
                     .map(Self::BookmarkSlot)
             }
+            action if action.starts_with("bookmark_") => action
+                .trim_start_matches("bookmark_")
+                .parse::<u8>()
+                .ok()
+                .filter(|slot| (1..=9).contains(slot))
+                .map(Self::BookmarkSlot),
+            action if action.starts_with("jump_to_bookmark_") => action
+                .trim_start_matches("jump_to_bookmark_")
+                .parse::<u8>()
+                .ok()
+                .filter(|slot| (1..=9).contains(slot))
+                .map(Self::BookmarkSlot),
+            action if action.starts_with("clear_bookmark_") => action
+                .trim_start_matches("clear_bookmark_")
+                .parse::<u8>()
+                .ok()
+                .filter(|slot| (1..=9).contains(slot))
+                .map(Self::ClearBookmarkSlot),
             action
                 if action.starts_with("movement_profile:")
                     || action.starts_with("mouse_profile:")
@@ -389,6 +410,10 @@ mod tests {
             ("ui_hints", Action::UiHintMode),
             ("show_ui_hints", Action::UiHintMode),
             ("hint_mode", Action::UiHintMode),
+            ("bookmark_1", Action::BookmarkSlot(1)),
+            ("jump_to_bookmark_1", Action::BookmarkSlot(1)),
+            ("clear_bookmark_1", Action::ClearBookmarkSlot(1)),
+            ("clear_all_bookmarks", Action::ClearAllBookmarks),
         ];
 
         for (input, expected) in cases {
@@ -604,6 +629,39 @@ mod tests {
             Action::from_string("position_history_mode"),
             Some(Action::PositionHistoryMode)
         );
+    }
+
+    #[test]
+    fn parses_bookmark_actions() {
+        assert_eq!(Action::from_string("bookmark_mode"), Some(Action::BookmarkMode));
+        assert_eq!(
+            Action::from_string("bookmark_slot_1"),
+            Some(Action::BookmarkSlot(1))
+        );
+        assert_eq!(
+            Action::from_string("bookmark_slot_9"),
+            Some(Action::BookmarkSlot(9))
+        );
+        assert_eq!(Action::from_string("bookmark_1"), Some(Action::BookmarkSlot(1)));
+        assert_eq!(
+            Action::from_string("jump_to_bookmark_1"),
+            Some(Action::BookmarkSlot(1))
+        );
+    }
+
+    #[test]
+    fn bookmark_actions_are_one_shot_not_continuous() {
+        let actions = [
+            Action::BookmarkMode,
+            Action::BookmarkSlot(1),
+            Action::ClearBookmarkSlot(1),
+            Action::ClearAllBookmarks,
+        ];
+        for action in actions {
+            assert!(!action.is_continuous(), "{action:?}");
+            assert!(!action.is_movement(), "{action:?}");
+            assert!(!action.is_wheel_direction(), "{action:?}");
+        }
     }
 }
 

--- a/src/action_handler.rs
+++ b/src/action_handler.rs
@@ -362,7 +362,9 @@ impl<B: MouseBackend> MouseMaster<B> {
             | Action::ClearMousePositions
             | Action::PositionHistoryMode
             | Action::BookmarkMode
-            | Action::BookmarkSlot(_) => {}
+            | Action::BookmarkSlot(_)
+            | Action::ClearBookmarkSlot(_)
+            | Action::ClearAllBookmarks => {}
             Action::Disable => self.set_active_mode(false),
             Action::PanicReset => {
                 self.hard_reset_runtime();

--- a/src/help_overlay.rs
+++ b/src/help_overlay.rs
@@ -41,6 +41,7 @@ pub enum HelpBindingSection {
     ClickDrag,
     Wheel,
     JumpGrid,
+    Bookmarks,
     UiHints,
     StepMove,
     Surgical,
@@ -54,6 +55,7 @@ impl HelpBindingSection {
             Self::ClickDrag => "Click/Drag",
             Self::Wheel => "Wheel",
             Self::JumpGrid => "Jump/Grid",
+            Self::Bookmarks => "Bookmarks",
             Self::UiHints => "UI Hints",
             Self::StepMove => "Step Move",
             Self::Surgical => "Surgical",
@@ -646,6 +648,7 @@ pub fn format_help_lines(view: &HelpOverlayView, config: TooltipOverlayConfig) -
         HelpBindingSection::ClickDrag,
         HelpBindingSection::Wheel,
         HelpBindingSection::JumpGrid,
+        HelpBindingSection::Bookmarks,
         HelpBindingSection::UiHints,
         HelpBindingSection::StepMove,
         HelpBindingSection::Surgical,
@@ -875,7 +878,9 @@ fn format_action(action: &Action) -> String {
         Action::ClearMousePositions => "Clear saved mouse positions".to_string(),
         Action::PositionHistoryMode => "Position history mode".to_string(),
         Action::BookmarkMode => "Bookmark mode".to_string(),
-        Action::BookmarkSlot(slot) => format!("Bookmark slot {slot}"),
+        Action::BookmarkSlot(slot) => format!("Jump to bookmark slot {slot}"),
+        Action::ClearBookmarkSlot(slot) => format!("Clear bookmark slot {slot}"),
+        Action::ClearAllBookmarks => "Clear all bookmarks".to_string(),
         Action::StepMove { direction, tier } => {
             let direction = match direction {
                 Direction2D::Up => "up",
@@ -946,9 +951,10 @@ fn action_section(action: &Action) -> HelpBindingSection {
         | Action::UiHintMode
         | Action::SaveMousePosition
         | Action::ClearMousePositions
-        | Action::PositionHistoryMode
-        | Action::BookmarkMode
-        | Action::BookmarkSlot(_) => HelpBindingSection::JumpGrid,
+        | Action::PositionHistoryMode => HelpBindingSection::JumpGrid,
+        Action::BookmarkMode | Action::BookmarkSlot(_) | Action::ClearBookmarkSlot(_) | Action::ClearAllBookmarks => {
+            HelpBindingSection::Bookmarks
+        }
         Action::Exit
         | Action::ReloadConfig
         | Action::PanicReset
@@ -1214,6 +1220,7 @@ mod tests {
             "Click/Drag:",
             "Wheel:",
             "Jump/Grid:",
+            "Bookmarks:",
             "Profiles/Runtime:",
         ] {
             assert!(lines.contains(heading), "{heading}");
@@ -1273,6 +1280,31 @@ mod tests {
         assert!(lines.find("Movement:").unwrap() < lines.find("Click/Drag:").unwrap());
         assert!(lines.find("Click/Drag:").unwrap() < lines.find("Wheel:").unwrap());
         assert!(lines.find("Wheel:").unwrap() < lines.find("Jump/Grid:").unwrap());
+    }
+
+    #[test]
+    fn bookmark_entries_appear_in_help_bindings() {
+        let view = help_view_from_bindings(
+            [
+                (
+                    KeyChord::new(false, false, false, true, VirtualKey::B),
+                    Action::BookmarkMode,
+                ),
+                (KeyChord::from_key(VirtualKey::Key1), Action::BookmarkSlot(1)),
+                (
+                    KeyChord::new(false, false, false, false, VirtualKey::Backspace),
+                    Action::ClearBookmarkSlot(1),
+                ),
+                (KeyChord::from_key(VirtualKey::Escape), Action::Disable),
+            ],
+            ModeContext::Active,
+        );
+
+        let lines = format_help_lines(&view, TooltipOverlayConfig::default()).join("\n");
+        assert!(lines.contains("Bookmarks:"));
+        assert!(lines.contains("Shift+B  -  Bookmark mode"));
+        assert!(lines.contains("Key1  -  Jump to bookmark slot 1"));
+        assert!(lines.contains("Backspace  -  Clear bookmark slot 1"));
     }
 
     #[test]

--- a/src/help_overlay.rs
+++ b/src/help_overlay.rs
@@ -1286,15 +1286,9 @@ mod tests {
     fn bookmark_entries_appear_in_help_bindings() {
         let view = help_view_from_bindings(
             [
-                (
-                    KeyChord::new(false, false, false, true, VirtualKey::B),
-                    Action::BookmarkMode,
-                ),
-                (KeyChord::from_key(VirtualKey::Key1), Action::BookmarkSlot(1)),
-                (
-                    KeyChord::new(false, false, false, false, VirtualKey::Backspace),
-                    Action::ClearBookmarkSlot(1),
-                ),
+                (KeyChord::parse("Shift+B").unwrap(), Action::BookmarkMode),
+                (KeyChord::from_key(VirtualKey::Num1), Action::BookmarkSlot(1)),
+                (KeyChord::from_key(VirtualKey::Backspace), Action::ClearBookmarkSlot(1)),
                 (KeyChord::from_key(VirtualKey::Escape), Action::Disable),
             ],
             ModeContext::Active,

--- a/src/help_overlay.rs
+++ b/src/help_overlay.rs
@@ -1220,7 +1220,6 @@ mod tests {
             "Click/Drag:",
             "Wheel:",
             "Jump/Grid:",
-            "Bookmarks:",
             "Profiles/Runtime:",
         ] {
             assert!(lines.contains(heading), "{heading}");
@@ -1297,7 +1296,7 @@ mod tests {
         let lines = format_help_lines(&view, TooltipOverlayConfig::default()).join("\n");
         assert!(lines.contains("Bookmarks:"));
         assert!(lines.contains("Shift+B  -  Bookmark mode"));
-        assert!(lines.contains("Key1  -  Jump to bookmark slot 1"));
+        assert!(lines.contains("Num1  -  Jump to bookmark slot 1"));
         assert!(lines.contains("Backspace  -  Clear bookmark slot 1"));
     }
 


### PR DESCRIPTION
### Motivation
- Treat bookmarks as semantic, one-shot actions decoupled from continuous input plumbing so saving/jumping/clearing bookmarks is not handled by movement/wheel tick loops or held-repeat logic. 
- Provide user-facing discoverability by exposing bookmark bindings in the help overlay and supporting common canonical and alias action strings. 

### Description
- Added new actions to `Action`: `ClearBookmarkSlot(u8)` and `ClearAllBookmarks`, kept `BookmarkMode` and `BookmarkSlot(u8)`, and updated parsing in `Action::from_string` to accept `bookmark_mode`, `bookmark_slot_1..9`, `bookmark_1..9`, `jump_to_bookmark_1..9`, `clear_bookmark_1..9` and `clear_all_bookmarks` while restricting slot range to `1..=9`; changes in `src/action.rs`. 
- Ensured bookmark actions remain one-shot by including `ClearBookmarkSlot` and `ClearAllBookmarks` alongside other non-continuous control actions so they are excluded from movement tick/held-repeat and wheel-tick paths; changes in `src/action_handler.rs`. 
- Added a `Bookmarks` help section and formatted labels for bookmark actions (`Bookmark mode`, `Jump to bookmark slot N`, `Clear bookmark slot N`, `Clear all bookmarks`) and included the section in the help grouping/order; changes in `src/help_overlay.rs`. 
- Added unit tests covering parsing of canonical and alias bookmark strings, classification that bookmark actions are one-shot (not continuous), and help overlay assertions that bookmark entries appear in the `Bookmarks` section. 

### Testing
- Attempted targeted runs via `cargo test bookmark -- --nocapture` to exercise bookmark-related tests, but the build failed early due to a missing system development dependency required by a transitive `x11` crate (pkg-config cannot find `xi.pc`), so the added tests were not executed in this environment. 
- An earlier attempt with an invalid multi-filter test invocation was rejected by `cargo test` usage rules, so no test subset was run that way. 
- The new unit tests are present and should run once the native X11 `xi` pkg-config/system library is available in the CI/build environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14a391ebd48332aa10b32b81bdaf29)