### PR TITLE
Surgical zoom overlay: state, capture helper, and refresh throttling

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -612,9 +612,10 @@ list_tooltip_duration_ms = 1200
 enabled = true
 speed_px = 1
 zoom_enabled = true
-# Experimental: zoom fields are parsed and tracked, but no full rendered
-# zoom viewport is shown unless a complete overlay implementation is enabled.
+# Surgical zoom overlay is topmost, non-activating, and click-through.
 zoom_scale = 2.0
 zoom_size_px = 180
 overlay_offset_x = 24
 overlay_offset_y = 24
+refresh_interval_ms = 16
+center_crosshair = true

--- a/docs/config.md
+++ b/docs/config.md
@@ -471,11 +471,13 @@ list_tooltip_duration_ms = 1200
 | --- | --- | --- | --- | --- | --- |
 | `surgical_mode.enabled` | boolean | `false` | Yes | Active | Enables fixed-speed surgical movement tier. |
 | `surgical_mode.speed_px` | integer | `1` | Yes | Active | Fixed movement speed used when `surgical_mode` action is held. |
-| `surgical_mode.zoom_enabled` | boolean | `false` | Yes | Active | Experimental: tracks surgical zoom intent; full rendered zoom viewport is not currently shown. |
+| `surgical_mode.zoom_enabled` | boolean | `false` | Yes | Active | Enables the surgical zoom overlay while the surgical action is held. |
 | `surgical_mode.zoom_scale` | float | `2.0` | Yes | Active | Zoom factor for surgical overlay. |
 | `surgical_mode.zoom_size_px` | integer | `180` | Yes | Active | Surgical overlay square size in pixels. |
 | `surgical_mode.overlay_offset_x` | integer | `24` | Yes | Active | Overlay horizontal offset from cursor. |
 | `surgical_mode.overlay_offset_y` | integer | `24` | Yes | Active | Overlay vertical offset from cursor. |
+| `surgical_mode.refresh_interval_ms` | integer milliseconds | `16` | Yes | Active | Minimum interval between surgical zoom capture/paint updates. |
+| `surgical_mode.center_crosshair` | boolean | `true` | Yes | Active | Draws a center crosshair in the surgical zoom overlay. |
 
 
 ### Surgical behavior semantics

--- a/src/action_handler.rs
+++ b/src/action_handler.rs
@@ -15,6 +15,9 @@ use enigo::*;
 use std::collections::{HashSet, VecDeque};
 use std::env;
 use std::time::{Duration, Instant};
+use windows::Win32::UI::WindowsAndMessaging::{
+    GetSystemMetrics, SM_CXVIRTUALSCREEN, SM_CYVIRTUALSCREEN, SM_XVIRTUALSCREEN, SM_YVIRTUALSCREEN,
+};
 
 const DIAGONAL_NORMALIZATION: f64 = std::f64::consts::FRAC_1_SQRT_2;
 const DEBUG_DIAGNOSTICS_ENV: &str = "MULTI_MOUSEMOVER_DEBUG";
@@ -628,10 +631,16 @@ impl<B: MouseBackend> MouseMaster<B> {
                     zoom_size_px: self.config.surgical_mode.zoom_size_px,
                     overlay_offset_x: self.config.surgical_mode.overlay_offset_x,
                     overlay_offset_y: self.config.surgical_mode.overlay_offset_y,
+                    refresh_interval_ms: self.config.surgical_mode.refresh_interval_ms,
+                    center_crosshair: self.config.surgical_mode.center_crosshair,
                 },
                 surgical_active,
                 x,
                 y,
+                unsafe { GetSystemMetrics(SM_XVIRTUALSCREEN) },
+                unsafe { GetSystemMetrics(SM_YVIRTUALSCREEN) },
+                unsafe { GetSystemMetrics(SM_CXVIRTUALSCREEN) },
+                unsafe { GetSystemMetrics(SM_CYVIRTUALSCREEN) },
             );
         }
 

--- a/src/action_handler.rs
+++ b/src/action_handler.rs
@@ -7,7 +7,7 @@ use crate::{
     app_state::KeyEvent,
     keyboard::VirtualKey,
     window_geometry::{foreground_window_snap_points, WindowSnapPoints},
-    zoom_overlay::{update_zoom_state, SurgicalZoomConfig, SurgicalZoomState},
+    zoom_overlay::{update_zoom_state, SurgicalZoomConfig, SurgicalZoomState, VirtualScreenBounds},
     Config, FinalAdjustConfig,
 };
 use action::{Action, Direction2D, StepMoveTier};
@@ -637,10 +637,12 @@ impl<B: MouseBackend> MouseMaster<B> {
                 surgical_active,
                 x,
                 y,
-                unsafe { GetSystemMetrics(SM_XVIRTUALSCREEN) },
-                unsafe { GetSystemMetrics(SM_YVIRTUALSCREEN) },
-                unsafe { GetSystemMetrics(SM_CXVIRTUALSCREEN) },
-                unsafe { GetSystemMetrics(SM_CYVIRTUALSCREEN) },
+                VirtualScreenBounds {
+                    left: unsafe { GetSystemMetrics(SM_XVIRTUALSCREEN) },
+                    top: unsafe { GetSystemMetrics(SM_YVIRTUALSCREEN) },
+                    width: unsafe { GetSystemMetrics(SM_CXVIRTUALSCREEN) },
+                    height: unsafe { GetSystemMetrics(SM_CYVIRTUALSCREEN) },
+                },
             );
         }
 

--- a/src/config_audit.rs
+++ b/src/config_audit.rs
@@ -323,6 +323,8 @@ fn is_known_active_path(path: &str) -> bool {
         "surgical_mode.zoom_size_px",
         "surgical_mode.overlay_offset_x",
         "surgical_mode.overlay_offset_y",
+        "surgical_mode.refresh_interval_ms",
+        "surgical_mode.center_crosshair",
         "movement_profiles.*.default_speed",
         "movement_profiles.*.min_speed",
         "movement_profiles.*.max_speed",

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,6 +62,7 @@ use windows::Win32::Foundation::*;
 use windows::Win32::System::LibraryLoader::*;
 use windows::Win32::UI::Input::KeyboardAndMouse::GetAsyncKeyState;
 use windows::Win32::UI::WindowsAndMessaging::*;
+use zoom_overlay::{sync_surgical_zoom_overlay, SurgicalZoomConfig};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum UiHintExitReason {
@@ -4865,6 +4866,23 @@ fn main() {
             }
         }
         help_overlay::update_overlay(Instant::now());
+        {
+            let action_handler = ACTION_HANDLER.read().unwrap();
+            let mm = &action_handler.mouse_master;
+            sync_surgical_zoom_overlay(
+                mm.surgical_zoom_state,
+                SurgicalZoomConfig {
+                    enabled: mm.config.surgical_mode.enabled,
+                    zoom_enabled: mm.config.surgical_mode.zoom_enabled,
+                    zoom_scale: mm.config.surgical_mode.zoom_scale,
+                    zoom_size_px: mm.config.surgical_mode.zoom_size_px,
+                    overlay_offset_x: mm.config.surgical_mode.overlay_offset_x,
+                    overlay_offset_y: mm.config.surgical_mode.overlay_offset_y,
+                    refresh_interval_ms: mm.config.surgical_mode.refresh_interval_ms,
+                    center_crosshair: mm.config.surgical_mode.center_crosshair,
+                },
+            );
+        }
 
         if debug_diagnostics {
             let now = Instant::now();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1018,6 +1018,8 @@ pub struct SurgicalModeConfig {
     zoom_size_px: i32,
     overlay_offset_x: i32,
     overlay_offset_y: i32,
+    refresh_interval_ms: u64,
+    center_crosshair: bool,
 }
 
 impl Default for SurgicalModeConfig {
@@ -1030,6 +1032,8 @@ impl Default for SurgicalModeConfig {
             zoom_size_px: 180,
             overlay_offset_x: 24,
             overlay_offset_y: 24,
+            refresh_interval_ms: 16,
+            center_crosshair: true,
         }
     }
 }
@@ -1996,6 +2000,12 @@ impl Config {
         if self.surgical_mode.zoom_size_px < 32 {
             warn_config_normalized("surgical_mode.zoom_size_px is below 32; clamping to 32");
             self.surgical_mode.zoom_size_px = 32;
+        }
+        if self.surgical_mode.refresh_interval_ms > 1000 {
+            warn_config_normalized(
+                "surgical_mode.refresh_interval_ms is above 1000; clamping to 1000",
+            );
+            self.surgical_mode.refresh_interval_ms = 1000;
         }
     }
 

--- a/src/screen_capture.rs
+++ b/src/screen_capture.rs
@@ -139,3 +139,76 @@ pub fn capture_virtual_screen() -> Option<ScreenSnapshot> {
         })
     }
 }
+
+pub fn capture_region_around_cursor(
+    cursor_x: i32,
+    cursor_y: i32,
+    source_size_px: i32,
+) -> Option<ScreenSnapshot> {
+    let left = unsafe { GetSystemMetrics(SM_XVIRTUALSCREEN) };
+    let top = unsafe { GetSystemMetrics(SM_YVIRTUALSCREEN) };
+    let width = unsafe { GetSystemMetrics(SM_CXVIRTUALSCREEN) };
+    let height = unsafe { GetSystemMetrics(SM_CYVIRTUALSCREEN) };
+    if width <= 0 || height <= 0 {
+        return None;
+    }
+
+    let source_w = source_size_px.min(width).max(1);
+    let source_h = source_size_px.min(height).max(1);
+    let source_left = (cursor_x - source_w / 2).clamp(left, left + width - source_w);
+    let source_top = (cursor_y - source_h / 2).clamp(top, top + height - source_h);
+
+    unsafe {
+        let screen_dc = GetDC(None);
+        if screen_dc.is_invalid() {
+            return None;
+        }
+        let memory_dc = CreateCompatibleDC(Some(screen_dc));
+        if memory_dc.is_invalid() {
+            let _ = ReleaseDC(None, screen_dc);
+            return None;
+        }
+        let bitmap = CreateCompatibleBitmap(screen_dc, source_w, source_h);
+        if bitmap.is_invalid() {
+            let _ = DeleteDC(memory_dc);
+            let _ = ReleaseDC(None, screen_dc);
+            return None;
+        }
+        let old_bitmap = SelectObject(memory_dc, bitmap.into());
+        if old_bitmap.is_invalid() {
+            let _ = DeleteObject(bitmap.into());
+            let _ = DeleteDC(memory_dc);
+            let _ = ReleaseDC(None, screen_dc);
+            return None;
+        }
+        if BitBlt(
+            memory_dc,
+            0,
+            0,
+            source_w,
+            source_h,
+            Some(screen_dc),
+            source_left,
+            source_top,
+            SRCCOPY,
+        )
+        .is_err()
+        {
+            let _ = SelectObject(memory_dc, old_bitmap);
+            let _ = DeleteObject(bitmap.into());
+            let _ = DeleteDC(memory_dc);
+            let _ = ReleaseDC(None, screen_dc);
+            return None;
+        }
+        let _ = ReleaseDC(None, screen_dc);
+        Some(ScreenSnapshot {
+            left: source_left,
+            top: source_top,
+            width: source_w,
+            height: source_h,
+            hdc: memory_dc,
+            bitmap,
+            old_bitmap,
+        })
+    }
+}

--- a/src/screen_capture.rs
+++ b/src/screen_capture.rs
@@ -16,6 +16,12 @@ pub struct ScreenSnapshot {
 }
 
 impl ScreenSnapshot {
+    pub fn hdc(&self) -> HDC {
+        self.hdc
+    }
+}
+
+impl ScreenSnapshot {
     #[cfg(test)]
     pub fn test_bounds(left: i32, top: i32, width: i32, height: i32) -> Self {
         Self {

--- a/src/zoom_overlay.rs
+++ b/src/zoom_overlay.rs
@@ -1,3 +1,5 @@
+use std::time::{Duration, Instant};
+
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct SurgicalZoomConfig {
     pub enabled: bool,
@@ -6,13 +8,35 @@ pub struct SurgicalZoomConfig {
     pub zoom_size_px: i32,
     pub overlay_offset_x: i32,
     pub overlay_offset_y: i32,
+    pub refresh_interval_ms: u64,
+    pub center_crosshair: bool,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SurgicalZoomState {
     pub visible: bool,
     pub x: i32,
     pub y: i32,
+    pub source_left: i32,
+    pub source_top: i32,
+    pub source_size_px: i32,
+    pub center_crosshair: bool,
+    pub pending_refresh: bool,
+}
+
+impl Default for SurgicalZoomState {
+    fn default() -> Self {
+        Self {
+            visible: false,
+            x: 0,
+            y: 0,
+            source_left: 0,
+            source_top: 0,
+            source_size_px: 0,
+            center_crosshair: false,
+            pending_refresh: false,
+        }
+    }
 }
 
 pub fn update_zoom_state(
@@ -21,15 +45,59 @@ pub fn update_zoom_state(
     surgical_active: bool,
     cursor_x: i32,
     cursor_y: i32,
+    virtual_left: i32,
+    virtual_top: i32,
+    virtual_width: i32,
+    virtual_height: i32,
 ) {
     if !(config.enabled && config.zoom_enabled && surgical_active) {
         state.visible = false;
+        state.pending_refresh = false;
         return;
     }
 
     state.visible = true;
     state.x = cursor_x + config.overlay_offset_x;
     state.y = cursor_y + config.overlay_offset_y;
+    let source_size = ((config.zoom_size_px as f32) / config.zoom_scale).round().max(1.0) as i32;
+    let (source_left, source_top) = surgical_zoom_source_rect(cursor_x, cursor_y, source_size, virtual_left, virtual_top, virtual_width, virtual_height);
+    state.source_left = source_left;
+    state.source_top = source_top;
+    state.source_size_px = source_size;
+    state.center_crosshair = config.center_crosshair;
+    state.pending_refresh = true;
+}
+
+pub fn surgical_zoom_source_rect(
+    cursor_x: i32,
+    cursor_y: i32,
+    source_size_px: i32,
+    virtual_left: i32,
+    virtual_top: i32,
+    virtual_width: i32,
+    virtual_height: i32,
+) -> (i32, i32) {
+    let half = source_size_px / 2;
+    let source_width = source_size_px.min(virtual_width.max(1));
+    let source_height = source_size_px.min(virtual_height.max(1));
+    let max_left = virtual_left + virtual_width - source_width;
+    let max_top = virtual_top + virtual_height - source_height;
+    (
+        (cursor_x - half).clamp(virtual_left, max_left),
+        (cursor_y - half).clamp(virtual_top, max_top),
+    )
+}
+
+pub fn zoom_refresh_throttles_to_configured_interval(
+    last_refresh: Option<Instant>,
+    now: Instant,
+    refresh_interval_ms: u64,
+) -> bool {
+    if refresh_interval_ms == 0 {
+        return true;
+    }
+    let interval = Duration::from_millis(refresh_interval_ms);
+    last_refresh.is_none_or(|ts| now.duration_since(ts) >= interval)
 }
 
 #[cfg(test)]
@@ -37,7 +105,14 @@ mod tests {
     use super::*;
 
     #[test]
-    fn activation_and_deactivation_toggle_visibility() {
+    fn surgical_zoom_source_rect_clamps_at_screen_edges() {
+        assert_eq!(surgical_zoom_source_rect(2, 2, 100, 0, 0, 1920, 1080), (0, 0));
+        assert_eq!(surgical_zoom_source_rect(1919, 1079, 100, 0, 0, 1920, 1080), (1820, 980));
+        assert_eq!(surgical_zoom_source_rect(-1900, -100, 120, -1920, -200, 3840, 2160), (-1920, -160));
+    }
+
+    #[test]
+    fn overlay_position_applies_configured_offsets() {
         let mut state = SurgicalZoomState::default();
         let cfg = SurgicalZoomConfig {
             enabled: true,
@@ -45,14 +120,29 @@ mod tests {
             zoom_scale: 2.0,
             zoom_size_px: 180,
             overlay_offset_x: 24,
-            overlay_offset_y: 24,
+            overlay_offset_y: 12,
+            refresh_interval_ms: 16,
+            center_crosshair: true,
         };
+        update_zoom_state(&mut state, cfg, true, 100, 200, 0, 0, 1920, 1080);
+        assert_eq!((state.x, state.y), (124, 212));
+    }
 
-        update_zoom_state(&mut state, cfg, true, 100, 200);
+    #[test]
+    fn surgical_mode_visibility_toggles_overlay_state() {
+        let mut state = SurgicalZoomState::default();
+        let cfg = SurgicalZoomConfig { enabled: true, zoom_enabled: true, zoom_scale: 2.0, zoom_size_px: 180, overlay_offset_x: 0, overlay_offset_y: 0, refresh_interval_ms: 16, center_crosshair: false };
+        update_zoom_state(&mut state, cfg, true, 10, 20, 0, 0, 100, 100);
         assert!(state.visible);
-        assert_eq!((state.x, state.y), (124, 224));
-
-        update_zoom_state(&mut state, cfg, false, 100, 200);
+        update_zoom_state(&mut state, cfg, false, 10, 20, 0, 0, 100, 100);
         assert!(!state.visible);
+    }
+
+    #[test]
+    fn zoom_refresh_throttles_to_configured_interval() {
+        let now = Instant::now();
+        assert!(zoom_refresh_throttles_to_configured_interval(None, now, 16));
+        assert!(!zoom_refresh_throttles_to_configured_interval(Some(now), now + Duration::from_millis(8), 16));
+        assert!(zoom_refresh_throttles_to_configured_interval(Some(now), now + Duration::from_millis(16), 16));
     }
 }

--- a/src/zoom_overlay.rs
+++ b/src/zoom_overlay.rs
@@ -13,6 +13,15 @@ thread_local! {
     pub static SURGICAL_ZOOM_OVERLAY: RefCell<SurgicalZoomOverlay> = RefCell::new(SurgicalZoomOverlay::new());
 }
 
+unsafe extern "system" fn surgical_zoom_overlay_proc(
+    hwnd: HWND,
+    msg: u32,
+    wparam: WPARAM,
+    lparam: LPARAM,
+) -> LRESULT {
+    unsafe { DefWindowProcW(hwnd, msg, wparam, lparam) }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct SurgicalZoomConfig {
     pub enabled: bool,
@@ -72,7 +81,7 @@ impl SurgicalZoomOverlay {
             let hinstance = GetModuleHandleW(None).ok().unwrap_or_default();
             let class_name = w!("SurgicalZoomOverlayWindowClass");
             let wc = WNDCLASSW {
-                lpfnWndProc: Some(DefWindowProcW),
+                lpfnWndProc: Some(surgical_zoom_overlay_proc),
                 hInstance: hinstance.into(),
                 lpszClassName: class_name,
                 hCursor: LoadCursorW(None, IDC_ARROW).ok().unwrap_or_default(),
@@ -318,7 +327,7 @@ mod tests {
         assert!(!state.visible);
     }
     #[test]
-    fn zoom_refresh_throttles_to_configured_interval() {
+    fn zoom_refresh_interval_predicate() {
         let now = Instant::now();
         assert!(zoom_refresh_throttles_to_configured_interval(None, now, 16));
         assert!(!zoom_refresh_throttles_to_configured_interval(

--- a/src/zoom_overlay.rs
+++ b/src/zoom_overlay.rs
@@ -34,7 +34,7 @@ pub struct SurgicalZoomConfig {
     pub center_crosshair: bool,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct SurgicalZoomState {
     pub visible: bool,
     pub x: i32,
@@ -46,19 +46,12 @@ pub struct SurgicalZoomState {
     pub pending_refresh: bool,
 }
 
-impl Default for SurgicalZoomState {
-    fn default() -> Self {
-        Self {
-            visible: false,
-            x: 0,
-            y: 0,
-            source_left: 0,
-            source_top: 0,
-            source_size_px: 0,
-            center_crosshair: false,
-            pending_refresh: false,
-        }
-    }
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct VirtualScreenBounds {
+    pub left: i32,
+    pub top: i32,
+    pub width: i32,
+    pub height: i32,
 }
 
 pub struct SurgicalZoomOverlay {
@@ -214,10 +207,7 @@ pub fn update_zoom_state(
     surgical_active: bool,
     cursor_x: i32,
     cursor_y: i32,
-    virtual_left: i32,
-    virtual_top: i32,
-    virtual_width: i32,
-    virtual_height: i32,
+    virtual_screen: VirtualScreenBounds,
 ) {
     if !(config.enabled && config.zoom_enabled && surgical_active) {
         state.visible = false;
@@ -234,10 +224,10 @@ pub fn update_zoom_state(
         cursor_x,
         cursor_y,
         source_size,
-        virtual_left,
-        virtual_top,
-        virtual_width,
-        virtual_height,
+        virtual_screen.left,
+        virtual_screen.top,
+        virtual_screen.width,
+        virtual_screen.height,
     );
     state.source_left = source_left;
     state.source_top = source_top;
@@ -305,7 +295,19 @@ mod tests {
             refresh_interval_ms: 16,
             center_crosshair: true,
         };
-        update_zoom_state(&mut state, cfg, true, 100, 200, 0, 0, 1920, 1080);
+        update_zoom_state(
+            &mut state,
+            cfg,
+            true,
+            100,
+            200,
+            VirtualScreenBounds {
+                left: 0,
+                top: 0,
+                width: 1920,
+                height: 1080,
+            },
+        );
         assert_eq!((state.x, state.y), (124, 212));
     }
     #[test]
@@ -321,9 +323,33 @@ mod tests {
             refresh_interval_ms: 16,
             center_crosshair: false,
         };
-        update_zoom_state(&mut state, cfg, true, 10, 20, 0, 0, 100, 100);
+        update_zoom_state(
+            &mut state,
+            cfg,
+            true,
+            10,
+            20,
+            VirtualScreenBounds {
+                left: 0,
+                top: 0,
+                width: 100,
+                height: 100,
+            },
+        );
         assert!(state.visible);
-        update_zoom_state(&mut state, cfg, false, 10, 20, 0, 0, 100, 100);
+        update_zoom_state(
+            &mut state,
+            cfg,
+            false,
+            10,
+            20,
+            VirtualScreenBounds {
+                left: 0,
+                top: 0,
+                width: 100,
+                height: 100,
+            },
+        );
         assert!(!state.visible);
     }
     #[test]

--- a/src/zoom_overlay.rs
+++ b/src/zoom_overlay.rs
@@ -1,4 +1,17 @@
+use std::cell::RefCell;
+use std::ptr;
 use std::time::{Duration, Instant};
+use windows::core::w;
+use windows::Win32::Foundation::*;
+use windows::Win32::Graphics::Gdi::*;
+use windows::Win32::System::LibraryLoader::GetModuleHandleW;
+use windows::Win32::UI::WindowsAndMessaging::*;
+
+use crate::screen_capture::capture_region_around_cursor;
+
+thread_local! {
+    pub static SURGICAL_ZOOM_OVERLAY: RefCell<SurgicalZoomOverlay> = RefCell::new(SurgicalZoomOverlay::new());
+}
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct SurgicalZoomConfig {
@@ -39,6 +52,153 @@ impl Default for SurgicalZoomState {
     }
 }
 
+pub struct SurgicalZoomOverlay {
+    hwnd: Option<HWND>,
+    last_refresh: Option<Instant>,
+}
+
+impl SurgicalZoomOverlay {
+    pub fn new() -> Self {
+        Self {
+            hwnd: None,
+            last_refresh: None,
+        }
+    }
+    fn ensure_window(&mut self) {
+        if self.hwnd.is_some() {
+            return;
+        }
+        unsafe {
+            let hinstance = GetModuleHandleW(None).ok().unwrap_or_default();
+            let class_name = w!("SurgicalZoomOverlayWindowClass");
+            let wc = WNDCLASSW {
+                lpfnWndProc: Some(DefWindowProcW),
+                hInstance: hinstance.into(),
+                lpszClassName: class_name,
+                hCursor: LoadCursorW(None, IDC_ARROW).ok().unwrap_or_default(),
+                ..Default::default()
+            };
+            let _ = RegisterClassW(&wc);
+            let hwnd = CreateWindowExW(
+                WS_EX_LAYERED
+                    | WS_EX_TOPMOST
+                    | WS_EX_TOOLWINDOW
+                    | WS_EX_TRANSPARENT
+                    | WS_EX_NOACTIVATE,
+                class_name,
+                w!("Surgical Zoom"),
+                WS_POPUP,
+                0,
+                0,
+                1,
+                1,
+                None,
+                None,
+                Some(HINSTANCE(hinstance.0)),
+                Some(ptr::null_mut()),
+            );
+            if let Ok(hwnd) = hwnd {
+                let _ = SetLayeredWindowAttributes(hwnd, COLORREF(0), 255, LWA_ALPHA);
+                self.hwnd = Some(hwnd);
+                let _ = ShowWindow(hwnd, SW_HIDE);
+            }
+        }
+    }
+
+    fn hide(&mut self) {
+        if let Some(hwnd) = self.hwnd {
+            unsafe {
+                let _ = ShowWindow(hwnd, SW_HIDE);
+            }
+        }
+    }
+
+    fn render(
+        &mut self,
+        state: &SurgicalZoomState,
+        refresh_interval_ms: u64,
+        overlay_size_px: i32,
+    ) {
+        self.ensure_window();
+        let Some(hwnd) = self.hwnd else {
+            return;
+        };
+        let now = Instant::now();
+        if !zoom_refresh_throttles_to_configured_interval(
+            self.last_refresh,
+            now,
+            refresh_interval_ms,
+        ) {
+            return;
+        }
+        let Some(snapshot) = capture_region_around_cursor(
+            state.source_left + state.source_size_px / 2,
+            state.source_top + state.source_size_px / 2,
+            state.source_size_px,
+        ) else {
+            return;
+        };
+        unsafe {
+            let _ = SetWindowPos(
+                hwnd,
+                Some(HWND_TOPMOST),
+                state.x,
+                state.y,
+                overlay_size_px,
+                overlay_size_px,
+                SWP_NOACTIVATE | SWP_SHOWWINDOW,
+            );
+            let _ = ShowWindow(hwnd, SW_SHOWNOACTIVATE);
+            let hdc = GetDC(Some(hwnd));
+            if hdc.is_invalid() {
+                return;
+            }
+            let mut rect = RECT::default();
+            let _ = GetClientRect(hwnd, &mut rect);
+            let w = rect.right - rect.left;
+            let h = rect.bottom - rect.top;
+            let _ = StretchBlt(
+                hdc,
+                0,
+                0,
+                w,
+                h,
+                Some(snapshot.hdc()),
+                0,
+                0,
+                snapshot.width,
+                snapshot.height,
+                SRCCOPY,
+            );
+            if state.center_crosshair {
+                let pen = CreatePen(PS_SOLID, 1, COLORREF(0x0000FF));
+                let old = SelectObject(hdc, pen.into());
+                let cx = w / 2;
+                let cy = h / 2;
+                let _ = MoveToEx(hdc, cx - 10, cy, None);
+                let _ = LineTo(hdc, cx + 10, cy);
+                let _ = MoveToEx(hdc, cx, cy - 10, None);
+                let _ = LineTo(hdc, cx, cy + 10);
+                let _ = SelectObject(hdc, old);
+                let _ = DeleteObject(pen.into());
+            }
+            let _ = ReleaseDC(Some(hwnd), hdc);
+        }
+        self.last_refresh = Some(now);
+    }
+}
+
+pub fn sync_surgical_zoom_overlay(state: SurgicalZoomState, config: SurgicalZoomConfig) {
+    SURGICAL_ZOOM_OVERLAY.with(|ov| {
+        let mut ov = ov.borrow_mut();
+        if !(state.visible && config.enabled && config.zoom_enabled) {
+            ov.hide();
+            return;
+        }
+        ov.render(&state, config.refresh_interval_ms, config.zoom_size_px);
+    });
+}
+
 pub fn update_zoom_state(
     state: &mut SurgicalZoomState,
     config: SurgicalZoomConfig,
@@ -55,12 +215,21 @@ pub fn update_zoom_state(
         state.pending_refresh = false;
         return;
     }
-
     state.visible = true;
     state.x = cursor_x + config.overlay_offset_x;
     state.y = cursor_y + config.overlay_offset_y;
-    let source_size = ((config.zoom_size_px as f32) / config.zoom_scale).round().max(1.0) as i32;
-    let (source_left, source_top) = surgical_zoom_source_rect(cursor_x, cursor_y, source_size, virtual_left, virtual_top, virtual_width, virtual_height);
+    let source_size = ((config.zoom_size_px as f32) / config.zoom_scale)
+        .round()
+        .max(1.0) as i32;
+    let (source_left, source_top) = surgical_zoom_source_rect(
+        cursor_x,
+        cursor_y,
+        source_size,
+        virtual_left,
+        virtual_top,
+        virtual_width,
+        virtual_height,
+    );
     state.source_left = source_left;
     state.source_top = source_top;
     state.source_size_px = source_size;
@@ -103,14 +272,17 @@ pub fn zoom_refresh_throttles_to_configured_interval(
 #[cfg(test)]
 mod tests {
     use super::*;
-
     #[test]
     fn surgical_zoom_source_rect_clamps_at_screen_edges() {
-        assert_eq!(surgical_zoom_source_rect(2, 2, 100, 0, 0, 1920, 1080), (0, 0));
-        assert_eq!(surgical_zoom_source_rect(1919, 1079, 100, 0, 0, 1920, 1080), (1820, 980));
-        assert_eq!(surgical_zoom_source_rect(-1900, -100, 120, -1920, -200, 3840, 2160), (-1920, -160));
+        assert_eq!(
+            surgical_zoom_source_rect(2, 2, 100, 0, 0, 1920, 1080),
+            (0, 0)
+        );
+        assert_eq!(
+            surgical_zoom_source_rect(1919, 1079, 100, 0, 0, 1920, 1080),
+            (1820, 980)
+        );
     }
-
     #[test]
     fn overlay_position_applies_configured_offsets() {
         let mut state = SurgicalZoomState::default();
@@ -127,22 +299,37 @@ mod tests {
         update_zoom_state(&mut state, cfg, true, 100, 200, 0, 0, 1920, 1080);
         assert_eq!((state.x, state.y), (124, 212));
     }
-
     #[test]
     fn surgical_mode_visibility_toggles_overlay_state() {
         let mut state = SurgicalZoomState::default();
-        let cfg = SurgicalZoomConfig { enabled: true, zoom_enabled: true, zoom_scale: 2.0, zoom_size_px: 180, overlay_offset_x: 0, overlay_offset_y: 0, refresh_interval_ms: 16, center_crosshair: false };
+        let cfg = SurgicalZoomConfig {
+            enabled: true,
+            zoom_enabled: true,
+            zoom_scale: 2.0,
+            zoom_size_px: 180,
+            overlay_offset_x: 0,
+            overlay_offset_y: 0,
+            refresh_interval_ms: 16,
+            center_crosshair: false,
+        };
         update_zoom_state(&mut state, cfg, true, 10, 20, 0, 0, 100, 100);
         assert!(state.visible);
         update_zoom_state(&mut state, cfg, false, 10, 20, 0, 0, 100, 100);
         assert!(!state.visible);
     }
-
     #[test]
     fn zoom_refresh_throttles_to_configured_interval() {
         let now = Instant::now();
         assert!(zoom_refresh_throttles_to_configured_interval(None, now, 16));
-        assert!(!zoom_refresh_throttles_to_configured_interval(Some(now), now + Duration::from_millis(8), 16));
-        assert!(zoom_refresh_throttles_to_configured_interval(Some(now), now + Duration::from_millis(16), 16));
+        assert!(!zoom_refresh_throttles_to_configured_interval(
+            Some(now),
+            now + Duration::from_millis(8),
+            16
+        ));
+        assert!(zoom_refresh_throttles_to_configured_interval(
+            Some(now),
+            now + Duration::from_millis(16),
+            16
+        ));
     }
 }


### PR DESCRIPTION
### Motivation
- Provide a real surgical zoom overlay plumbing so surgical hold can show a magnified, clamped view around the cursor without stealing focus or breaking multi-monitor math.
- Add capture and throttling scaffolding so rendered updates can be rate-limited and safely handle edge-of-monitor and negative virtual-origin coordinate systems.

### Description
- Added richer surgical zoom state and helpers in `src/zoom_overlay.rs`, including overlay position offsets, source-region computation clamped to the virtual desktop, source-size derivation from `zoom_scale`, an optional center crosshair flag, and a refresh-throttle predicate (`zoom_refresh_throttles_to_configured_interval`).
- Implemented `capture_region_around_cursor` in `src/screen_capture.rs` to snapshot a clamped square region centered on the cursor, handling multi-monitor/negative virtual origins and returning a `ScreenSnapshot`.
- Wired the overlay lifecycle to surgical-mode hold/release in `src/action_handler.rs` by passing virtual-screen bounds and new surgical config fields into `update_zoom_state` on each movement tick.
- Extended surgical-mode configuration in `src/main.rs` with `refresh_interval_ms` and `center_crosshair` (defaults and normalization clamp), and added the new keys to the config audit whitelist in `src/config_audit.rs`.
- Updated `config.toml` and `docs/config.md` to document the overlay semantics and the two new knobs; the overlay is described as topmost, non-activating, and click-through.
- Added logic-level unit tests located in `src/zoom_overlay.rs` for source clamping, refresh throttling, overlay offset application, and visibility toggling:
  `surgical_zoom_source_rect_clamps_at_screen_edges`, `zoom_refresh_throttles_to_configured_interval`, `overlay_position_applies_configured_offsets`, and `surgical_mode_visibility_toggles_overlay_state`.

### Testing
- Added the four logic-level unit tests described above and attempted to run them locally in this environment.
- Test execution was blocked by the build in this Linux container due to a missing system dependency required by the `x11` crate (`xi.pc`/xi pkg-config library), so the Rust test run could not complete here.
- Manual verification on Windows is still required for topmost / non-activating / click-through behavior; no runtime UI-level tests were performed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a176e63100c8332a2aef2df83b52627)