### PR TITLE
Add input stale-key config, normalization, docs and tests

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -20,19 +20,6 @@ acceleration = 2
 acceleration_rate = 1
 top_speed = 6
 
-# Input ownership/reconciliation controls.
-[input]
-swallow_owned_modifiers = true
-modifier_reconcile_on_tick = true
-modifier_reconcile_interval_ms = 50
-# Stale-key recovery: if a tracked held key has not produced expected transitions
-# for this timeout window, it may be treated as stuck and reconciled against
-# current OS modifier state. Reconciliation cadence is max(interval, timeout), so
-# this timeout effectively gates how often stale key recovery checks can run.
-stuck_key_timeout_ms = 10000
-debug_input = false
-shift_can_modify_plain_movement = true
-
 # ---------------------------------------------------------------------------
 # Key and system bindings
 # ---------------------------------------------------------------------------
@@ -121,6 +108,19 @@ key_bindings = [
     ["RightAlt+F14", "clear_mouse_positions"],
     ["RightAlt+F15", "position_history_mode"]
 ]
+
+# Input ownership/reconciliation controls.
+[input]
+swallow_owned_modifiers = true
+modifier_reconcile_on_tick = true
+modifier_reconcile_interval_ms = 50
+# Stale-key recovery: if a tracked held key has not produced expected transitions
+# for this timeout window, it may be treated as stuck and reconciled against
+# current OS modifier state. Reconciliation cadence is max(interval, timeout), so
+# this timeout effectively gates how often stale key recovery checks can run.
+stuck_key_timeout_ms = 10000
+debug_input = false
+shift_can_modify_plain_movement = true
 
 [ui_hints]
 enabled = true

--- a/config.toml
+++ b/config.toml
@@ -20,6 +20,19 @@ acceleration = 2
 acceleration_rate = 1
 top_speed = 6
 
+# Input ownership/reconciliation controls.
+[input]
+swallow_owned_modifiers = true
+modifier_reconcile_on_tick = true
+modifier_reconcile_interval_ms = 50
+# Stale-key recovery: if a tracked held key has not produced expected transitions
+# for this timeout window, it may be treated as stuck and reconciled against
+# current OS modifier state. Reconciliation cadence is max(interval, timeout), so
+# this timeout effectively gates how often stale key recovery checks can run.
+stuck_key_timeout_ms = 10000
+debug_input = false
+shift_can_modify_plain_movement = true
+
 # ---------------------------------------------------------------------------
 # Key and system bindings
 # ---------------------------------------------------------------------------

--- a/docs/config.md
+++ b/docs/config.md
@@ -106,8 +106,8 @@ key_bindings = [
 | `system_bindings.panic_reset_sets_idle` | boolean | `true` | Yes | Active | When true, panic reset also sets idle mode (`SetActiveMode { active = false }`). |
 | `input.swallow_owned_modifiers` | boolean | `true` | Yes | Active | Swallow app-owned modifier down/up transitions while active mode is enabled. |
 | `input.modifier_reconcile_on_tick` | boolean | `true` | Yes | Active | Enables periodic modifier reconciliation checks. |
-| `input.modifier_reconcile_interval_ms` | integer milliseconds | `50` | Yes | Active | Poll interval for modifier reconciliation. |
-| `input.stuck_key_timeout_ms` | integer milliseconds | `1500` | Yes | Active | Timeout used to classify stale held keys as stuck. |
+| `input.modifier_reconcile_interval_ms` | integer milliseconds | `50` | Yes | Active | Base polling interval for modifier reconciliation; normalized to `10..=5000` and reset to default when `0`. |
+| `input.stuck_key_timeout_ms` | integer milliseconds | `10000` | Yes | Active | Timeout used to classify stale held keys as stuck; normalized to `500..=60000` and reset to default when `0`. |
 | `input.debug_input` | boolean | `false` | Yes | Active | Enables verbose debug-input logs (raw keys, swallow reasons, system matches, trigger tracking). |
 | `input.shift_can_modify_plain_movement` | boolean | `true` | Yes | Active | Keeps shift-relaxed plain-movement matching enabled. |
 | `mouse_speed.default_speed` | integer | `1` | Yes | Active | Normal held-movement speed and replacement for legacy `starting_speed`. |
@@ -381,6 +381,7 @@ font_scale = 1.1
 
 - `selection_keys` removes whitespace, uppercases alpha keys, and removes duplicates while preserving first occurrence order.
 - Values outside supported ranges are normalized and logged as config warnings so the mode remains usable.
+- For input stale-key recovery, reconcile cadence is `max(input.modifier_reconcile_interval_ms, input.stuck_key_timeout_ms)`, so the timeout can effectively gate how often reconcile ticks run.
 - Duplicate and deeply nested UIA controls are common in complex apps; increase `min_hint_spacing_px` to reduce visual crowding.
 - When many controls are visible (for example browsers/Electron apps), results may be capped by `max_hints`; consider larger `selection_keys` and spacing tuning before raising the cap aggressively.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -510,7 +510,7 @@ impl Default for InputConfig {
             swallow_owned_modifiers: true,
             modifier_reconcile_on_tick: true,
             modifier_reconcile_interval_ms: 50,
-            stuck_key_timeout_ms: 1500,
+            stuck_key_timeout_ms: 10_000,
             debug_input: false,
             shift_can_modify_plain_movement: true,
         }
@@ -1632,6 +1632,7 @@ impl Config {
         self.normalize_tooltip_overlay_config();
         self.normalize_ui_hints_config();
         self.normalize_bookmarks_config();
+        self.normalize_input_config();
         // Keep the legacy field stable for downstream code and diagnostics after the
         // modern baseline has won normalization.
         self.starting_speed = self.mouse_speed.default_speed;
@@ -1794,6 +1795,24 @@ impl Config {
             );
             self.bookmarks.desktop_behavior = "focus_anchor_window".to_string();
         }
+    }
+
+    fn normalize_input_config(&mut self) {
+        if self.input.modifier_reconcile_interval_ms == 0 {
+            warn_config_normalized("input.modifier_reconcile_interval_ms is 0; using default");
+            self.input.modifier_reconcile_interval_ms =
+                InputConfig::default().modifier_reconcile_interval_ms;
+        }
+        self.input.modifier_reconcile_interval_ms = self
+            .input
+            .modifier_reconcile_interval_ms
+            .clamp(10, 5_000);
+
+        if self.input.stuck_key_timeout_ms == 0 {
+            warn_config_normalized("input.stuck_key_timeout_ms is 0; using default");
+            self.input.stuck_key_timeout_ms = InputConfig::default().stuck_key_timeout_ms;
+        }
+        self.input.stuck_key_timeout_ms = self.input.stuck_key_timeout_ms.clamp(500, 60_000);
     }
 
     fn normalize_final_adjust_config(&mut self) {
@@ -2687,6 +2706,10 @@ fn should_run_modifier_reconcile(
     if !config.modifier_reconcile_on_tick {
         return false;
     }
+    // Reconciliation must run no faster than either interval:
+    // - modifier_reconcile_interval_ms: regular polling cadence
+    // - stuck_key_timeout_ms: stale key recovery timeout
+    // The max() means stale key timeout effectively gates the cadence.
     let cadence_ms = config
         .modifier_reconcile_interval_ms
         .max(config.stuck_key_timeout_ms);
@@ -6455,6 +6478,63 @@ mod tests {
     }
 
     #[test]
+    fn input_config_default_uses_ten_second_stuck_timeout() {
+        let config = parse_config("");
+        assert_eq!(config.input.stuck_key_timeout_ms, 10_000);
+    }
+
+    #[test]
+    fn input_config_parses_overrides_from_toml() {
+        let config = parse_config(
+            r#"
+            [input]
+            swallow_owned_modifiers = false
+            modifier_reconcile_on_tick = false
+            modifier_reconcile_interval_ms = 250
+            stuck_key_timeout_ms = 12000
+            debug_input = true
+            shift_can_modify_plain_movement = false
+            "#,
+        );
+
+        assert!(!config.input.swallow_owned_modifiers);
+        assert!(!config.input.modifier_reconcile_on_tick);
+        assert_eq!(config.input.modifier_reconcile_interval_ms, 250);
+        assert_eq!(config.input.stuck_key_timeout_ms, 12_000);
+        assert!(config.input.debug_input);
+        assert!(!config.input.shift_can_modify_plain_movement);
+    }
+
+    #[test]
+    fn input_config_normalizes_zero_and_out_of_range_values() {
+        let zero = parse_config(
+            r#"
+            [input]
+            modifier_reconcile_interval_ms = 0
+            stuck_key_timeout_ms = 0
+            "#,
+        );
+        assert_eq!(
+            zero.input.modifier_reconcile_interval_ms,
+            InputConfig::default().modifier_reconcile_interval_ms
+        );
+        assert_eq!(
+            zero.input.stuck_key_timeout_ms,
+            InputConfig::default().stuck_key_timeout_ms
+        );
+
+        let out_of_range = parse_config(
+            r#"
+            [input]
+            modifier_reconcile_interval_ms = 1
+            stuck_key_timeout_ms = 70000
+            "#,
+        );
+        assert_eq!(out_of_range.input.modifier_reconcile_interval_ms, 10);
+        assert_eq!(out_of_range.input.stuck_key_timeout_ms, 60_000);
+    }
+
+    #[test]
     fn slow_mouse_config_parses_from_toml() {
         let fixed = parse_config(
             r#"
@@ -7933,15 +8013,15 @@ mod bookmark_runtime_logic_tests {
         let mut input = InputConfig::default();
         input.modifier_reconcile_on_tick = true;
         input.modifier_reconcile_interval_ms = 50;
-        input.stuck_key_timeout_ms = 1500;
+        input.stuck_key_timeout_ms = 10_000;
 
         assert!(!should_run_modifier_reconcile(
             &input,
-            Duration::from_millis(1499)
+            Duration::from_millis(9_999)
         ));
         assert!(should_run_modifier_reconcile(
             &input,
-            Duration::from_millis(1500)
+            Duration::from_millis(10_000)
         ));
 
         input.stuck_key_timeout_ms = 10;


### PR DESCRIPTION
### Motivation
- Make stale-key recovery behavior explicit and configurable via a dedicated `[input]` section so runtime input semantics are discoverable and tunable.  
- Ensure input timing values are sane and recoverable from accidental zero or out-of-range values by normalizing and clamping.  
- Document the reconcile cadence so it is clear how `stuck_key_timeout_ms` interacts with the reconcile interval.

### Description
- Added an `[input]` block to `config.toml` near runtime settings with keys: `swallow_owned_modifiers`, `modifier_reconcile_on_tick`, `modifier_reconcile_interval_ms`, `stuck_key_timeout_ms = 10000`, `debug_input`, and `shift_can_modify_plain_movement`, plus comments explaining stale-key recovery semantics.  
- Updated `InputConfig::default()` in `src/main.rs` to set `stuck_key_timeout_ms` to `10_000`.  
- Implemented `normalize_input_config()` and wired it into `Config::normalize()` to normalize input settings; it resets values to defaults when `0` and clamps to sane bounds (`modifier_reconcile_interval_ms` => `10..=5000`, `stuck_key_timeout_ms` => `500..=60000`).  
- Left the existing reconcile scheduler behavior intact and documented it in code and `docs/config.md`: reconcile cadence is `max(modifier_reconcile_interval_ms, stuck_key_timeout_ms)` so the timeout can effectively gate cadence.  
- Updated `docs/config.md` to reflect new defaults, normalization behavior, and cadence note.  
- Added unit tests in `src/main.rs` that cover: default stuck timeout (`10_000`), TOML parsing of `[input]` overrides, zero/out-of-range normalization, and the reconcile cadence gating logic.

### Testing
- Ran `cargo test` for the new input-focused tests locally in this environment using the test name prefix (`cargo test input_config_`), but the build failed during dependency compilation because the system library `xi` (pkg-config `xi.pc`) required by the transitive `x11` crate is not available here.  
- The added unit tests are present and exercise parsing and normalization, but they could not be executed to completion in this CI/environment due to the missing `xi` system package error when compiling dependencies.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a161601213883328b8037550563070f)