### PR TITLE
Update wheel defaults, profiles, and normalization/profile-resolution tests

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -267,41 +267,61 @@ show_direction_labels = true
 # Wheel speed and profiles
 # ---------------------------------------------------------------------------
 [wheel]
-default_speed = 3
+# Wheel level semantics:
+# - level 1 is roughly one wheel notch/event in many apps.
+# - higher levels increase per-event scroll distance (up to max_speed).
+# - level 10 is intentionally high and often page-like, depending on app behavior.
+default_speed = 1
 min_speed = 1
-max_speed = 12
+max_speed = 10
 speed_step = 1
-tick_interval = 8
+# tick_interval controls held-key repeat cadence for wheel actions (milliseconds).
+tick_interval = 120
 speed_indicator_ms = 700
 vertical_multiplier = 1
 horizontal_multiplier = 1
 
 # Preset examples. Cycle them with RightAlt+V / RightAlt+B or bind
 # wheel_profile:<name> directly.
-[wheel_profiles.fast]
-default_speed = 6
-min_speed = 1
-max_speed = 18
-speed_step = 2
-tick_interval = 8
-speed_indicator_ms = 700
-vertical_multiplier = 1
-horizontal_multiplier = 1
-
 [wheel_profiles.precise]
 default_speed = 1
 min_speed = 1
-max_speed = 5
+max_speed = 4
 speed_step = 1
-tick_interval = 12
+tick_interval = 180
 speed_indicator_ms = 700
 vertical_multiplier = 1
 horizontal_multiplier = 1
 
-[wheel_profiles.horizontal]
-default_speed = 3
-horizontal_multiplier = 3
+[wheel_profiles.normal]
+default_speed = 1
+min_speed = 1
+max_speed = 10
+speed_step = 1
+tick_interval = 120
+speed_indicator_ms = 700
 vertical_multiplier = 1
+horizontal_multiplier = 1
+
+[wheel_profiles.fast]
+default_speed = 3
+min_speed = 1
+max_speed = 10
+speed_step = 1
+tick_interval = 80
+speed_indicator_ms = 700
+vertical_multiplier = 1
+horizontal_multiplier = 1
+
+[wheel_profiles.page]
+default_speed = 10
+min_speed = 4
+max_speed = 10
+speed_step = 1
+tick_interval = 100
+speed_indicator_ms = 700
+vertical_multiplier = 1
+horizontal_multiplier = 1
 
 # ---------------------------------------------------------------------------
 # Jump mode, stages, visuals, and labels

--- a/docs/config.md
+++ b/docs/config.md
@@ -144,14 +144,16 @@ key_bindings = [
 | `grid_mode.move_cursor_each_step` | boolean | `true` | Yes | Active | Moves cursor as grid-mode selections narrow. |
 | `grid_mode.line_visible` | boolean | `true` | Yes | Active | Shows grid-mode guide line. |
 | `grid_mode.show_direction_labels` | boolean | `true` | Yes | Active | Shows grid-mode direction labels. |
-| `wheel.default_speed` | integer | `3` | Yes | Active | Base wheel speed. |
-| `wheel.min_speed` | integer | `1` | Yes | Active | Lower bound for wheel speed changes. |
-| `wheel.max_speed` | integer | `12` | Yes | Active | Upper bound for wheel speed changes. |
-| `wheel.speed_step` | integer | `1` | Yes | Active | Increment used by wheel speed up/down actions. |
-| `wheel.tick_interval` | integer milliseconds | `8` | Yes | Active | Wheel repeat interval. |
+| `wheel.default_speed` | integer | `1` | Yes | Active | Base wheel level (1 ≈ one notch/event in many apps; 10 is high/page-like in many apps). |
+| `wheel.min_speed` | integer | `1` | Yes | Active | Lower bound for wheel level changes. |
+| `wheel.max_speed` | integer | `10` | Yes | Active | Upper bound for wheel level changes. |
+| `wheel.speed_step` | integer | `1` | Yes | Active | Increment used by wheel level up/down actions. |
+| `wheel.tick_interval` | integer milliseconds | `120` | Yes | Active | Held-key wheel repeat cadence; lower values repeat faster. |
 | `wheel.speed_indicator_ms` | integer milliseconds | `700` | Yes | Active | Duration for wheel-speed feedback. |
 | `wheel.vertical_multiplier` | integer | `1` | Yes | Active | Vertical wheel multiplier. |
 | `wheel.horizontal_multiplier` | integer | `1` | Yes | Active | Horizontal wheel multiplier. |
+
+Wheel levels are interpreted by the target application. Some apps map level changes nearly linearly, while others apply custom acceleration or page-oriented behavior.
 | `wheel_profiles.*.default_speed` | integer | none | Yes | Active | Optional named wheel profile override. |
 | `wheel_profiles.*.min_speed` | integer | none | Yes | Active | Optional named wheel profile override. |
 | `wheel_profiles.*.max_speed` | integer | none | Yes | Active | Optional named wheel profile override. |

--- a/src/main.rs
+++ b/src/main.rs
@@ -1070,11 +1070,11 @@ pub struct WheelConfig {
 impl Default for WheelConfig {
     fn default() -> Self {
         Self {
-            default_speed: 3,
+            default_speed: 1,
             min_speed: 1,
-            max_speed: 12,
+            max_speed: 10,
             speed_step: 1,
-            tick_interval: DEFAULT_POLLING_RATE_MS,
+            tick_interval: 120,
             speed_indicator_ms: DEFAULT_WHEEL_SPEED_INDICATOR_MS,
             vertical_multiplier: 1,
             horizontal_multiplier: 1,
@@ -6305,6 +6305,93 @@ mod tests {
     }
 
     #[test]
+    fn wheel_defaults_match_config_defaults() {
+        let config = parse_config("");
+
+        assert_eq!(config.wheel.default_speed, 1);
+        assert_eq!(config.wheel.min_speed, 1);
+        assert_eq!(config.wheel.max_speed, 10);
+        assert_eq!(config.wheel.speed_step, 1);
+        assert_eq!(config.wheel.tick_interval, 120);
+    }
+
+    #[test]
+    fn wheel_profile_resolution_inherits_base_and_applies_overrides() {
+        let config = parse_config(
+            r#"
+            [wheel]
+            default_speed = 2
+            min_speed = 1
+            max_speed = 10
+            speed_step = 1
+            tick_interval = 120
+            speed_indicator_ms = 700
+            vertical_multiplier = 2
+            horizontal_multiplier = 3
+
+            [wheel_profiles.precise]
+            max_speed = 4
+            tick_interval = 180
+
+            [wheel_profiles.fast]
+            default_speed = 5
+            tick_interval = 80
+
+            [wheel_profiles.page]
+            default_speed = 10
+            min_speed = 4
+            tick_interval = 100
+            "#,
+        );
+
+        let precise = config.resolved_wheel_profile(Some("precise")).unwrap();
+        assert_eq!(precise.default_speed, 2);
+        assert_eq!(precise.min_speed, 1);
+        assert_eq!(precise.max_speed, 4);
+        assert_eq!(precise.tick_interval, 180);
+        assert_eq!(precise.vertical_multiplier, 2);
+        assert_eq!(precise.horizontal_multiplier, 3);
+
+        let fast = config.resolved_wheel_profile(Some("fast")).unwrap();
+        assert_eq!(fast.default_speed, 5);
+        assert_eq!(fast.min_speed, 1);
+        assert_eq!(fast.max_speed, 10);
+        assert_eq!(fast.tick_interval, 80);
+        assert_eq!(fast.vertical_multiplier, 2);
+        assert_eq!(fast.horizontal_multiplier, 3);
+
+        let page = config.resolved_wheel_profile(Some("page")).unwrap();
+        assert_eq!(page.default_speed, 10);
+        assert_eq!(page.min_speed, 4);
+        assert_eq!(page.max_speed, 10);
+        assert_eq!(page.tick_interval, 100);
+        assert_eq!(page.vertical_multiplier, 2);
+        assert_eq!(page.horizontal_multiplier, 3);
+    }
+
+    #[test]
+    fn wheel_default_speed_is_clamped_after_profile_min_max_overrides() {
+        let config = parse_config(
+            r#"
+            [wheel]
+            default_speed = 6
+            min_speed = 1
+            max_speed = 10
+            speed_step = 1
+            tick_interval = 120
+
+            [wheel_profiles.precise]
+            min_speed = 7
+            max_speed = 8
+            "#,
+        );
+
+        let precise = config.resolved_wheel_profile(Some("precise")).unwrap();
+        assert_eq!(precise.default_speed, 7);
+        assert_eq!(precise.min_speed, 7);
+        assert_eq!(precise.max_speed, 8);
+    }
+
     fn wheel_config_parses_and_normalizes_bounds() {
         let config = parse_config(
             r#"

--- a/src/main.rs
+++ b/src/main.rs
@@ -6803,7 +6803,7 @@ enabled = true"#,
 
         assert!(summary.contains("polling_rate=8ms"));
         assert!(summary.contains("mouse_speed default=1 range=1..12 step=1 profiles=1"));
-        assert!(summary.contains("wheel default=3 range=1..12 step=1 tick=8ms"));
+        assert!(summary.contains("wheel default=1 range=1..10 step=1 tick=120ms"));
         assert!(summary.contains("slow_mouse strategy=Fixed speed=1 (default 1, range 1..2) acceleration=0 every 1 tick(s)"));
         assert!(summary.contains("features: [enabled, bindings]"));
         assert!(summary.contains("surgical_mode: enabled=false bindings=0"));


### PR DESCRIPTION
### Motivation

- Make wheel settings level-oriented (1..10) and document that `tick_interval` governs held-key repeat cadence for wheel actions.
- Provide clearer, opinionated wheel profile presets (`precise`, `normal`, `fast`, `page`) for common usage patterns.
- Ensure runtime defaults, normalization, and profile resolution behave predictably (defaults clamped to profile bounds and profile overrides inherit base fields).

### Description

- Updated `config.toml` `[wheel]` defaults to `default_speed = 1`, `min_speed = 1`, `max_speed = 10`, `speed_step = 1`, `tick_interval = 120`, kept both multipliers at `1`, and rewrote surrounding comments to explain wheel "level" semantics and `tick_interval` interpretation.
- Replaced/added wheel profile presets in `config.toml` with explicit `precise` (`tick_interval = 180`, lower top-end), `normal` (balanced), `fast` (`tick_interval = 80`, shorter cadence), and `page` (high level, medium cadence).
- Aligned `WheelConfig::default()` in `src/main.rs` to the new baseline defaults and left existing normalization safeguards in place so `default_speed` is clamped to `min_speed`/`max_speed` and `min/max/step/tick` are validated.
- Verified and preserved profile resolution logic: `resolved_wheel_profile` inherits the base `wheel` then `resolve_wheel_profile_from` applies per-field overrides for all wheel fields (`default_speed`, `min_speed`, `max_speed`, `speed_step`, `tick_interval`, `speed_indicator_ms`, `vertical_multiplier`, `horizontal_multiplier`) and normalization is run via `normalize_wheel_settings`.
- Updated `docs/config.md` wheel entries to clarify level semantics (e.g. `1` ≈ one notch/event; `10` often page-like) and added an app-specific interpretation caveat.
- Added unit tests to `src/main.rs` to assert the new defaults and to verify profile-resolution inheritance and normalization interactions for `precise`, `fast`, and `page` profiles.
- No changes required to `src/config_audit.rs` because it already accepts the active wheel keys and wildcard profile paths.

### Testing

- Added unit tests: `wheel_defaults_match_config_defaults`, `wheel_profile_resolution_inherits_base_and_applies_overrides`, and `wheel_default_speed_is_clamped_after_profile_min_max_overrides` in `src/main.rs` (these are included in the repository changes).
- Attempted to run `cargo test wheel_ -- --nocapture` in the current environment but the build failed due to a missing system dependency required by the `x11` crate (pkg-config/`xi` system library); therefore tests could not be executed here and should be validated in CI or an environment with the native `xi` development package available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a160f4590b88332be52ed3897af789a)