### PR TITLE
Refine wheel/profile UI copy to level-oriented terminology

### DIFF
--- a/src/help_overlay.rs
+++ b/src/help_overlay.rs
@@ -459,22 +459,25 @@ fn help_stats_lines(stats: &HelpRuntimeStats) -> Vec<String> {
             on_off(stats.jump_active)
         ),
         format!(
-            "Movement profile: {} | Speed: {} (default {}, range {}..{}, step {})",
+            "Movement profile: {} | Level {} / {} (default {}, range {}..{}, step {})",
             stats.movement_profile,
             stats.mouse_speed.current,
+            stats.mouse_speed.max,
             stats.mouse_speed.default,
             stats.mouse_speed.min,
             stats.mouse_speed.max,
             stats.mouse_speed.step
         ),
         format!(
-            "Wheel profile: {} | Speed: {} (default {}, range {}..{}, step {})",
+            "Wheel profile: {} | Level {} / {} (default {}, range {}..{}, step {}) | Repeat {}ms",
             stats.wheel_profile,
             stats.wheel_speed.current,
+            stats.wheel_speed.max,
             stats.wheel_speed.default,
             stats.wheel_speed.min,
             stats.wheel_speed.max,
-            stats.wheel_speed.step
+            stats.wheel_speed.step,
+            stats.wheel_tick_interval_ms
         ),
         format!(
             "Slow: {} | Speed: {} (range {}..{}) | Acceleration: {} every {} tick(s)",
@@ -573,20 +576,22 @@ pub fn format_tooltip_message(
 ) -> TooltipMessage {
     match notification.kind {
         RuntimeNotificationKind::MouseSpeed => TooltipMessage {
-            title: "Mouse speed".to_string(),
+            title: "Mouse level".to_string(),
             body: format!(
-                "Speed {} (default {}, range {}..{})",
+                "Level {} / {} (default {}, range {}..{})",
                 stats.mouse_speed.current,
+                stats.mouse_speed.max,
                 stats.mouse_speed.default,
                 stats.mouse_speed.min,
                 stats.mouse_speed.max
             ),
         },
         RuntimeNotificationKind::WheelSpeed => TooltipMessage {
-            title: "Wheel speed".to_string(),
+            title: "Wheel level".to_string(),
             body: format!(
-                "Speed {} (default {}, range {}..{})",
+                "Level {} / {} (default {}, range {}..{})",
                 stats.wheel_speed.current,
+                stats.wheel_speed.max,
                 stats.wheel_speed.default,
                 stats.wheel_speed.min,
                 stats.wheel_speed.max
@@ -598,7 +603,13 @@ pub fn format_tooltip_message(
         },
         RuntimeNotificationKind::WheelProfile => TooltipMessage {
             title: "Wheel profile".to_string(),
-            body: stats.wheel_profile.clone(),
+            body: format!(
+                "{} | Level {} / {} | Repeat {}ms",
+                stats.wheel_profile,
+                stats.wheel_speed.current,
+                stats.wheel_speed.max,
+                stats.wheel_tick_interval_ms
+            ),
         },
         RuntimeNotificationKind::Drag => TooltipMessage {
             title: "Drag".to_string(),
@@ -849,9 +860,9 @@ fn format_action(action: &Action) -> String {
         Action::WheelDown => "Wheel down".to_string(),
         Action::WheelLeft => "Wheel left".to_string(),
         Action::WheelRight => "Wheel right".to_string(),
-        Action::WheelSpeedUp => "Wheel speed up".to_string(),
-        Action::WheelSpeedDown => "Wheel speed down".to_string(),
-        Action::WheelSpeedReset => "Reset wheel speed".to_string(),
+        Action::WheelSpeedUp => "Wheel level up".to_string(),
+        Action::WheelSpeedDown => "Wheel level down".to_string(),
+        Action::WheelSpeedReset => "Reset wheel level".to_string(),
         Action::WheelProfileNext => "Next wheel profile".to_string(),
         Action::WheelProfilePrevious => "Previous wheel profile".to_string(),
         Action::WheelProfileSelect(profile) => format!("Wheel profile: {profile}"),
@@ -1188,10 +1199,12 @@ mod tests {
         let lines = format_help_lines(&view, TooltipOverlayConfig::default()).join("\n");
 
         assert!(lines.contains("Mode: active | Drag: on | Slow: on | Jump: on"));
-        assert!(
-            lines.contains("Movement profile: fast | Speed: 7 (default 5, range 2..12, step 2)")
-        );
-        assert!(lines.contains("Wheel profile: precise | Speed: 4 (default 3, range 1..9, step 1)"));
+        assert!(lines.contains(
+            "Movement profile: fast | Level 7 / 12 (default 5, range 2..12, step 2)"
+        ));
+        assert!(lines.contains(
+            "Wheel profile: precise | Level 4 / 9 (default 3, range 1..9, step 1) | Repeat 12ms"
+        ));
         assert!(
             lines.contains("Slow: fixed | Speed: 1 (range 1..2) | Acceleration: 0 every 1 tick(s)")
         );
@@ -1399,13 +1412,13 @@ mod tests {
         let cases = [
             (
                 RuntimeNotificationKind::MouseSpeed,
-                "Mouse speed",
-                "Speed 6",
+                "Mouse level",
+                "Level 6 / 9",
             ),
             (
                 RuntimeNotificationKind::WheelSpeed,
-                "Wheel speed",
-                "Speed 5",
+                "Wheel level",
+                "Level 5 / 8",
             ),
             (
                 RuntimeNotificationKind::MovementProfile,
@@ -1415,7 +1428,7 @@ mod tests {
             (
                 RuntimeNotificationKind::WheelProfile,
                 "Wheel profile",
-                "precise",
+                "precise | Level 5 / 8 | Repeat 0ms",
             ),
             (RuntimeNotificationKind::Drag, "Drag", "held"),
             (
@@ -1469,6 +1482,16 @@ mod tests {
 
         assert!(on.body.contains("held"));
         assert!(off.body.contains("released"));
+    }
+
+    #[test]
+    fn help_output_does_not_include_position_history_symbol_name() {
+        let view = help_view_from_bindings(
+            [(KeyChord::from_key(VirtualKey::P), Action::PositionHistoryMode)],
+            ModeContext::Active,
+        );
+        let lines = format_help_lines(&view, TooltipOverlayConfig::default()).join("\n");
+        assert!(!lines.contains("PositionHistory"));
     }
 
     #[test]

--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -247,7 +247,7 @@ fn compact_status_text(
     }
     if fields.wheel_speed {
         parts.push(format!(
-            "W:{}/{}",
+            "WL:{}/{}",
             snapshot.wheel_speed, snapshot.default_wheel_speed
         ));
     }
@@ -296,7 +296,7 @@ fn detailed_status_text(
     if fields.flash && snapshot.flash_reason != IndicatorFlashReason::None {
         match snapshot.flash_reason {
             IndicatorFlashReason::MouseSpeed => Some("flash:mouse_speed".to_string()),
-            IndicatorFlashReason::WheelSpeed => Some("flash:wheel_speed".to_string()),
+            IndicatorFlashReason::WheelSpeed => Some("flash:wheel_level".to_string()),
             IndicatorFlashReason::None => None,
         }
     } else {
@@ -912,6 +912,30 @@ mod tests {
         assert!(text.contains("A:ON"));
         assert!(text.contains("JMP:ON"));
         assert!(plan.width > super::OVERLAY_WIDTH);
+    }
+
+    #[test]
+    fn compact_render_plan_uses_wheel_level_copy() {
+        let mut config = StatusOverlayConfig::default();
+        config.mode = StatusOverlayMode::Compact;
+        let mut snapshot = snapshot_from_state(IndicatorState::WheelScrollingNormal);
+        snapshot.wheel_speed = 1;
+        snapshot.default_wheel_speed = 10;
+
+        let plan = render_plan(&snapshot, config);
+        let text = plan.text.unwrap_or_default();
+        assert!(text.contains("WL:1/10"));
+    }
+
+    #[test]
+    fn detailed_flash_copy_uses_wheel_level_term() {
+        let mut config = StatusOverlayConfig::default();
+        config.mode = StatusOverlayMode::Detailed;
+        let mut snapshot = snapshot_from_state(IndicatorState::WheelScrollingNormal);
+        snapshot.flash_reason = IndicatorFlashReason::WheelSpeed;
+
+        let plan = render_plan(&snapshot, config);
+        assert_eq!(plan.text.as_deref(), Some("flash:wheel_level"));
     }
 
     #[test]

--- a/src/overlay.rs
+++ b/src/overlay.rs
@@ -812,7 +812,7 @@ mod tests {
         should_repaint, snapshot_from_state, IndicatorVisual, OverlayPosition, OverlayVisualState,
         StatusOverlayConfig, StatusOverlayMode, RGB,
     };
-    use crate::indicator::IndicatorState;
+    use crate::indicator::{IndicatorFlashReason, IndicatorState};
     use windows::Win32::UI::WindowsAndMessaging::{
         WS_EX_LAYERED, WS_EX_NOACTIVATE, WS_EX_TOOLWINDOW, WS_EX_TOPMOST, WS_EX_TRANSPARENT,
     };


### PR DESCRIPTION
### Motivation
- Replace ambiguous "speed" wording with explicit level-oriented language for wheel and mouse so UI strings clearly show resolved level and maximum (e.g., `Level 1 / 10`).
- Ensure runtime notifications, overlay indicators and action labels consistently use the new terminology and include wheel cadence where appropriate.
- Prevent internal symbol names (e.g., `PositionHistory`) from leaking into help text.

### Description
- Updated help runtime lines in `src/help_overlay.rs` to show movement and wheel settings as `Level current / max` and appended wheel repeat cadence to the wheel profile line.
- Reworked `format_tooltip_message` in `src/help_overlay.rs` so mouse/wheel notifications use `Mouse level` / `Wheel level` titles and level-oriented bodies, and expanded the wheel profile tooltip to include resolved profile name, level and repeat (`Repeat Nms`).
- Renamed wheel action labels to `wheel level` phrasing in `src/help_overlay.rs` for consistency with notifications.
- Updated overlay compact/detailed status rendering in `src/overlay.rs` to use `WL:x/y` for compact wheel display and `flash:wheel_level` for flash messages.
- Added/adjusted unit tests: updated expectations in `format_help_lines_include_runtime_flags_and_speed_settings` and `tooltip_formatting_uses_kind_specific_title_and_body`, and added `help_output_does_not_include_position_history_symbol_name` (help overlay) plus `compact_render_plan_uses_wheel_level_copy` and `detailed_flash_copy_uses_wheel_level_term` (overlay) to validate the new copy and guard against symbol-name leakage.

### Testing
- Attempted a focused test run, but an initial multi-test positional invocation was malformed and aborted; a subsequent `cargo test` run failed during build because the `x11` crate requires the system `xi` pkg-config files which are not present in this environment, so tests could not be executed here.
- The change set includes updated and new unit tests covering help strings, tooltip bodies, overlay compact/detailed text, and the PositionHistory leak guard, but execution of these tests was blocked by the missing system dependency.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a161dbed6d48332b49f25a27e5a93ce)