### PR TITLE
Gate debug-only PAINT_SMOKE_LOG lazy_static to fix release build

### DIFF
--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -27,8 +27,10 @@ lazy_static::lazy_static! {
             None
         }
     }));
+}
 
-    #[cfg(debug_assertions)]
+#[cfg(debug_assertions)]
+lazy_static::lazy_static! {
     static ref PAINT_SMOKE_LOG: Mutex<PaintSmokeLog> = Mutex::new(PaintSmokeLog::new());
 }
 


### PR DESCRIPTION
### Motivation
- Prevent release-mode compilation errors where the `lazy_static!` expansion for `PAINT_SMOKE_LOG` tried to reference the debug-only type `PaintSmokeLog` when that type is not compiled in release builds.

### Description
- Move the `PAINT_SMOKE_LOG` definition into its own `lazy_static!` block and add a block-level `#[cfg(debug_assertions)]` so the static is only expanded when debug assertions are enabled; `OVERLAY` remains in the unconditional `lazy_static!` block in `src/overlay.rs`.

### Testing
- Ran `cargo build --release`; the previous `lazy_static`/type errors in `src/overlay.rs` were resolved, but the build subsequently failed due to a missing system library `xi` required by the `x11` crate (missing `xi.pc`/pkg-config), which is an unrelated environment dependency.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15fe3594608332b48cd7062f3e8c49)