### PR TITLE
Persist resolved key-down bindings and release exact actions on key-up

### DIFF
--- a/src/action_handler.rs
+++ b/src/action_handler.rs
@@ -2382,13 +2382,11 @@ mod tests {
         handler.clear_runtime_input_state();
 
         assert!(!handler.mouse_master.left_button_held());
-        assert!(
-            handler
-                .mouse_master
-                .backend
-                .button_ups
-                .contains(&Button::Left)
-        );
+        assert!(handler
+            .mouse_master
+            .backend
+            .button_ups
+            .contains(&Button::Left));
     }
 
     #[test]

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -97,6 +97,7 @@ pub struct AppState {
     bound_chords: HashSet<KeyChord>,
     active_keys: HashSet<VirtualKey>,
     active_trigger_chords: HashSet<KeyChord>,
+    active_triggers: std::collections::HashMap<VirtualKey, ActiveTrigger>,
     owned_modifiers: HashSet<VirtualKey>,
     held_physical_keys: HashSet<VirtualKey>,
     swallow_owned_modifiers: bool,
@@ -111,6 +112,14 @@ pub struct AppState {
     system_bindings: RuntimeSystemBindings,
     help_visible: bool,
     grid_direction_labels: GridDirectionLabels,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ActiveTrigger {
+    pub trigger_key: VirtualKey,
+    pub resolved_chord: KeyChord,
+    pub resolved_action: Action,
+    pub is_continuous: bool,
 }
 
 #[derive(Debug)]
@@ -232,6 +241,7 @@ impl Default for AppState {
             bound_chords: HashSet::new(),
             active_keys: HashSet::new(),
             active_trigger_chords: HashSet::new(),
+            active_triggers: std::collections::HashMap::new(),
             owned_modifiers: HashSet::new(),
             held_physical_keys: HashSet::new(),
             swallow_owned_modifiers: true,
@@ -313,6 +323,7 @@ impl AppState {
     pub fn clear_active_action_keys(&mut self) {
         self.active_keys.clear();
         self.active_trigger_chords.clear();
+        self.active_triggers.clear();
     }
 
     pub fn clear_active_action_keys_and_exit_exclusive_modes(&mut self) {
@@ -919,7 +930,7 @@ impl AppState {
         swallow
     }
 
-    pub fn route_key_event(&mut self, event: KeyEvent, action: Option<Action>) {
+    pub fn route_key_event(&mut self, event: KeyEvent, mut action: Option<Action>) {
         if self.help_visible && event.is_down && event.key == VirtualKey::Escape {
             self.enqueue_command(AppCommand::HideHelp);
             return;
@@ -1048,12 +1059,13 @@ impl AppState {
         if event.is_down {
             self.active_keys.insert(event.key);
             self.held_physical_keys.insert(event.key);
-            if action.is_some() {
-                self.track_active_trigger_chord(event);
+            if let Some(resolved_action) = action.clone() {
+                self.track_active_trigger(event, resolved_action);
             }
         } else {
             self.active_keys.remove(&event.key);
             self.held_physical_keys.remove(&event.key);
+            action = self.resolve_key_up_action(event, action);
         }
 
         if event.is_down && matches!(action.as_ref(), Some(Action::ShowHelp)) {
@@ -1133,14 +1145,6 @@ impl AppState {
 
         for command in self.commands_for_active_keys(event, action) {
             self.enqueue_command(command);
-        }
-
-        if !event.is_down {
-            self.active_trigger_chords
-                .retain(|chord| chord.key != event.key);
-            if self.debug_input {
-                eprintln!("[debug-input] active-trigger remove: {:?}", event.key);
-            }
         }
     }
 
@@ -1224,7 +1228,7 @@ impl AppState {
         false
     }
 
-    fn track_active_trigger_chord(&mut self, event: KeyEvent) {
+    fn track_active_trigger(&mut self, event: KeyEvent, action: Action) {
         if let Some(chord) = self
             .bound_chords
             .iter()
@@ -1232,11 +1236,42 @@ impl AppState {
             .max_by_key(|chord| chord.specificity())
             .copied()
         {
+            self.active_triggers.insert(
+                event.key,
+                ActiveTrigger {
+                    trigger_key: event.key,
+                    resolved_chord: chord,
+                    resolved_action: action.clone(),
+                    is_continuous: action.is_continuous(),
+                },
+            );
             self.active_trigger_chords.insert(chord);
             if self.debug_input {
                 eprintln!("[debug-input] active-trigger add: {:?}", chord);
             }
         }
+    }
+
+    fn resolve_key_up_action(
+        &mut self,
+        event: KeyEvent,
+        fallback: Option<Action>,
+    ) -> Option<Action> {
+        if let Some(active_trigger) = self.active_triggers.remove(&event.key) {
+            self.active_trigger_chords
+                .remove(&active_trigger.resolved_chord);
+            if self.debug_input {
+                eprintln!(
+                    "[debug-input] active-trigger remove: {:?}",
+                    active_trigger.resolved_chord
+                );
+            }
+            if active_trigger.is_continuous {
+                return Some(active_trigger.resolved_action);
+            }
+            return None;
+        }
+        fallback
     }
 
     fn debug_swallow(&self, reason: &str, event: &KeyEvent, swallow: bool) {

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -696,6 +696,12 @@ pub struct KeyBindings {
     bindings: Vec<(KeyChord, Action)>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedBinding {
+    pub chord: KeyChord,
+    pub action: Action,
+}
+
 impl KeyBindings {
     /// Create a new KeyBindings instance
     pub fn new() -> Self {
@@ -737,26 +743,58 @@ impl KeyBindings {
             .find_map(|(bound_chord, action)| (*bound_chord == chord).then_some(action))
     }
 
-    pub fn get_action_for_event(&self, event: &KeyEvent) -> Option<Action> {
-        if let Some(action) = self
-            .bindings
-            .iter()
-            .find_map(|(chord, action)| chord.matches_event(event).then(|| action.clone()))
-        {
-            return Some(action);
+    pub fn resolve_for_key_down_event(
+        &self,
+        event: &KeyEvent,
+        shift_can_modify_plain_movement: bool,
+    ) -> Option<ResolvedBinding> {
+        if !event.is_down {
+            return None;
         }
 
-        if event.is_down {
-            return self.bindings.iter().find_map(|(chord, action)| {
-                chord
-                    .matches_event_allowing_shift_modifier(event)
-                    .then(|| action.clone())
+        if let Some((chord, action)) = self
+            .bindings
+            .iter()
+            .find(|(chord, _)| chord.matches_event(event))
+        {
+            return Some(ResolvedBinding {
+                chord: *chord,
+                action: action.clone(),
             });
         }
 
-        self.bindings
+        if let Some((chord, action)) = self
+            .bindings
             .iter()
-            .find_map(|(chord, action)| (chord.key == event.key).then(|| action.clone()))
+            .find(|(chord, _)| chord.matches_key_down_event(event))
+        {
+            return Some(ResolvedBinding {
+                chord: *chord,
+                action: action.clone(),
+            });
+        }
+
+        if !shift_can_modify_plain_movement {
+            return None;
+        }
+
+        self.bindings.iter().find_map(|(chord, action)| {
+            chord
+                .matches_event_allowing_shift_modifier(event)
+                .then(|| ResolvedBinding {
+                    chord: *chord,
+                    action: action.clone(),
+                })
+        })
+    }
+
+    pub fn get_action_for_event(
+        &self,
+        event: &KeyEvent,
+        shift_can_modify_plain_movement: bool,
+    ) -> Option<Action> {
+        self.resolve_for_key_down_event(event, shift_can_modify_plain_movement)
+            .map(|resolved| resolved.action)
     }
 
     pub fn bound_chords(&self) -> impl Iterator<Item = KeyChord> + '_ {
@@ -938,14 +976,17 @@ mod tests {
         event.right_alt_down = true;
 
         assert_eq!(
-            bindings.get_action_for_event(&event),
+            bindings.get_action_for_event(&event, true),
             Some(Action::MoveToTopEdge)
         );
 
         event.alt_down = false;
         event.right_alt_down = false;
 
-        assert_eq!(bindings.get_action_for_event(&event), Some(Action::MoveUp));
+        assert_eq!(
+            bindings.get_action_for_event(&event, true),
+            Some(Action::MoveUp)
+        );
     }
 
     #[test]
@@ -956,7 +997,10 @@ mod tests {
         let mut event = KeyEvent::new(VirtualKey::W, true);
         event.shift_down = true;
 
-        assert_eq!(bindings.get_action_for_event(&event), Some(Action::MoveUp));
+        assert_eq!(
+            bindings.get_action_for_event(&event, true),
+            Some(Action::MoveUp)
+        );
     }
 
     #[test]
@@ -973,7 +1017,7 @@ mod tests {
         event.right_alt_down = true;
 
         assert_eq!(
-            bindings.get_action_for_event(&event),
+            bindings.get_action_for_event(&event, true),
             Some(Action::MoveToTopEdge)
         );
     }
@@ -986,7 +1030,82 @@ mod tests {
         let mut event = KeyEvent::new(VirtualKey::W, true);
         event.ctrl_down = true;
 
-        assert_eq!(bindings.get_action_for_event(&event), None);
+        assert_eq!(bindings.get_action_for_event(&event, true), None);
+    }
+
+    #[test]
+    fn shift_exact_binding_wins_over_plain_binding() {
+        let mut bindings = KeyBindings::new();
+        bindings.add_chord_binding(KeyChord::parse("E").unwrap(), Action::MoveRight);
+        bindings.add_chord_binding(KeyChord::parse("Shift+E").unwrap(), Action::MoveLeft);
+
+        let mut event = KeyEvent::new(VirtualKey::E, true);
+        event.shift_down = true;
+
+        assert_eq!(
+            bindings
+                .resolve_for_key_down_event(&event, true)
+                .map(|r| r.action),
+            Some(Action::MoveLeft)
+        );
+    }
+
+    #[test]
+    fn shift_falls_back_to_plain_when_enabled_and_shift_binding_absent() {
+        let mut bindings = KeyBindings::new();
+        bindings.add_chord_binding(KeyChord::parse("E").unwrap(), Action::MoveRight);
+        let mut event = KeyEvent::new(VirtualKey::E, true);
+        event.shift_down = true;
+        assert_eq!(
+            bindings
+                .resolve_for_key_down_event(&event, true)
+                .map(|r| r.action),
+            Some(Action::MoveRight)
+        );
+    }
+
+    #[test]
+    fn shift_does_not_fallback_to_plain_when_disabled() {
+        let mut bindings = KeyBindings::new();
+        bindings.add_chord_binding(KeyChord::parse("E").unwrap(), Action::MoveRight);
+        let mut event = KeyEvent::new(VirtualKey::E, true);
+        event.shift_down = true;
+        assert_eq!(bindings.resolve_for_key_down_event(&event, false), None);
+    }
+
+    #[test]
+    fn right_alt_then_alt_then_plain_precedence() {
+        let mut bindings = KeyBindings::new();
+        bindings.add_chord_binding(KeyChord::parse("W").unwrap(), Action::MoveUp);
+        bindings.add_chord_binding(KeyChord::parse("Alt+W").unwrap(), Action::MoveDown);
+        bindings.add_chord_binding(KeyChord::parse("RightAlt+W").unwrap(), Action::MoveLeft);
+
+        let mut ralt = KeyEvent::new(VirtualKey::W, true);
+        ralt.alt_down = true;
+        ralt.right_alt_down = true;
+        assert_eq!(
+            bindings
+                .resolve_for_key_down_event(&ralt, true)
+                .map(|r| r.action),
+            Some(Action::MoveLeft)
+        );
+
+        let mut alt = KeyEvent::new(VirtualKey::W, true);
+        alt.alt_down = true;
+        assert_eq!(
+            bindings
+                .resolve_for_key_down_event(&alt, true)
+                .map(|r| r.action),
+            Some(Action::MoveDown)
+        );
+
+        let plain = KeyEvent::new(VirtualKey::W, true);
+        assert_eq!(
+            bindings
+                .resolve_for_key_down_event(&plain, true)
+                .map(|r| r.action),
+            Some(Action::MoveUp)
+        );
     }
 
     #[test]
@@ -1000,7 +1119,7 @@ mod tests {
             event.shift_down = true;
 
             assert_eq!(
-                bindings.get_action_for_event(&event),
+                bindings.get_action_for_event(&event, true),
                 Some(Action::SlowMouse),
                 "{key:?}"
             );

--- a/src/main.rs
+++ b/src/main.rs
@@ -343,6 +343,7 @@ lazy_static! {
         RwLock::new(handler)
     };
     static ref KEY_ACTIONS: RwLock<KeyBindings> = RwLock::new(KeyBindings::new());
+    static ref SHIFT_CAN_MODIFY_PLAIN_MOVEMENT: RwLock<bool> = RwLock::new(true);
     static ref APP_STATE: RwLock<AppState> = RwLock::new(AppState::default());
     static ref CONFIG_WARNINGS: Mutex<Vec<StoredConfigWarning>> = Mutex::new(Vec::new());
     static ref UI_HINT_QUERY_TX: Mutex<Option<Sender<UiHintQueryResult>>> = Mutex::new(None);
@@ -2291,6 +2292,8 @@ impl Config {
         app_state.set_bound_chords(key_actions.bound_chords());
         app_state.set_owned_modifiers(key_actions.owned_modifiers());
         app_state.set_debug_input(self.input.debug_input);
+        *SHIFT_CAN_MODIFY_PLAIN_MOVEMENT.write().unwrap() =
+            self.input.shift_can_modify_plain_movement;
     }
 
     fn initialize_system_bindings(&self) -> Result<(), Box<dyn Error>> {
@@ -2781,7 +2784,11 @@ fn process_queued_key_events(debug_diagnostics: bool) -> LoopDiagnostics {
             break;
         };
 
-        let action = KEY_ACTIONS.read().unwrap().get_action_for_event(&event);
+        let shift_can_modify_plain_movement = *SHIFT_CAN_MODIFY_PLAIN_MOVEMENT.read().unwrap();
+        let action = KEY_ACTIONS
+            .read()
+            .unwrap()
+            .get_action_for_event(&event, shift_can_modify_plain_movement);
 
         if debug_diagnostics && should_log_routing_event(&event, action.clone()) {
             println!(
@@ -5617,7 +5624,7 @@ mod tests {
             (VirtualKey::K, Action::MoveDown),
         ] {
             let event = KeyEvent::new(key, true);
-            let resolved = bindings.get_action_for_event(&event);
+            let resolved = bindings.get_action_for_event(&event, true);
             app_state.route_key_event(event, resolved);
             assert_eq!(
                 app_state.pop_command(),
@@ -5626,7 +5633,7 @@ mod tests {
         }
 
         assert_eq!(
-            bindings.get_action_for_event(&KeyEvent::new(VirtualKey::W, true)),
+            bindings.get_action_for_event(&KeyEvent::new(VirtualKey::W, true), true),
             None
         );
         assert_eq!(


### PR DESCRIPTION
### Motivation
- Key handling should deterministically resolve a single binding on key-down and ensure key-up releases that exact resolved action rather than re-resolving heuristically.
- Shift/RightAlt precedence and an optional shift-relaxed fallback need to be respected consistently across down/up lifecycle.
- One-shot (non-continuous) actions must not leave continuous actions active after key-up.

### Description
- Introduced `ResolvedBinding` in `src/keyboard.rs` and implemented `resolve_for_key_down_event` that deterministically resolves key-down bindings in the order: exact full-chord, less-specific matches, then optional shift-relaxed plain fallback controlled by `shift_can_modify_plain_movement`, and `get_action_for_event` now accepts the runtime `shift_can_modify_plain_movement` flag. 
- Added `ActiveTrigger` and an `active_triggers: HashMap<VirtualKey, ActiveTrigger>` to `AppState` in `src/app_state.rs` to persist the resolved chord/action and whether it is continuous, and updated `route_key_event` to store the resolved action on key-down and consult that stored trigger on key-up. 
- Key-up handling now returns the exact stored resolved action for continuous actions and clears the trigger entry without performing generic re-resolution, and one-shot actions clear trigger state without leaving continuous actions active. 
- Exposed `shift_can_modify_plain_movement` at runtime via a new `SHIFT_CAN_MODIFY_PLAIN_MOVEMENT` static in `src/main.rs` and passed it into key resolution during event processing. 
- Added and updated unit tests in `src/keyboard.rs` to cover `Shift+E` vs `E` precedence, shift fallback enabled/disabled, `RightAlt+W` vs `Alt+W` vs `W` precedence, and related resolution behavior.

### Testing
- Ran `cargo fmt` and formatting completed successfully. 
- Attempted `cargo test -q` but the test run failed in this container due to a missing system dependency (X11 `xi` / `xi.pc`) required by the `x11` crate during build, so the Rust test suite could not be executed here. 
- Added unit tests for the new resolver logic in `src/keyboard.rs` (see tests for shifted precedence, shift fallback, and RightAlt/Alt/plain precedence) which are included in the patch but were not executed end-to-end due to the environment issue above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14e48bb1dc8332ad5757eb43837844)