### PR TITLE
Bookmarks: clamp slot count to 1..=9, add typed policies, configurable cancel keys, and prioritize routing

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -161,7 +161,7 @@ font_scale = 1.0
 # These bindings remain available in both active and idle mode.
 [system_bindings]
 toggle_active = "Ctrl+Q"
-exit = "Escape"
+exit = "Ctrl+Escape"
 exit_ignore_extra_modifiers = true
 panic_reset = "RightAlt+Escape"
 panic_reset_ignore_extra_modifiers = true

--- a/docs/config.md
+++ b/docs/config.md
@@ -443,7 +443,7 @@ Configures bookmark mode and bookmark slot behavior. Bookmark JSON path resoluti
 [bookmarks]
 enabled = true
 file = "bookmarks.json"
-slot_count = 9            # clamped to 1..99
+slot_count = 9            # clamped to 1..9
 show_tooltips = true
 desktop_behavior = "focus_anchor_window"
 desktop_switch_wait_ms = 150   # clamped to 0..3000
@@ -482,14 +482,13 @@ Conflict example:
 
 ```toml
 [system_bindings]
-exit = "Escape"
+exit = "Ctrl+Escape"
 
 [bookmark_mode]
 cancel = "Escape" # conceptual mode-local cancel
 ```
 
-Pressing `Escape` dispatches `Exit`, not bookmark cancel, because system bindings have higher priority.
-If you instead set `exit = "Ctrl+Alt+Escape"`, a plain `Escape` can still be consumed by bookmark cancel.
+`Escape` cancels help/exclusive modes before general routing. `Ctrl+Escape` exits the app. `RightAlt+Escape` panic-resets runtime state.
 
 ### Alt / RightAlt ownership caveat
 

--- a/src/action.rs
+++ b/src/action.rs
@@ -682,6 +682,14 @@ mod tests {
     }
 
     #[test]
+    fn bookmark_action_parser_rejects_slot_10() {
+        assert_eq!(Action::from_string("bookmark_slot_10"), None);
+        assert_eq!(Action::from_string("bookmark_10"), None);
+        assert_eq!(Action::from_string("jump_to_bookmark_10"), None);
+        assert_eq!(Action::from_string("clear_bookmark_10"), None);
+    }
+
+    #[test]
     fn bookmark_actions_are_one_shot_not_continuous() {
         let actions = [
             Action::BookmarkMode,

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -105,6 +105,8 @@ pub struct AppState {
     system_bindings: RuntimeSystemBindings,
     help_visible: bool,
     grid_direction_labels: GridDirectionLabels,
+    bookmark_cancel_key: VirtualKey,
+    bookmark_clear_modifier_key: VirtualKey,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -245,6 +247,8 @@ impl Default for AppState {
             system_bindings: RuntimeSystemBindings::default(),
             help_visible: false,
             grid_direction_labels: GridDirectionLabels::default(),
+            bookmark_cancel_key: VirtualKey::Escape,
+            bookmark_clear_modifier_key: VirtualKey::Backspace,
         }
     }
 }
@@ -364,6 +368,10 @@ impl AppState {
 
     pub fn set_system_bindings(&mut self, system_bindings: RuntimeSystemBindings) {
         self.system_bindings = system_bindings;
+    }
+    pub fn set_bookmark_keys(&mut self, cancel_key: VirtualKey, clear_modifier_key: VirtualKey) {
+        self.bookmark_cancel_key = cancel_key;
+        self.bookmark_clear_modifier_key = clear_modifier_key;
     }
 
     pub fn set_grid_direction_labels(&mut self, labels: GridDirectionLabels) {
@@ -945,30 +953,21 @@ impl AppState {
     }
 
     pub fn route_key_event(&mut self, event: KeyEvent, mut action: Option<Action>) {
-        if self.help_visible && event.is_down && event.key == VirtualKey::Escape {
-            self.enqueue_command(AppCommand::HideHelp);
-            return;
-        }
-
-        if (self.is_jump_active() || self.is_grid_active())
-            && self.is_toggle_active_key_down_event(&event)
-        {
-            self.enqueue_command(AppCommand::ToggleActiveMode);
-            return;
-        }
-
-        if self.active_mode && event.is_down && matches!(action.as_ref(), Some(Action::Disable)) {
-            self.exit_ui_hint_mode();
-            self.exit_bookmark_mode();
-            self.enqueue_command(AppCommand::SetActiveMode { active: false });
-            return;
-        }
-
         if event.is_down && self.is_panic_reset_binding(&event) {
             if self.system_bindings.panic_reset_sets_idle {
                 self.enqueue_command(AppCommand::SetActiveMode { active: false });
             }
             self.enqueue_command(AppCommand::PanicReset);
+            return;
+        }
+        if self.help_visible && event.is_down && event.key == VirtualKey::Escape {
+            self.enqueue_command(AppCommand::HideHelp);
+            return;
+        }
+        if self.active_mode && event.is_down && matches!(action.as_ref(), Some(Action::Disable)) {
+            self.exit_ui_hint_mode();
+            self.exit_bookmark_mode();
+            self.enqueue_command(AppCommand::SetActiveMode { active: false });
             return;
         }
 
@@ -983,6 +982,12 @@ impl AppState {
             && (self.is_exit_binding(&event) || matches!(action.as_ref(), Some(Action::Exit)))
         {
             self.enqueue_command(AppCommand::Exit);
+            return;
+        }
+        if (self.is_jump_active() || self.is_grid_active())
+            && self.is_toggle_active_key_down_event(&event)
+        {
+            self.enqueue_command(AppCommand::ToggleActiveMode);
             return;
         }
 
@@ -1006,13 +1011,13 @@ impl AppState {
                     ..
                 } = &mut self.bookmark_mode
                 {
-                    if event.key == VirtualKey::Backspace {
+                    if event.key == self.bookmark_clear_modifier_key {
                         *clear_modifier_held = false;
                     }
                 }
                 return;
             }
-            if event.key == VirtualKey::Escape {
+            if event.key == self.bookmark_cancel_key {
                 self.exit_bookmark_mode();
                 self.enqueue_command(AppCommand::CancelBookmarkMode);
                 return;
@@ -1022,7 +1027,7 @@ impl AppState {
                 ..
             } = &mut self.bookmark_mode
             {
-                if event.key == VirtualKey::Backspace {
+                if event.key == self.bookmark_clear_modifier_key {
                     *clear_modifier_held = true;
                     return;
                 }
@@ -3281,6 +3286,65 @@ mod tests {
         assert_eq!(
             collect_commands(&mut state),
             vec![AppCommand::CancelBookmarkMode]
+        );
+    }
+
+    #[test]
+    fn bookmark_mode_uses_configured_cancel_key() {
+        let mut state = AppState::default();
+        state.set_bookmark_keys(VirtualKey::Q, VirtualKey::Backspace);
+        state.enter_bookmark_mode(VirtualKey::B);
+        state.route_key_event(KeyEvent::new(VirtualKey::Q, true), None);
+        assert_eq!(collect_commands(&mut state), vec![AppCommand::CancelBookmarkMode]);
+    }
+
+    #[test]
+    fn bookmark_mode_uses_configured_clear_modifier_key() {
+        let mut state = AppState::default();
+        state.set_bookmark_keys(VirtualKey::Escape, VirtualKey::Q);
+        state.enter_bookmark_mode(VirtualKey::B);
+        state.route_key_event(KeyEvent::new(VirtualKey::Q, true), None);
+        state.route_key_event(KeyEvent::new(VirtualKey::Num1, true), Some(Action::BookmarkSlot(1)));
+        assert_eq!(collect_commands(&mut state), vec![AppCommand::ClearBookmarkSlot(1)]);
+    }
+
+    #[test]
+    fn plain_escape_cancels_bookmark_mode_when_exit_is_ctrl_escape() {
+        let mut state = AppState::default();
+        state.set_system_bindings(RuntimeSystemBindings {
+            exit: KeyChord::parse("Ctrl+Escape").unwrap(),
+            ..RuntimeSystemBindings::default()
+        });
+        state.enter_bookmark_mode(VirtualKey::B);
+        state.route_key_event(KeyEvent::new(VirtualKey::Escape, true), None);
+        assert_eq!(collect_commands(&mut state), vec![AppCommand::CancelBookmarkMode]);
+    }
+
+    #[test]
+    fn ctrl_escape_exits_even_when_bookmark_mode_active() {
+        let mut state = AppState::default();
+        state.set_system_bindings(RuntimeSystemBindings {
+            exit: KeyChord::parse("Ctrl+Escape").unwrap(),
+            ..RuntimeSystemBindings::default()
+        });
+        state.enter_bookmark_mode(VirtualKey::B);
+        let mut ev = KeyEvent::new(VirtualKey::Escape, true);
+        ev.ctrl_down = true;
+        state.route_key_event(ev, Some(Action::Exit));
+        assert_eq!(collect_commands(&mut state), vec![AppCommand::Exit]);
+    }
+
+    #[test]
+    fn panic_reset_wins_over_bookmark_cancel() {
+        let mut state = AppState::default();
+        state.enter_bookmark_mode(VirtualKey::B);
+        let mut ev = KeyEvent::new(VirtualKey::Escape, true);
+        ev.alt_down = true;
+        ev.right_alt_down = true;
+        state.route_key_event(ev, Some(Action::PanicReset));
+        assert_eq!(
+            collect_commands(&mut state),
+            vec![AppCommand::SetActiveMode { active: false }, AppCommand::PanicReset]
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -7743,9 +7743,9 @@ file = "data/bookmarks.json"
 mod bookmark_runtime_logic_tests {
     use super::*;
 
-    fn cfg(policy: &str) -> BookmarksConfig {
+    fn cfg(policy: BookmarkCoordinatePolicy) -> BookmarksConfig {
         let mut c = BookmarksConfig::default();
-        c.coordinate_policy = policy.to_string();
+        c.coordinate_policy = policy;
         c
     }
 
@@ -7773,7 +7773,7 @@ mod bookmark_runtime_logic_tests {
     #[test]
     fn exact_policy_preserves_coordinate() {
         assert_eq!(
-            resolve_recall_target(&rec(5000, -2000), &cfg("exact")),
+            resolve_recall_target(&rec(5000, -2000), &cfg(BookmarkCoordinatePolicy::Exact)),
             (5000, -2000)
         );
     }
@@ -7781,7 +7781,10 @@ mod bookmark_runtime_logic_tests {
     #[test]
     fn clamp_to_nearest_monitor_clamps_out_of_bounds_target() {
         assert_eq!(
-            resolve_recall_target(&rec(5000, -2000), &cfg("clamp_to_nearest_monitor")),
+            resolve_recall_target(
+                &rec(5000, -2000),
+                &cfg(BookmarkCoordinatePolicy::ClampToNearestMonitor)
+            ),
             (99, 0)
         );
     }
@@ -7796,9 +7799,9 @@ mod bookmark_runtime_logic_tests {
     }
 
     #[test]
-    fn move_without_switch_allows_move_attempt() {
+    fn current_only_allows_move_attempt() {
         let mut c = BookmarksConfig::default();
-        c.desktop_behavior = "move_without_switch".into();
+        c.desktop_behavior = BookmarkDesktopBehavior::CurrentOnly;
         let r = rec(5, 6);
         assert_eq!(resolve_recall_target(&r, &c), (5, 6));
     }
@@ -7830,7 +7833,7 @@ mod bookmark_runtime_logic_tests {
         };
         let mut c = BookmarksConfig::default();
         c.require_desktop_switch_success = false;
-        c.desktop_behavior = "focus_anchor_window".into();
+        c.desktop_behavior = BookmarkDesktopBehavior::FocusAnchorWindow;
         let (x, y) = resolve_recall_target(&record, &c);
         assert_eq!((x, y), (42, 24));
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -650,12 +650,30 @@ pub struct BookmarksConfig {
     pub file: String,
     pub slot_count: u32,
     pub show_tooltips: bool,
-    pub desktop_behavior: String,
+    pub desktop_behavior: BookmarkDesktopBehavior,
     pub desktop_switch_wait_ms: u64,
     pub require_desktop_switch_success: bool,
     pub cancel_key: String,
     pub clear_modifier_key: String,
-    pub coordinate_policy: String,
+    pub coordinate_policy: BookmarkCoordinatePolicy,
+}
+
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum BookmarkDesktopBehavior {
+    CurrentOnly,
+    SwitchDesktop,
+    #[default]
+    FocusAnchorWindow,
+}
+
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum BookmarkCoordinatePolicy {
+    Exact,
+    ClampToNearestMonitor,
+    #[default]
+    ClampToVirtualScreen,
 }
 
 impl Default for BookmarksConfig {
@@ -665,12 +683,12 @@ impl Default for BookmarksConfig {
             file: "bookmarks.json".to_string(),
             slot_count: 9,
             show_tooltips: true,
-            desktop_behavior: "focus_anchor_window".to_string(),
+            desktop_behavior: BookmarkDesktopBehavior::FocusAnchorWindow,
             desktop_switch_wait_ms: 150,
             require_desktop_switch_success: false,
             cancel_key: "Escape".to_string(),
             clear_modifier_key: "Backspace".to_string(),
-            coordinate_policy: "clamp_to_virtual_screen".to_string(),
+            coordinate_policy: BookmarkCoordinatePolicy::ClampToVirtualScreen,
         }
     }
 }
@@ -1737,7 +1755,7 @@ impl Config {
     }
 
     fn normalize_bookmarks_config(&mut self) {
-        self.bookmarks.slot_count = self.bookmarks.slot_count.clamp(1, 99);
+        self.bookmarks.slot_count = self.bookmarks.slot_count.clamp(1, 9);
         if self.bookmarks.file.trim().is_empty() {
             warn_config_normalized("bookmarks.file is empty; using bookmarks.json");
             self.bookmarks.file = "bookmarks.json".to_string();
@@ -1751,18 +1769,6 @@ impl Config {
         if VirtualKey::from_string(&self.bookmarks.clear_modifier_key).is_none() {
             warn_config_normalized("bookmarks.clear_modifier_key is invalid; using Backspace");
             self.bookmarks.clear_modifier_key = "Backspace".to_string();
-        }
-        if self.bookmarks.coordinate_policy != "clamp_to_virtual_screen" {
-            warn_config_normalized(
-                "bookmarks.coordinate_policy is invalid; using clamp_to_virtual_screen",
-            );
-            self.bookmarks.coordinate_policy = "clamp_to_virtual_screen".to_string();
-        }
-        if self.bookmarks.desktop_behavior != "focus_anchor_window" {
-            warn_config_normalized(
-                "bookmarks.desktop_behavior is invalid; using focus_anchor_window",
-            );
-            self.bookmarks.desktop_behavior = "focus_anchor_window".to_string();
         }
     }
 
@@ -2289,6 +2295,11 @@ impl Config {
             .write()
             .unwrap()
             .set_system_bindings(system_bindings);
+        APP_STATE.write().unwrap().set_bookmark_keys(
+            VirtualKey::from_string(&self.bookmarks.cancel_key).unwrap_or(VirtualKey::Escape),
+            VirtualKey::from_string(&self.bookmarks.clear_modifier_key)
+                .unwrap_or(VirtualKey::Backspace),
+        );
 
         Ok(())
     }
@@ -3313,14 +3324,14 @@ fn help_stats_from_snapshot(
 
 fn resolve_recall_target(record: &BookmarkRecord, cfg: &BookmarksConfig) -> (i32, i32) {
     let (mut x, mut y) = (record.x, record.y);
-    match cfg.coordinate_policy.as_str() {
-        "exact" => {}
-        "clamp_to_nearest_monitor" => {
+    match cfg.coordinate_policy {
+        BookmarkCoordinatePolicy::Exact => {}
+        BookmarkCoordinatePolicy::ClampToNearestMonitor => {
             let mr = &record.monitor_rect;
             x = x.clamp(mr.left, mr.right.saturating_sub(1));
             y = y.clamp(mr.top, mr.bottom.saturating_sub(1));
         }
-        _ => {
+        BookmarkCoordinatePolicy::ClampToVirtualScreen => {
             let vr = virtual_screen_region();
             x = x.clamp(vr.left, (vr.left + vr.width).saturating_sub(1));
             y = y.clamp(vr.top, (vr.top + vr.height).saturating_sub(1));
@@ -3864,15 +3875,15 @@ fn execute_app_command(command: AppCommand, debug_diagnostics: bool) {
 
             let mut desktop_ok = true;
             let mut desktop_warn: Option<String> = None;
-            match cfg.desktop_behavior.as_str() {
-                "current_only" => {
+            match cfg.desktop_behavior {
+                BookmarkDesktopBehavior::CurrentOnly => {
                     let current = virtual_desktop::current_virtual_desktop_id();
                     if current != record.virtual_desktop_id {
                         desktop_ok = false;
                         desktop_warn = Some("Desktop mismatch".to_string());
                     }
                 }
-                "focus_anchor_window" => {
+                BookmarkDesktopBehavior::FocusAnchorWindow => {
                     let (ok, warn) = evaluate_focus_attempt(virtual_desktop::focus_anchor_window(
                         record.anchor_hwnd,
                     ));
@@ -3881,7 +3892,7 @@ fn execute_app_command(command: AppCommand, debug_diagnostics: bool) {
                         desktop_warn = warn;
                     }
                 }
-                "switch_desktop" => {
+                BookmarkDesktopBehavior::SwitchDesktop => {
                     if let Err(e) =
                         virtual_desktop::switch_to_desktop(record.virtual_desktop_id.as_deref())
                     {
@@ -3889,7 +3900,6 @@ fn execute_app_command(command: AppCommand, debug_diagnostics: bool) {
                         desktop_warn = Some(e);
                     }
                 }
-                _ => {}
             }
             if cfg.desktop_switch_wait_ms > 0 {
                 sleep(Duration::from_millis(cfg.desktop_switch_wait_ms));
@@ -4447,7 +4457,7 @@ fn emit_startup_feature_binding_warnings(config: &Config) {
         if (config.bookmarks.slot_count as usize) > dedup.len() {
             warn_config_normalized("bookmarks.slot_count exceeds number of bound bookmark slots.");
         }
-        if config.bookmarks.desktop_behavior == "switch_desktop" {
+        if config.bookmarks.desktop_behavior == BookmarkDesktopBehavior::SwitchDesktop {
             warn_config_normalized("bookmarks.desktop_behavior=switch_desktop is configured, but desktop switching backend availability is not guaranteed.");
         }
     }
@@ -4513,7 +4523,7 @@ fn startup_validation_summary(config: &Config, config_path: &Path, warnings: &[S
     ));
     let bookmark_path = resolve_bookmarks_path(config_path, Path::new(&config.bookmarks.file));
     lines.push(format!(
-        "  bookmarks: enabled={} file={} mode_bindings={} slots={:?} desktop_behavior={}",
+        "  bookmarks: enabled={} file={} mode_bindings={} slots={:?} desktop_behavior={:?}",
         config.bookmarks.enabled,
         bookmark_path.display(),
         feature_bindings.bookmark_mode,
@@ -7607,13 +7617,13 @@ enabled = true"#,
     }
 
     #[test]
-    fn bookmarks_config_normalizes_invalid_values() {
+    fn bookmark_slot_count_zero_clamps_to_1() {
         let config = parse_config(
             r#"[bookmarks]
 slot_count = 0
 file = ""
-desktop_behavior = "bad"
-coordinate_policy = "bad"
+desktop_behavior = "focus_anchor_window"
+coordinate_policy = "clamp_to_virtual_screen"
 cancel_key = "Nope"
 clear_modifier_key = "Nope"
 desktop_switch_wait_ms = 999999
@@ -7621,10 +7631,10 @@ desktop_switch_wait_ms = 999999
         );
         assert_eq!(config.bookmarks.slot_count, 1);
         assert_eq!(config.bookmarks.file, "bookmarks.json");
-        assert_eq!(config.bookmarks.desktop_behavior, "focus_anchor_window");
+        assert_eq!(config.bookmarks.desktop_behavior, BookmarkDesktopBehavior::FocusAnchorWindow);
         assert_eq!(
             config.bookmarks.coordinate_policy,
-            "clamp_to_virtual_screen"
+            BookmarkCoordinatePolicy::ClampToVirtualScreen
         );
         assert_eq!(config.bookmarks.cancel_key, "Escape");
         assert_eq!(config.bookmarks.clear_modifier_key, "Backspace");
@@ -7632,9 +7642,30 @@ desktop_switch_wait_ms = 999999
     }
 
     #[test]
-    fn bookmarks_slot_count_high_clamps() {
+    fn bookmark_slot_count_above_9_clamps_to_9() {
         let config = parse_config("[bookmarks]\nslot_count = 999\n");
-        assert_eq!(config.bookmarks.slot_count, 99);
+        assert_eq!(config.bookmarks.slot_count, 9);
+    }
+
+    #[test]
+    fn bookmark_desktop_behavior_parses_valid_values() {
+        let cfg = parse_config("[bookmarks]\ndesktop_behavior = \"current_only\"\n");
+        assert_eq!(
+            cfg.bookmarks.desktop_behavior,
+            BookmarkDesktopBehavior::CurrentOnly
+        );
+    }
+
+    #[test]
+    fn bookmark_coordinate_policy_parses_valid_values() {
+        let cfg = parse_config("[bookmarks]\ncoordinate_policy = \"exact\"\n");
+        assert_eq!(cfg.bookmarks.coordinate_policy, BookmarkCoordinatePolicy::Exact);
+    }
+
+    #[test]
+    fn invalid_bookmark_policy_reports_config_error() {
+        let err = parse_config_error("[bookmarks]\ndesktop_behavior = \"bad\"\n");
+        assert!(err.contains("unknown variant"));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Reduce supported bookmark slots to 1..=9 and make erroneous user config fail early for policy fields by replacing raw strings with typed enums. 
- Allow bookmark cancel/clear behavior to be driven by configuration instead of hardcoded `Escape`/`Backspace`. 
- Eliminate ambiguity between modal cancel, app exit, and panic-reset by making routing precedence explicit and consistent. 
- Keep docs and default config examples aligned with the new behavior and limits. 

### Description
- Clamp `bookmarks.slot_count` to `1..=9` in `normalize_bookmarks_config` and update default and docs to reflect the new clamp. 
- Replace `bookmarks.desktop_behavior` and `bookmarks.coordinate_policy` string fields with typed enums `BookmarkDesktopBehavior` and `BookmarkCoordinatePolicy`, and switch runtime matching to use these enums. 
- Add `bookmark_cancel_key` and `bookmark_clear_modifier_key` fields to `AppState`, expose `set_bookmark_keys`, and wire `initialize_system_bindings` to set them from `bookmarks.cancel_key`/`bookmarks.clear_modifier_key` so bookmark-mode routing no longer uses hardcoded `Escape`/`Backspace`. 
- Reorder `route_key_event` checks to evaluate panic-reset first, then help cancel, active-mode disable, system exit chord, and toggles to enforce the requested routing priority and Escape conflict resolution. 
- Update `config.toml` and `docs/config.md` examples/text to document slot clamping and the new Escape/Ctrl+Escape/RightAlt+Escape semantics. 
- Add and adjust unit tests to cover slot clamping, rejecting slot 10 in action parsing, enum parsing and invalid-policy errors, configured bookmark keys, and Escape/Ctrl+Escape/RightAlt+Escape precedence. 

### Testing
- Added unit tests: `bookmark_slot_count_above_9_clamps_to_9`, `bookmark_slot_count_zero_clamps_to_1`, `bookmark_action_parser_rejects_slot_10`, `bookmark_desktop_behavior_parses_valid_values`, `bookmark_coordinate_policy_parses_valid_values`, `invalid_bookmark_policy_reports_config_error`, `bookmark_mode_uses_configured_cancel_key`, `bookmark_mode_uses_configured_clear_modifier_key`, `plain_escape_cancels_bookmark_mode_when_exit_is_ctrl_escape`, `ctrl_escape_exits_even_when_bookmark_mode_active`, and `panic_reset_wins_over_bookmark_cancel`. 
- Attempted to run the bookmark-focused tests with `cargo test bookmark_ -- --nocapture`, but the test run failed at build time due to a missing system dependency required by the `x11` crate (pkg-config could not find `xi.pc`), so automated tests could not complete in this environment. 
- Note: an earlier `cargo test` invocation with multiple explicit test filters failed due to incorrect CLI usage; this did not reflect test failures in code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16421d4ae8833295eac1514272ff46)