### PR TITLE
Decouple modifier reconcile cadence from stuck key timeout

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -128,8 +128,9 @@ modifier_reconcile_on_tick = true
 modifier_reconcile_interval_ms = 50
 # Stale-key recovery: if a tracked held key has not produced expected transitions
 # for this timeout window, it may be treated as stuck and reconciled against
-# current OS modifier state. Reconciliation cadence is max(interval, timeout), so
-# this timeout effectively gates how often stale key recovery checks can run.
+# current OS modifier state. Reconciliation runs every
+# modifier_reconcile_interval_ms; this timeout is only the stale-duration
+# threshold used for classification/diagnostics.
 stuck_key_timeout_ms = 10000
 debug_input = false
 shift_can_modify_plain_movement = true

--- a/docs/config.md
+++ b/docs/config.md
@@ -142,8 +142,8 @@ key_bindings = [
 | `system_bindings.panic_reset_sets_idle` | boolean | `true` | Yes | Active | When true, panic reset also sets idle mode (`SetActiveMode { active = false }`). |
 | `input.swallow_owned_modifiers` | boolean | `true` | Yes | Active | Swallow app-owned modifier down/up transitions while active mode is enabled. |
 | `input.modifier_reconcile_on_tick` | boolean | `true` | Yes | Active | Enables periodic modifier reconciliation checks. |
-| `input.modifier_reconcile_interval_ms` | integer milliseconds | `50` | Yes | Active | Base polling interval for modifier reconciliation; normalized to `10..=5000` and reset to default when `0`. |
-| `input.stuck_key_timeout_ms` | integer milliseconds | `10000` | Yes | Active | Timeout used to classify stale held keys as stuck; normalized to `500..=60000` and reset to default when `0`. |
+| `input.modifier_reconcile_interval_ms` | integer milliseconds | `50` | Yes | Active | Polling interval for periodic modifier reconciliation; normalized to `10..=5000` and reset to default when `0`. |
+| `input.stuck_key_timeout_ms` | integer milliseconds | `10000` | Yes | Active | Stale-duration threshold used to classify tracked held keys as stuck for diagnostics/recovery; normalized to `500..=60000` and reset to default when `0`. |
 | `input.debug_input` | boolean | `false` | Yes | Active | Enables verbose debug-input logs (raw keys, swallow reasons, system matches, trigger tracking). |
 | `input.shift_can_modify_plain_movement` | boolean | `true` | Yes | Active | Keeps shift-relaxed plain-movement matching enabled. |
 | `mouse_speed.default_speed` | integer | `1` | Yes | Active | Normal held-movement speed and replacement for legacy `starting_speed`. |
@@ -417,7 +417,7 @@ font_scale = 1.1
 
 - `selection_keys` removes whitespace, uppercases alpha keys, and removes duplicates while preserving first occurrence order.
 - Values outside supported ranges are normalized and logged as config warnings so the mode remains usable.
-- For input stale-key recovery, reconcile cadence is `max(input.modifier_reconcile_interval_ms, input.stuck_key_timeout_ms)`, so the timeout can effectively gate how often reconcile ticks run.
+- For input stale-key recovery, reconcile ticks run every `input.modifier_reconcile_interval_ms`; `input.stuck_key_timeout_ms` only controls when a held key is considered stale/stuck.
 - Duplicate and deeply nested UIA controls are common in complex apps; increase `min_hint_spacing_px` to reduce visual crowding.
 - When many controls are visible (for example browsers/Electron apps), results may be capped by `max_hints`; consider larger `selection_keys` and spacing tuning before raising the cap aggressively.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2724,13 +2724,9 @@ fn should_run_modifier_reconcile(
     if !config.modifier_reconcile_on_tick {
         return false;
     }
-    // Reconciliation must run no faster than either interval:
-    // - modifier_reconcile_interval_ms: regular polling cadence
-    // - stuck_key_timeout_ms: stale key recovery timeout
-    // The max() means stale key timeout effectively gates the cadence.
-    let cadence_ms = config
-        .modifier_reconcile_interval_ms
-        .max(config.stuck_key_timeout_ms);
+    // Reconciliation cadence is controlled only by modifier_reconcile_interval_ms.
+    // stuck_key_timeout_ms is used by stale-key diagnostics/classification logic.
+    let cadence_ms = config.modifier_reconcile_interval_ms;
     elapsed_since_last_reconcile >= Duration::from_millis(cadence_ms)
 }
 
@@ -8141,7 +8137,7 @@ mod bookmark_runtime_logic_tests {
     }
 
     #[test]
-    fn modifier_reconcile_is_cadence_gated() {
+    fn reconcile_cadence_not_gated_by_stuck_timeout() {
         let mut input = InputConfig::default();
         input.modifier_reconcile_on_tick = true;
         input.modifier_reconcile_interval_ms = 50;
@@ -8149,21 +8145,16 @@ mod bookmark_runtime_logic_tests {
 
         assert!(!should_run_modifier_reconcile(
             &input,
-            Duration::from_millis(9_999)
-        ));
-        assert!(should_run_modifier_reconcile(
-            &input,
-            Duration::from_millis(10_000)
-        ));
-
-        input.stuck_key_timeout_ms = 10;
-        assert!(!should_run_modifier_reconcile(
-            &input,
             Duration::from_millis(49)
         ));
         assert!(should_run_modifier_reconcile(
             &input,
             Duration::from_millis(50)
+        ));
+
+        assert!(should_run_modifier_reconcile(
+            &input,
+            Duration::from_millis(9_999)
         ));
 
         input.modifier_reconcile_on_tick = false;


### PR DESCRIPTION
### Motivation
- Fix a bug where `stuck_key_timeout_ms` was inadvertently gating modifier-reconcile scheduling, causing reconciles to run at the larger of the interval and timeout instead of the intended polling cadence. 
- Preserve `stuck_key_timeout_ms` semantics for classifying stale held keys and diagnostics without letting it affect the scheduler. 
- Add a focused regression test that documents and prevents this behavior from regressing. 

### Description
- Change `should_run_modifier_reconcile` to use only `input.modifier_reconcile_interval_ms` for cadence and update the inline comment to state that `stuck_key_timeout_ms` is for stale-key diagnostics; file modified: `src/main.rs`. 
- Replace and rename the test to `reconcile_cadence_not_gated_by_stuck_timeout` and adjust assertions to verify `elapsed=49ms => no reconcile`, `elapsed=50ms => reconcile`, and `elapsed=9999ms => reconcile` with `interval=50` and `timeout=10000`; file modified: `src/main.rs`. 
- Update `config.toml` comments to state reconciliation runs every `modifier_reconcile_interval_ms` and that `stuck_key_timeout_ms` is a stale-duration threshold. 
- Update `docs/config.md` to clarify that `modifier_reconcile_interval_ms` controls reconcile ticks and `stuck_key_timeout_ms` only controls stale/stuck classification. 

### Testing
- Ran `cargo test reconcile_cadence_not_gated_by_stuck_timeout -- --nocapture` to exercise the new regression test. 
- The test run failed to build in this environment due to a system dependency error: the `x11` crate requires the `xi` system library and `pkg-config` could not find `xi` (`Package xi was not found in the pkg-config search path`). 
- No other automated test changes were executed here because the build failure prevents running the full test suite in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1781f0e3548332a4312dbe7d5ad649)