### PR TITLE
Remove deprecated position-history actions and help overlay wiring

### DIFF
--- a/src/action.rs
+++ b/src/action.rs
@@ -73,9 +73,6 @@ pub enum Action {
     Disable,
     ShowHelp,
     UiHintMode,
-    SaveMousePosition,
-    ClearMousePositions,
-    PositionHistoryMode,
     BookmarkMode,
     BookmarkSlot(u8),
     ClearBookmarkSlot(u8),
@@ -206,9 +203,6 @@ impl Action {
             "disable" | "disable_app" | "idle_mode" => Some(Self::Disable),
             "show_help" | "help" | "toggle_help" | "hints" | "show_hints" => Some(Self::ShowHelp),
             "ui_hint_mode" | "ui_hints" | "show_ui_hints" | "hint_mode" => Some(Self::UiHintMode),
-            "save_mouse_position" => Some(Self::SaveMousePosition),
-            "clear_mouse_positions" => Some(Self::ClearMousePositions),
-            "position_history_mode" => Some(Self::PositionHistoryMode),
             "bookmark_mode" => Some(Self::BookmarkMode),
             "clear_all_bookmarks" => Some(Self::ClearAllBookmarks),
             action if action.starts_with("bookmark_slot_") => action
@@ -614,19 +608,10 @@ mod tests {
     }
 
     #[test]
-    fn parses_position_history_actions() {
-        assert_eq!(
-            Action::from_string("save_mouse_position"),
-            Some(Action::SaveMousePosition)
-        );
-        assert_eq!(
-            Action::from_string("clear_mouse_positions"),
-            Some(Action::ClearMousePositions)
-        );
-        assert_eq!(
-            Action::from_string("position_history_mode"),
-            Some(Action::PositionHistoryMode)
-        );
+    fn removed_position_history_actions_do_not_parse() {
+        assert_eq!(Action::from_string("save_mouse_position"), None);
+        assert_eq!(Action::from_string("clear_mouse_positions"), None);
+        assert_eq!(Action::from_string("position_history_mode"), None);
     }
 
     #[test]

--- a/src/action_handler.rs
+++ b/src/action_handler.rs
@@ -368,9 +368,6 @@ impl<B: MouseBackend> MouseMaster<B> {
             | Action::NavigateForward
             | Action::ShowHelp
             | Action::UiHintMode
-            | Action::SaveMousePosition
-            | Action::ClearMousePositions
-            | Action::PositionHistoryMode
             | Action::BookmarkMode
             | Action::BookmarkSlot(_)
             | Action::ClearBookmarkSlot(_)

--- a/src/help_overlay.rs
+++ b/src/help_overlay.rs
@@ -887,9 +887,6 @@ fn format_action(action: &Action) -> String {
         Action::Disable => "Disable".to_string(),
         Action::ShowHelp => "Hints / Help".to_string(),
         Action::UiHintMode => "UI Hints".to_string(),
-        Action::SaveMousePosition => "Save mouse position".to_string(),
-        Action::ClearMousePositions => "Clear saved mouse positions".to_string(),
-        Action::PositionHistoryMode => "Position history mode".to_string(),
         Action::BookmarkMode => "Bookmark mode".to_string(),
         Action::BookmarkSlot(slot) => format!("Jump to bookmark slot {slot}"),
         Action::ClearBookmarkSlot(slot) => format!("Clear bookmark slot {slot}"),
@@ -961,10 +958,7 @@ fn action_section(action: &Action) -> HelpBindingSection {
         | Action::ScreenSelect
         | Action::NavigateBack
         | Action::NavigateForward
-        | Action::UiHintMode
-        | Action::SaveMousePosition
-        | Action::ClearMousePositions
-        | Action::PositionHistoryMode => HelpBindingSection::JumpGrid,
+        | Action::UiHintMode => HelpBindingSection::JumpGrid,
         Action::BookmarkMode
         | Action::BookmarkSlot(_)
         | Action::ClearBookmarkSlot(_)
@@ -995,7 +989,6 @@ fn mode_includes_action(mode: ModeContext, action: &Action) -> bool {
                     | Action::Disable
                     | Action::ShowHelp
                     | Action::UiHintMode
-                    | Action::PositionHistoryMode
             )
         }
         ModeContext::Bookmark => matches!(
@@ -1485,13 +1478,22 @@ mod tests {
     }
 
     #[test]
-    fn help_output_does_not_include_position_history_symbol_name() {
-        let view = help_view_from_bindings(
-            [(KeyChord::from_key(VirtualKey::P), Action::PositionHistoryMode)],
-            ModeContext::Active,
-        );
+    fn removed_position_history_action_strings_are_not_shown_in_help() {
+        let parsed = [
+            "save_mouse_position",
+            "clear_mouse_positions",
+            "position_history_mode",
+        ]
+        .into_iter()
+        .filter_map(Action::from_string)
+        .map(|action| (KeyChord::from_key(VirtualKey::P), action));
+
+        let view = help_view_from_bindings(parsed, ModeContext::Active);
         let lines = format_help_lines(&view, TooltipOverlayConfig::default()).join("\n");
-        assert!(!lines.contains("PositionHistory"));
+
+        assert!(!lines.contains("save_mouse_position"));
+        assert!(!lines.contains("clear_mouse_positions"));
+        assert!(!lines.contains("position_history_mode"));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Remove obsolete position-history actions and their parser mappings so the codebase no longer exposes or documents removed functionality.
- Prevent dangling matches and help overlay entries that referenced deleted action variants.
- Replace symbol-based tests with behavior-focused regressions that assert removed action strings no longer parse or appear in help output.

### Description
- Removed `SaveMousePosition`, `ClearMousePositions`, and `PositionHistoryMode` from the `Action` enum and deleted their parser mappings in `src/action.rs`.
- Replaced the old positive parser test with a negative regression test `removed_position_history_actions_do_not_parse` that asserts the three strings now parse to `None` in `src/action.rs`.
- Removed the deleted variants from the no-op handling branch of `MouseMaster::execute_action` in `src/action_handler.rs` so match arms no longer reference the removed enums.
- Cleaned up `src/help_overlay.rs` by removing help labels and routing for the deleted actions and replacing the previous symbol-referencing test with `removed_position_history_action_strings_are_not_shown_in_help`, which parses the original strings and asserts they are not rendered in help output.

### Testing
- Verified no remaining references with `rg -n "SaveMousePosition|ClearMousePositions|PositionHistoryMode" src/action.rs src/action_handler.rs src/help_overlay.rs` which returned no matches after changes.
- Attempted `cargo test action` but the build failed in this environment due to a missing system dependency required by the `x11` crate (`xi.pc` not found via `pkg-config`).
- Attempted `cargo test help_overlay` but it failed for the same system-level `x11`/`xi` pkg-config dependency before tests could run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16299a15f08332b7acea177b4302a0)