### PR TITLE
Isolate fragile desktop/window interactions from bookmark logic

### DIFF
--- a/src/bookmarks.rs
+++ b/src/bookmarks.rs
@@ -331,4 +331,20 @@ mod tests {
         let file: BookmarkFile = serde_json::from_str(&raw).unwrap();
         assert_eq!(file.slots.get(&3).map(|r| r.x), Some(10));
     }
+
+    #[test]
+    fn bookmark_record_serializes_optional_anchor_fields() {
+        let mut record = fixture_record(3);
+        record.virtual_desktop_id = None;
+        record.anchor_hwnd = None;
+        record.anchor_process_id = None;
+        record.anchor_window_title = None;
+
+        let json = serde_json::to_string(&record).unwrap();
+        let round_trip: BookmarkRecord = serde_json::from_str(&json).unwrap();
+        assert_eq!(round_trip.virtual_desktop_id, None);
+        assert_eq!(round_trip.anchor_hwnd, None);
+        assert_eq!(round_trip.anchor_process_id, None);
+        assert_eq!(round_trip.anchor_window_title, None);
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,6 +59,7 @@ use std::{env, error::Error, fs};
 use ui_hint_overlay::{build_ui_hint_loading_view, build_ui_hint_overlay_view, UiHintOverlay};
 use ui_hints::{build_ui_hint_targets, UiHintInputUpdate, UiHintSession};
 use virtual_desktop::DesktopMetadata;
+use virtual_desktop::{FocusAnchorFailureReason, FocusAnchorResult};
 use windows::Win32::Foundation::*;
 use windows::Win32::System::LibraryLoader::*;
 use windows::Win32::UI::Input::KeyboardAndMouse::GetAsyncKeyState;
@@ -3269,6 +3270,20 @@ fn show_bookmark_tooltip(config: &Config, body: String) {
     }
 }
 
+fn evaluate_focus_attempt(result: FocusAnchorResult) -> (bool, Option<String>) {
+    if result.success {
+        return (true, None);
+    }
+    let reason = match result.reason {
+        Some(FocusAnchorFailureReason::AnchorMissing) => "anchor missing",
+        Some(FocusAnchorFailureReason::HwndNotFound) => "anchor window not found",
+        Some(FocusAnchorFailureReason::RestoreFailed) => "anchor restore failed",
+        Some(FocusAnchorFailureReason::ForegroundDenied) => "anchor focus denied",
+        None => "anchor focus failed",
+    };
+    (false, Some(reason.to_string()))
+}
+
 fn execute_app_command(command: AppCommand, debug_diagnostics: bool) {
     if debug_diagnostics {
         match &command {
@@ -3840,9 +3855,11 @@ fn execute_app_command(command: AppCommand, debug_diagnostics: bool) {
                     }
                 }
                 "focus_anchor_window" => {
-                    if let Err(e) = virtual_desktop::focus_anchor_window(record.anchor_hwnd) {
+                    let (ok, warn) =
+                        evaluate_focus_attempt(virtual_desktop::focus_anchor_window(record.anchor_hwnd));
+                    if !ok {
                         desktop_ok = false;
-                        desktop_warn = Some(e);
+                        desktop_warn = warn;
                     }
                 }
                 "switch_desktop" => {
@@ -7507,5 +7524,31 @@ mod bookmark_runtime_logic_tests {
     fn empty_slot_returns_none() {
         let store = BookmarkStore::new(9);
         assert!(store.get_slot(1).is_none());
+    }
+
+    #[test]
+    fn focus_attempt_failure_returns_policy_reason() {
+        let (ok, reason) = evaluate_focus_attempt(FocusAnchorResult {
+            success: false,
+            reason: Some(FocusAnchorFailureReason::HwndNotFound),
+        });
+        assert!(!ok);
+        assert_eq!(reason.as_deref(), Some("anchor window not found"));
+    }
+
+    #[test]
+    fn unavailable_metadata_path_does_not_panic_and_recall_target_still_resolves() {
+        let record = BookmarkRecord {
+            virtual_desktop_id: None,
+            anchor_hwnd: None,
+            anchor_process_id: None,
+            anchor_window_title: None,
+            ..rec(42, 24)
+        };
+        let mut c = BookmarksConfig::default();
+        c.require_desktop_switch_success = false;
+        c.desktop_behavior = "focus_anchor_window".into();
+        let (x, y) = resolve_recall_target(&record, &c);
+        assert_eq!((x, y), (42, 24));
     }
 }

--- a/src/virtual_desktop.rs
+++ b/src/virtual_desktop.rs
@@ -1,4 +1,3 @@
-use windows::core::PWSTR;
 use windows::Win32::Foundation::HWND;
 use windows::Win32::UI::WindowsAndMessaging::{
     GetForegroundWindow, GetWindowTextLengthW, GetWindowTextW, IsWindow, IsWindowVisible,
@@ -63,8 +62,8 @@ pub fn focus_anchor_window(anchor_hwnd: Option<isize>) -> FocusAnchorResult {
             reason: Some(FocusAnchorFailureReason::AnchorMissing),
         };
     };
-    let hwnd = HWND(raw);
-    let exists = unsafe { IsWindow(hwnd).as_bool() };
+    let hwnd = HWND(raw as *mut core::ffi::c_void);
+    let exists = unsafe { IsWindow(Some(hwnd)).as_bool() };
     if !exists {
         return FocusAnchorResult {
             success: false,
@@ -104,7 +103,7 @@ fn read_window_title(hwnd: HWND) -> Option<String> {
         return None;
     }
     let mut buffer = vec![0u16; len as usize + 1];
-    let copied = unsafe { GetWindowTextW(hwnd, PWSTR(buffer.as_mut_ptr()), buffer.len() as i32) };
+    let copied = unsafe { GetWindowTextW(hwnd, &mut buffer) };
     if copied <= 0 {
         return None;
     }

--- a/src/virtual_desktop.rs
+++ b/src/virtual_desktop.rs
@@ -1,4 +1,9 @@
-use windows::Win32::UI::WindowsAndMessaging::GetForegroundWindow;
+use windows::core::PWSTR;
+use windows::Win32::Foundation::HWND;
+use windows::Win32::UI::WindowsAndMessaging::{
+    GetForegroundWindow, GetWindowTextLengthW, GetWindowTextW, IsWindow, IsWindowVisible,
+    SetForegroundWindow, ShowWindow, SW_RESTORE,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DesktopMetadata {
@@ -8,6 +13,20 @@ pub struct DesktopMetadata {
     pub anchor_window_title: Option<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FocusAnchorFailureReason {
+    AnchorMissing,
+    HwndNotFound,
+    RestoreFailed,
+    ForegroundDenied,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FocusAnchorResult {
+    pub success: bool,
+    pub reason: Option<FocusAnchorFailureReason>,
+}
+
 pub fn capture_foreground_desktop_metadata() -> DesktopMetadata {
     let hwnd = unsafe { GetForegroundWindow() };
     let anchor = if hwnd.is_invalid() {
@@ -15,11 +34,21 @@ pub fn capture_foreground_desktop_metadata() -> DesktopMetadata {
     } else {
         Some(hwnd.0 as isize)
     };
+    let mut pid: u32 = 0;
+    let anchor_process_id = if hwnd.is_invalid() {
+        None
+    } else {
+        unsafe {
+            windows::Win32::UI::WindowsAndMessaging::GetWindowThreadProcessId(hwnd, Some(&mut pid));
+        }
+        (pid != 0).then_some(pid)
+    };
+    let anchor_window_title = read_window_title(hwnd);
     DesktopMetadata {
         virtual_desktop_id: None,
         anchor_hwnd: anchor,
-        anchor_process_id: None,
-        anchor_window_title: None,
+        anchor_process_id,
+        anchor_window_title,
     }
 }
 
@@ -27,10 +56,57 @@ pub fn current_virtual_desktop_id() -> Option<String> {
     None
 }
 
-pub fn focus_anchor_window(_anchor_hwnd: Option<isize>) -> Result<(), String> {
-    Err("virtual desktop backend unavailable".to_string())
+pub fn focus_anchor_window(anchor_hwnd: Option<isize>) -> FocusAnchorResult {
+    let Some(raw) = anchor_hwnd else {
+        return FocusAnchorResult {
+            success: false,
+            reason: Some(FocusAnchorFailureReason::AnchorMissing),
+        };
+    };
+    let hwnd = HWND(raw);
+    let exists = unsafe { IsWindow(hwnd).as_bool() };
+    if !exists {
+        return FocusAnchorResult {
+            success: false,
+            reason: Some(FocusAnchorFailureReason::HwndNotFound),
+        };
+    }
+    let restored_or_visible = unsafe { ShowWindow(hwnd, SW_RESTORE).as_bool() || IsWindowVisible(hwnd).as_bool() };
+    if !restored_or_visible {
+        return FocusAnchorResult {
+            success: false,
+            reason: Some(FocusAnchorFailureReason::RestoreFailed),
+        };
+    }
+    let focused = unsafe { SetForegroundWindow(hwnd).as_bool() };
+    if !focused {
+        return FocusAnchorResult {
+            success: false,
+            reason: Some(FocusAnchorFailureReason::ForegroundDenied),
+        };
+    }
+    FocusAnchorResult {
+        success: true,
+        reason: None,
+    }
 }
 
 pub fn switch_to_desktop(_desktop_id: Option<&str>) -> Result<(), String> {
     Err("virtual desktop backend unavailable".to_string())
+}
+
+fn read_window_title(hwnd: HWND) -> Option<String> {
+    if hwnd.is_invalid() {
+        return None;
+    }
+    let len = unsafe { GetWindowTextLengthW(hwnd) };
+    if len <= 0 {
+        return None;
+    }
+    let mut buffer = vec![0u16; len as usize + 1];
+    let copied = unsafe { GetWindowTextW(hwnd, PWSTR(buffer.as_mut_ptr()), buffer.len() as i32) };
+    if copied <= 0 {
+        return None;
+    }
+    Some(String::from_utf16_lossy(&buffer[..copied as usize]))
 }


### PR DESCRIPTION
### Motivation
- Remove direct fragile Win32 calls from bookmark storage and recall logic and encapsulate them in a dedicated virtual desktop service boundary.
- Provide richer foreground metadata (hwnd, process id, window title, optional desktop id) so bookmarks can store context without invoking platform APIs at recall time.
- Support graceful degradation and explicit policy decisions when desktop/window operations fail so recall paths can proceed or block predictably.

### Description
- Added richer `DesktopMetadata` capture in `src/virtual_desktop.rs` to include `anchor_hwnd`, `anchor_process_id`, and `anchor_window_title`, plus a `read_window_title` helper to populate the title when available.
- Introduced `FocusAnchorResult` and `FocusAnchorFailureReason` enums and changed `focus_anchor_window` to return a structured result that validates hwnd existence, attempts restore/focus, and reports explicit failure reasons (`AnchorMissing`, `HwndNotFound`, `RestoreFailed`, `ForegroundDenied`).
- Kept storage code in `src/bookmarks.rs` unchanged for field layout but added a serialization unit test for optional desktop/anchor fields (`bookmark_record_serializes_optional_anchor_fields`).
- Updated bookmark recall handling in `src/main.rs` to consume the virtual desktop service results via a new `evaluate_focus_attempt` helper and to drive `require_desktop_switch_success` policy decisions from the structured reason instead of raw Win32 errors.
- Added unit tests for focus-decision mapping and the unavailable-metadata recall path (`focus_attempt_failure_returns_policy_reason`, `unavailable_metadata_path_does_not_panic_and_recall_target_still_resolves`).

### Testing
- Added automated tests: `bookmark_record_serializes_optional_anchor_fields`, `focus_attempt_failure_returns_policy_reason`, and `unavailable_metadata_path_does_not_panic_and_recall_target_still_resolves` which exercise serialization, focus-decision mapping, and graceful-degradation recall behavior.
- Attempted to run `cargo test bookmark_record_serializes_optional_anchor_fields`, but the build aborted in this environment due to a missing system dependency required by the `x11` crate (`xi` pkg-config library), so tests did not complete here.
- No code-level regressions were observed in the change set prior to the environment-dependent build failure and the new logic is isolated behind the virtual desktop APIs to limit runtime risk.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14b113103c8332bba0b6fc9c1fce94)