### PR TITLE
Add periodic stale-key reconciliation and tests

### DIFF
--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -25,7 +25,6 @@ pub struct KeyEvent {
 }
 
 impl KeyEvent {
-    #[cfg(test)]
     pub fn new(key: VirtualKey, is_down: bool) -> Self {
         Self {
             key,
@@ -301,6 +300,44 @@ impl AppState {
 
     pub fn set_debug_input(&mut self, enabled: bool) {
         self.debug_input = enabled;
+    }
+
+    pub fn reconcile_stale_keys<F>(&mut self, mut is_key_physically_down: F)
+    where
+        F: FnMut(VirtualKey) -> bool,
+    {
+        let stale_keys: Vec<VirtualKey> = self
+            .held_physical_keys
+            .iter()
+            .copied()
+            .filter(|key| !is_key_physically_down(*key))
+            .collect();
+
+        for key in stale_keys {
+            let stale_owned_modifier = self.owned_modifiers.contains(&key);
+            let stale_trigger = self.active_triggers.contains_key(&key);
+            let mut synthesized_action = None;
+
+            self.held_physical_keys.remove(&key);
+            self.active_keys.remove(&key);
+            if stale_trigger {
+                synthesized_action = self.resolve_key_up_action(KeyEvent::new(key, false), None);
+            }
+
+            if let Some(action) = synthesized_action {
+                self.enqueue_command(AppCommand::KeyAction {
+                    action,
+                    is_down: false,
+                });
+            }
+
+            if self.debug_input {
+                eprintln!(
+                    "[debug-input] reconciled stale key={:?} trigger={} owned_modifier={}",
+                    key, stale_trigger, stale_owned_modifier
+                );
+            }
+        }
     }
 
     pub fn set_active_mode(&mut self, active_mode: bool) {
@@ -3316,5 +3353,67 @@ mod tests {
             collect_commands(&mut state),
             vec![AppCommand::CancelBookmarkMode]
         );
+    }
+
+    #[test]
+    fn reconcile_releases_stale_move_trigger() {
+        let mut state = state_with_bound_key(VirtualKey::E);
+        state.route_key_event(KeyEvent::new(VirtualKey::E, true), Some(Action::MoveUp));
+        assert_eq!(collect_commands(&mut state).len(), 1);
+
+        state.reconcile_stale_keys(|_| false);
+
+        assert_eq!(
+            collect_commands(&mut state),
+            vec![AppCommand::KeyAction {
+                action: Action::MoveUp,
+                is_down: false,
+            }]
+        );
+    }
+
+    #[test]
+    fn reconcile_releases_stale_slow_mouse_trigger() {
+        let mut state = state_with_bound_key(VirtualKey::LeftShift);
+        state.route_key_event(
+            KeyEvent::new(VirtualKey::LeftShift, true),
+            Some(Action::SlowMouse),
+        );
+        assert_eq!(collect_commands(&mut state).len(), 1);
+
+        state.reconcile_stale_keys(|_| false);
+
+        assert_eq!(
+            collect_commands(&mut state),
+            vec![AppCommand::KeyAction {
+                action: Action::SlowMouse,
+                is_down: false,
+            }]
+        );
+    }
+
+    #[test]
+    fn reconcile_clears_owned_modifier_when_physically_up() {
+        let mut state = AppState::default();
+        state.set_owned_modifiers([VirtualKey::RightAlt]);
+        state.route_key_event(KeyEvent::new(VirtualKey::RightAlt, true), None);
+        state.route_key_event(KeyEvent::new(VirtualKey::A, true), Some(Action::MoveLeft));
+        assert!(state.should_swallow_key(&KeyEvent::new(VirtualKey::RightAlt, true)));
+
+        state.reconcile_stale_keys(|key| key != VirtualKey::RightAlt);
+
+        assert!(!state.should_swallow_key(&KeyEvent::new(VirtualKey::RightAlt, true)));
+    }
+
+    #[test]
+    fn reconcile_removes_active_trigger_for_stale_key() {
+        let mut state = state_with_bound_key(VirtualKey::E);
+        state.route_key_event(KeyEvent::new(VirtualKey::E, true), Some(Action::MoveUp));
+        let up = KeyEvent::new(VirtualKey::E, false);
+        assert!(state.should_swallow_key(&up));
+
+        state.reconcile_stale_keys(|_| false);
+
+        assert!(!state.should_swallow_key(&up));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2686,6 +2686,19 @@ fn modifier_down(vk_code: i32) -> bool {
     unsafe { (GetAsyncKeyState(vk_code) & i16::MIN) != 0 }
 }
 
+fn should_run_modifier_reconcile(
+    config: &InputConfig,
+    elapsed_since_last_reconcile: Duration,
+) -> bool {
+    if !config.modifier_reconcile_on_tick {
+        return false;
+    }
+    let cadence_ms = config
+        .modifier_reconcile_interval_ms
+        .max(config.stuck_key_timeout_ms);
+    elapsed_since_last_reconcile >= Duration::from_millis(cadence_ms)
+}
+
 fn decode_key_event(w_param: WPARAM, kbd: KBDLLHOOKSTRUCT) -> Option<KeyEvent> {
     let key = VirtualKey::from_vk_code(kbd.vkCode)?;
     let is_down = w_param.0 as u32 == WM_KEYDOWN || w_param.0 as u32 == WM_SYSKEYDOWN;
@@ -4769,6 +4782,7 @@ fn main() {
     let (ui_query_tx, ui_query_rx) = mpsc::channel::<UiHintQueryResult>();
     *UI_HINT_QUERY_TX.lock().unwrap() = Some(ui_query_tx);
     *UI_HINT_QUERY_RX.lock().unwrap() = Some(ui_query_rx);
+    let mut last_modifier_reconcile = Instant::now();
 
     loop {
         let mut loop_diagnostics = LoopDiagnostics {
@@ -4780,6 +4794,16 @@ fn main() {
         process_ui_hint_query_timeout();
         process_ui_hint_query_results();
         loop_diagnostics.add(process_queued_key_events(debug_diagnostics));
+
+        if should_run_modifier_reconcile(&config.input, last_modifier_reconcile.elapsed()) {
+            APP_STATE
+                .write()
+                .unwrap()
+                .reconcile_stale_keys(|key| modifier_down(key.to_vk_code() as i32));
+            last_modifier_reconcile = Instant::now();
+            loop_diagnostics.add(process_queued_key_events(debug_diagnostics));
+        }
+
         {
             let mut action_handler = ACTION_HANDLER.write().unwrap();
             drain_runtime_notifications(&mut action_handler);
@@ -7800,5 +7824,38 @@ mod bookmark_runtime_logic_tests {
         c.desktop_behavior = "focus_anchor_window".into();
         let (x, y) = resolve_recall_target(&record, &c);
         assert_eq!((x, y), (42, 24));
+    }
+
+    #[test]
+    fn modifier_reconcile_is_cadence_gated() {
+        let mut input = InputConfig::default();
+        input.modifier_reconcile_on_tick = true;
+        input.modifier_reconcile_interval_ms = 50;
+        input.stuck_key_timeout_ms = 1500;
+
+        assert!(!should_run_modifier_reconcile(
+            &input,
+            Duration::from_millis(1499)
+        ));
+        assert!(should_run_modifier_reconcile(
+            &input,
+            Duration::from_millis(1500)
+        ));
+
+        input.stuck_key_timeout_ms = 10;
+        assert!(!should_run_modifier_reconcile(
+            &input,
+            Duration::from_millis(49)
+        ));
+        assert!(should_run_modifier_reconcile(
+            &input,
+            Duration::from_millis(50)
+        ));
+
+        input.modifier_reconcile_on_tick = false;
+        assert!(!should_run_modifier_reconcile(
+            &input,
+            Duration::from_millis(5000)
+        ));
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent actions from getting stuck when the app thinks a key is held but the physical key has been released by synthesizing appropriate releases and clearing trigger bookkeeping.
- Ensure movement, wheel, slow/surgical/scroll modifiers and owned modifiers are reconciled against the physical keyboard state so continuous behaviors are not left running indefinitely.

### Description
- Add `AppState::reconcile_stale_keys` in `src/app_state.rs` which iterates `held_physical_keys`, queries a provided physical-key predicate, clears stale bookkeeping, and synthesizes `AppCommand::KeyAction { is_down: false }` for stale continuous triggers while emitting debug logs when `debug_input=true`.
- Hook reconciliation into the main loop in `src/main.rs` via a new `should_run_modifier_reconcile` helper and a periodic call gated by `input.modifier_reconcile_on_tick` and a cadence computed from `modifier_reconcile_interval_ms` and `stuck_key_timeout_ms` (uses the max to avoid over-eager releases).
- The reconcile pass clears `held_physical_keys` and `active_keys`, uses existing `resolve_key_up_action` to remove active triggers and to queue release commands for continuous actions, and logs reconciled keys when `debug_input` is enabled.
- Add unit tests covering stale-key scenarios and cadence gating: `reconcile_releases_stale_move_trigger`, `reconcile_releases_stale_slow_mouse_trigger`, `reconcile_clears_owned_modifier_when_physically_up`, `reconcile_removes_active_trigger_for_stale_key`, and `modifier_reconcile_is_cadence_gated`.

### Testing
- Ran `cargo fmt` successfully to format changes.
- Attempted to run the reconciliation-focused unit tests with `cargo test`, but the test run failed in this environment during dependency build due to a missing system library required by the `x11` crate (`xi.pc` / `xi` package), so the new tests could not be executed end-to-end here.
- Unit tests were added to `src/app_state.rs` and a cadence test was added to `src/main.rs` and are expected to pass in an environment with the native `x11` dependencies installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14e6f1b6048332b421a48239e7e179)