### PR TITLE
Remove legacy position_history config and docs

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -103,10 +103,6 @@ key_bindings = [
     ["8", "bookmark_slot_8"],
     ["9", "bookmark_slot_9"],
 
-    # Position history (chosen to avoid overlap with existing bindings).
-    ["RightAlt+F13", "save_mouse_position"],
-    ["RightAlt+F14", "clear_mouse_positions"],
-    ["RightAlt+F15", "position_history_mode"]
 ]
 
 # Input ownership/reconciliation controls.
@@ -577,13 +573,6 @@ width = 10
 height = 8
 visual_context_margin_percent = 0
 zoom_scale = 1.0
-
-[position_history]
-enabled = true
-max_positions = 20
-selection_keys = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-label_length = 2
-show_numbers = false
 
 [bookmarks]
 enabled = true

--- a/docs/config.md
+++ b/docs/config.md
@@ -433,18 +433,14 @@ Suggested bindings:
 
 Note: many apps reserve `Alt` accelerators for menu/navigation. If a binding is intercepted, prefer switching to a less contended modifier combo.
 
-### `[position_history]`
 
-Configures saved mouse-position history and selection labels.
 
-```toml
-[position_history]
-enabled = true
-max_positions = 20
-selection_keys = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-label_length = 2
-show_numbers = false
-```
+### Migration note (removed position history)
+
+`[position_history]` and actions `save_mouse_position`, `clear_mouse_positions`, `position_history_mode` were removed.
+
+- Delete legacy keys from existing config files.
+- Use bookmark slots for saved locations.
 
 ### `[bookmarks]`
 


### PR DESCRIPTION
### Motivation
- Remove a deprecated position-history feature and its key bindings to simplify configuration and direct users toward the maintained bookmark system.
- Provide a short, clear migration note so users can clean up legacy keys and adopt bookmark slots for saved locations.

### Description
- Deleted the three legacy `key_bindings` entries for `save_mouse_position`, `clear_mouse_positions`, and `position_history_mode` and removed the nearby position-history comment from `config.toml`.
- Removed the full `[position_history]` table from `config.toml`.
- Removed the `### [position_history]` documentation section and sample from `docs/config.md` and inserted a concise migration note that states the removal and instructs: `Delete legacy keys from existing config files.` and `Use bookmark slots for saved locations.`
- Updated files were saved and staged for commit so the repository reflects the removed legacy configuration and docs.

### Testing
- Ran `rg -n "position_history|save_mouse_position|clear_mouse_positions|position_history_mode" config.toml` and confirmed there are no matches (test passed). 
- Ran `rg -n "position_history|save_mouse_position|clear_mouse_positions|position_history_mode" docs/config.md` and confirmed matches only refer to the newly added migration note (test passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1624642f3483329c9ba3eb087474af)