### PR TITLE
Evaluate system_bindings first and add panic_reset routing

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -143,6 +143,10 @@ font_scale = 1.0
 [system_bindings]
 toggle_active = "Ctrl+Q"
 exit = "Escape"
+exit_ignore_extra_modifiers = true
+panic_reset = "RightAlt+Escape"
+panic_reset_ignore_extra_modifiers = true
+panic_reset_sets_idle = true
 
 # ---------------------------------------------------------------------------
 # Movement speed and profiles

--- a/docs/config.md
+++ b/docs/config.md
@@ -99,7 +99,11 @@ key_bindings = [
 | `polling_rate` | integer milliseconds | `8` | Yes | Active | Main input loop delay. Lower values poll more often. |
 | `key_bindings` | array of `[key, action]` pairs | built-in movement/click/jump bindings | Yes | Active | Active-mode action bindings. |
 | `system_bindings.toggle_active` | key chord string | `"Ctrl+E"` | Yes | Active | Global active/idle toggle. |
-| `system_bindings.exit` | key chord string | `"Escape"` | Yes | Active | Global exit binding. |
+| `system_bindings.exit` | key chord string | `"Escape"` | Yes | Active | Global exit binding. Routed before mode-local handlers. |
+| `system_bindings.exit_ignore_extra_modifiers` | boolean | `true` | Yes | Active | When true, `exit` matches if required modifiers are present even when extra modifiers are held. |
+| `system_bindings.panic_reset` | key chord string | `"RightAlt+Escape"` | Yes | Active | Global non-exiting panic cleanup binding, routed before mode-local handlers. |
+| `system_bindings.panic_reset_ignore_extra_modifiers` | boolean | `true` | Yes | Active | When true, `panic_reset` allows extra held modifiers. |
+| `system_bindings.panic_reset_sets_idle` | boolean | `true` | Yes | Active | When true, panic reset also sets idle mode (`SetActiveMode { active = false }`). |
 | `mouse_speed.default_speed` | integer | `1` | Yes | Active | Normal held-movement speed and replacement for legacy `starting_speed`. |
 | `mouse_speed.min_speed` | integer | `1` | Yes | Active | Lower bound for runtime mouse speed changes. |
 | `mouse_speed.max_speed` | integer | `12` | Yes | Active | Upper bound for runtime mouse speed changes. |
@@ -469,3 +473,22 @@ coordinate_policy = "clamp_to_virtual_screen"
 ### Surgical behavior semantics
 
 `SurgicalMode` is a **held precision modifier**: movement requires both the surgical key and a movement key. Holding surgical alone produces no cursor movement. While active, movement runs at fixed `surgical_mode.speed_px` with no acceleration ramp.
+
+
+## System binding priority and Escape conflicts
+
+`system_bindings` are always evaluated first for key-down events: `exit`, then `panic_reset`, then `toggle_active`.
+Only after those checks does mode-local routing run (bookmark cancel, UI hint, jump/grid, etc.).
+
+Conflict example:
+
+```toml
+[system_bindings]
+exit = "Escape"
+
+[bookmark_mode]
+cancel = "Escape" # conceptual mode-local cancel
+```
+
+Pressing `Escape` dispatches `Exit`, not bookmark cancel, because system bindings have higher priority.
+If you instead set `exit = "Ctrl+Alt+Escape"`, a plain `Escape` can still be consumed by bookmark cancel.

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -317,12 +317,30 @@ impl AppState {
         self.system_bindings.toggle_active.matches_event(event)
     }
 
+    pub fn is_panic_reset_binding(&self, event: &KeyEvent) -> bool {
+        if self.system_bindings.panic_reset_ignore_extra_modifiers {
+            self.system_bindings
+                .panic_reset
+                .matches_event_ignoring_extra_modifiers(event)
+        } else {
+            self.system_bindings.panic_reset.matches_event(event)
+        }
+    }
+
     pub fn is_exit_binding(&self, event: &KeyEvent) -> bool {
-        self.system_bindings.exit.matches_event(event)
+        if self.system_bindings.exit_ignore_extra_modifiers {
+            self.system_bindings
+                .exit
+                .matches_event_ignoring_extra_modifiers(event)
+        } else {
+            self.system_bindings.exit.matches_event(event)
+        }
     }
 
     pub fn is_system_binding(&self, event: &KeyEvent) -> bool {
-        self.is_toggle_active_binding(event) || self.is_exit_binding(event)
+        self.is_toggle_active_binding(event)
+            || self.is_exit_binding(event)
+            || self.is_panic_reset_binding(event)
     }
 
     pub fn is_toggle_active_key_down_event(&self, event: &KeyEvent) -> bool {
@@ -334,7 +352,9 @@ impl AppState {
     }
 
     pub fn is_system_key_down_event(&self, event: &KeyEvent) -> bool {
-        self.is_toggle_active_key_down_event(event) || self.is_exit_key_down_event(event)
+        self.is_toggle_active_key_down_event(event)
+            || self.is_exit_key_down_event(event)
+            || (event.is_down && self.is_panic_reset_binding(event))
     }
 
     pub fn is_jump_active(&self) -> bool {
@@ -869,6 +889,14 @@ impl AppState {
             return;
         }
 
+        if event.is_down && self.is_panic_reset_binding(&event) {
+            if self.system_bindings.panic_reset_sets_idle {
+                self.enqueue_command(AppCommand::SetActiveMode { active: false });
+            }
+            self.enqueue_command(AppCommand::PanicReset);
+            return;
+        }
+
         if self.is_toggle_active_key_down_event(&event) {
             self.enqueue_command(AppCommand::ToggleActiveMode);
             return;
@@ -958,11 +986,6 @@ impl AppState {
             return;
         }
 
-        if self.is_exit_key_down_event(&event) {
-            self.enqueue_command(AppCommand::Exit);
-            return;
-        }
-
         if self.is_preserved_shortcut(&event) {
             return;
         }
@@ -990,14 +1013,6 @@ impl AppState {
             self.exit_position_history_mode();
             self.exit_bookmark_mode();
             self.enqueue_command(AppCommand::ReloadConfig);
-            return;
-        }
-
-        if event.is_down && matches!(action.as_ref(), Some(Action::PanicReset)) {
-            self.exit_ui_hint_mode();
-            self.exit_position_history_mode();
-            self.exit_bookmark_mode();
-            self.enqueue_command(AppCommand::PanicReset);
             return;
         }
 
@@ -3109,6 +3124,62 @@ mod tests {
         assert_eq!(
             collect_commands(&mut state),
             vec![AppCommand::ClearBookmarkSlot(1)]
+        );
+    }
+    #[test]
+    fn exit_routed_before_bookmark_mode_cancel() {
+        let mut state = AppState::default();
+        state.enter_bookmark_mode(VirtualKey::B);
+        state.route_key_event(KeyEvent::new(VirtualKey::Escape, true), None);
+        assert_eq!(collect_commands(&mut state), vec![AppCommand::Exit]);
+    }
+
+    #[test]
+    fn exit_routed_before_ui_hint_mode_handling() {
+        let mut state = AppState::default();
+        state.enter_ui_hint_querying(VirtualKey::U, 1, 0);
+        state.route_key_event(KeyEvent::new(VirtualKey::Escape, true), None);
+        assert_eq!(collect_commands(&mut state), vec![AppCommand::Exit]);
+    }
+
+    #[test]
+    fn panic_reset_routed_before_exclusive_modes() {
+        let mut state = AppState::default();
+        state.enter_bookmark_mode(VirtualKey::B);
+        let mut event = KeyEvent::new(VirtualKey::Escape, true);
+        event.alt_down = true;
+        event.right_alt_down = true;
+        state.route_key_event(event, Some(Action::PanicReset));
+        assert_eq!(
+            collect_commands(&mut state),
+            vec![
+                AppCommand::SetActiveMode { active: false },
+                AppCommand::PanicReset
+            ]
+        );
+    }
+
+    #[test]
+    fn escape_exit_wins_over_bookmark_cancel_when_both_escape() {
+        let mut state = AppState::default();
+        state.set_system_bindings(RuntimeSystemBindings::default());
+        state.enter_bookmark_mode(VirtualKey::B);
+        state.route_key_event(KeyEvent::new(VirtualKey::Escape, true), None);
+        assert_eq!(collect_commands(&mut state), vec![AppCommand::Exit]);
+    }
+
+    #[test]
+    fn ctrl_alt_escape_exit_does_not_override_plain_escape_bookmark_cancel() {
+        let mut state = AppState::default();
+        state.set_system_bindings(RuntimeSystemBindings {
+            exit: KeyChord::parse("Ctrl+Alt+Escape").unwrap(),
+            ..RuntimeSystemBindings::default()
+        });
+        state.enter_bookmark_mode(VirtualKey::B);
+        state.route_key_event(KeyEvent::new(VirtualKey::Escape, true), None);
+        assert_eq!(
+            collect_commands(&mut state),
+            vec![AppCommand::CancelBookmarkMode]
         );
     }
 }

--- a/src/key_chord.rs
+++ b/src/key_chord.rs
@@ -94,6 +94,15 @@ impl KeyChord {
             && self.win == event.win_down
     }
 
+    pub fn matches_event_ignoring_extra_modifiers(&self, event: &KeyEvent) -> bool {
+        self.key == event.key
+            && (!self.ctrl || event.ctrl_down || is_ctrl_key(self.key))
+            && (!self.alt || event.alt_down || is_alt_key(self.key))
+            && (!self.right_alt || event.right_alt_down)
+            && (!self.shift || event.shift_down || is_shift_key(self.key))
+            && (!self.win || event.win_down)
+    }
+
     pub fn matches_event_allowing_shift_modifier(&self, event: &KeyEvent) -> bool {
         self.key == event.key
             && self.is_unmodified()
@@ -150,6 +159,10 @@ fn is_alt_key(key: VirtualKey) -> bool {
 pub struct RuntimeSystemBindings {
     pub toggle_active: KeyChord,
     pub exit: KeyChord,
+    pub exit_ignore_extra_modifiers: bool,
+    pub panic_reset: KeyChord,
+    pub panic_reset_ignore_extra_modifiers: bool,
+    pub panic_reset_sets_idle: bool,
 }
 
 impl RuntimeSystemBindings {
@@ -157,6 +170,7 @@ impl RuntimeSystemBindings {
         Self {
             toggle_active,
             exit,
+            ..Self::default()
         }
     }
 }
@@ -180,6 +194,17 @@ impl Default for RuntimeSystemBindings {
                 shift: false,
                 win: false,
             },
+            exit_ignore_extra_modifiers: true,
+            panic_reset: KeyChord {
+                key: VirtualKey::Escape,
+                ctrl: false,
+                alt: true,
+                right_alt: true,
+                shift: false,
+                win: false,
+            },
+            panic_reset_ignore_extra_modifiers: true,
+            panic_reset_sets_idle: true,
         }
     }
 }
@@ -262,6 +287,29 @@ mod tests {
             KeyChord::parse("Escape").unwrap(),
             chord(VirtualKey::Escape, false, false, false, false, false)
         );
+    }
+
+    #[test]
+    fn matches_event_ignoring_extra_modifiers_escape_matches_alt_escape() {
+        let chord = KeyChord::parse("Escape").unwrap();
+        let mut event = KeyEvent::new(VirtualKey::Escape, true);
+        event.alt_down = true;
+        assert!(chord.matches_event_ignoring_extra_modifiers(&event));
+    }
+
+    #[test]
+    fn matches_event_escape_does_not_match_alt_escape_without_ignore_extra() {
+        let chord = KeyChord::parse("Escape").unwrap();
+        let mut event = KeyEvent::new(VirtualKey::Escape, true);
+        event.alt_down = true;
+        assert!(!chord.matches_event(&event));
+    }
+
+    #[test]
+    fn matches_event_ignoring_extra_modifiers_still_requires_required_modifier() {
+        let chord = KeyChord::parse("Ctrl+Q").unwrap();
+        let event = KeyEvent::new(VirtualKey::Q, true);
+        assert!(!chord.matches_event_ignoring_extra_modifiers(&event));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1102,6 +1102,10 @@ impl Default for ScrollModeConfig {
 struct SystemBindings {
     toggle_active: String,
     exit: String,
+    exit_ignore_extra_modifiers: bool,
+    panic_reset: Option<String>,
+    panic_reset_ignore_extra_modifiers: bool,
+    panic_reset_sets_idle: bool,
 }
 
 impl Default for SystemBindings {
@@ -1109,6 +1113,10 @@ impl Default for SystemBindings {
         Self {
             toggle_active: "Ctrl+E".to_string(),
             exit: "Escape".to_string(),
+            exit_ignore_extra_modifiers: true,
+            panic_reset: Some("RightAlt+Escape".to_string()),
+            panic_reset_ignore_extra_modifiers: true,
+            panic_reset_sets_idle: true,
         }
     }
 }
@@ -2200,12 +2208,24 @@ impl Config {
     }
 
     fn runtime_system_bindings(&self) -> Result<RuntimeSystemBindings, Box<dyn Error>> {
-        Ok(RuntimeSystemBindings::new(
-            KeyChord::parse(&self.system_bindings.toggle_active)
+        let panic_reset = self
+            .system_bindings
+            .panic_reset
+            .as_deref()
+            .unwrap_or("RightAlt+Escape");
+        Ok(RuntimeSystemBindings {
+            toggle_active: KeyChord::parse(&self.system_bindings.toggle_active)
                 .map_err(|e| format!("system_bindings.toggle_active: {e}"))?,
-            KeyChord::parse(&self.system_bindings.exit)
+            exit: KeyChord::parse(&self.system_bindings.exit)
                 .map_err(|e| format!("system_bindings.exit: {e}"))?,
-        ))
+            exit_ignore_extra_modifiers: self.system_bindings.exit_ignore_extra_modifiers,
+            panic_reset: KeyChord::parse(panic_reset)
+                .map_err(|e| format!("system_bindings.panic_reset: {e}"))?,
+            panic_reset_ignore_extra_modifiers: self
+                .system_bindings
+                .panic_reset_ignore_extra_modifiers,
+            panic_reset_sets_idle: self.system_bindings.panic_reset_sets_idle,
+        })
     }
 
     fn initialize_bindings(&self) {
@@ -3397,6 +3417,7 @@ fn execute_app_command(command: AppCommand, debug_diagnostics: bool) {
         }
         AppCommand::Exit => {
             exit_ui_hint_mode(UiHintExitReason::Exit);
+            let _ = panic_reset();
             ACTION_HANDLER.write().unwrap().mouse_master.exit();
         }
         AppCommand::ReloadConfig => {


### PR DESCRIPTION
### Motivation
- Ensure global `system_bindings` are matched before any mode-local or active/idle logic so escapes and emergency bindings cannot be shadowed by mode cancels. 
- Allow system exit/panic-reset bindings to match even when extra modifiers are held to reduce accidental mode trapping. 
- Provide a non-exiting `panic_reset` path for fast cleanup without terminating the process, and let it optionally set idle mode. 

### Description
- Added `matches_event_ignoring_extra_modifiers` to `KeyChord` to require specified modifiers while tolerating additional held modifiers, and added unit tests for the new matching semantics in `src/key_chord.rs`. 
- Extended the runtime config/model (`SystemBindings` in `src/main.rs` and `RuntimeSystemBindings` in `src/key_chord.rs`) with `exit_ignore_extra_modifiers`, `panic_reset` (optional), `panic_reset_ignore_extra_modifiers`, and `panic_reset_sets_idle`, and applied sensible defaults (`exit_ignore_extra_modifiers = true`, `panic_reset = RightAlt+Escape`, `panic_reset_ignore_extra_modifiers = true`, `panic_reset_sets_idle = true`). 
- Reordered `AppState::route_key_event()` in `src/app_state.rs` so key-down system bindings are evaluated first (exit → panic_reset → toggle_active) before mode-local routing, added `is_panic_reset_binding` helper, and ensured bookmark cancel/UI-hint handlers do not supersede `Exit`. 
- Wired command execution so `AppCommand::PanicReset` triggers a non-exiting cleanup path and `AppCommand::Exit` runs full cleanup then termination behavior in `src/main.rs`. 
- Updated `config.toml` and `docs/config.md` to document the new `system_bindings` options and explicitly describe priority semantics with an `Escape` conflict example. 
- Added unit tests for routing precedence scenarios in `src/app_state.rs` (exit before bookmark/UI hint, panic reset before exclusive modes, and escape conflict cases). 

### Testing
- Ran `cargo fmt --all` successfully. 
- Added unit tests and attempted `cargo test -q`, but the test run failed in this environment due to a missing system library required by the `x11` crate (`pkg-config` could not find `xi`), so automated tests could not complete here. 
- The new tests include `KeyChord` matcher tests and `AppState` routing precedence tests (present under `src/key_chord.rs` and `src/app_state.rs`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14dbf1a4408332b426ca5df5280d3f)