### PR TITLE
Refactor keyboard hook decoding to pure side-aware input decoder

### DIFF
--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -18,10 +18,17 @@ pub struct KeyEvent {
     pub key: VirtualKey,
     pub is_down: bool,
     pub alt_down: bool,
+    pub left_alt_down: bool,
     pub right_alt_down: bool,
     pub ctrl_down: bool,
+    pub left_ctrl_down: bool,
+    pub right_ctrl_down: bool,
     pub shift_down: bool,
+    pub left_shift_down: bool,
+    pub right_shift_down: bool,
     pub win_down: bool,
+    pub left_win_down: bool,
+    pub right_win_down: bool,
 }
 
 impl KeyEvent {
@@ -30,10 +37,40 @@ impl KeyEvent {
             key,
             is_down,
             alt_down: false,
+            left_alt_down: false,
             right_alt_down: false,
             ctrl_down: false,
+            left_ctrl_down: false,
+            right_ctrl_down: false,
             shift_down: false,
+            left_shift_down: false,
+            right_shift_down: false,
             win_down: false,
+            left_win_down: false,
+            right_win_down: false,
+        }
+    }
+
+    pub fn with_modifier_state(
+        key: VirtualKey,
+        is_down: bool,
+        modifiers: crate::input_decode::ModifierSnapshot,
+    ) -> Self {
+        Self {
+            key,
+            is_down,
+            alt_down: modifiers.left_alt || modifiers.right_alt,
+            left_alt_down: modifiers.left_alt,
+            right_alt_down: modifiers.right_alt,
+            ctrl_down: modifiers.left_ctrl || modifiers.right_ctrl,
+            left_ctrl_down: modifiers.left_ctrl,
+            right_ctrl_down: modifiers.right_ctrl,
+            shift_down: modifiers.left_shift || modifiers.right_shift,
+            left_shift_down: modifiers.left_shift,
+            right_shift_down: modifiers.right_shift,
+            win_down: modifiers.left_win || modifiers.right_win,
+            left_win_down: modifiers.left_win,
+            right_win_down: modifiers.right_win,
         }
     }
 }

--- a/src/input_decode.rs
+++ b/src/input_decode.rs
@@ -1,0 +1,120 @@
+use crate::keyboard::VirtualKey;
+
+pub const LLKHF_EXTENDED_BIT: u32 = 0x01;
+const LEFT_SHIFT_SCANCODE: u32 = 0x2A;
+const RIGHT_SHIFT_SCANCODE: u32 = 0x36;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RawKeyboardHookEvent {
+    pub vk_code: u32,
+    pub scan_code: u32,
+    pub flags: u32,
+    pub is_down: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct ModifierSnapshot {
+    pub left_alt: bool,
+    pub right_alt: bool,
+    pub left_ctrl: bool,
+    pub right_ctrl: bool,
+    pub left_shift: bool,
+    pub right_shift: bool,
+    pub left_win: bool,
+    pub right_win: bool,
+}
+
+pub fn decode_virtual_key_from_hook(raw: RawKeyboardHookEvent) -> Option<VirtualKey> {
+    match raw.vk_code {
+        0x10 => match raw.scan_code {
+            RIGHT_SHIFT_SCANCODE => Some(VirtualKey::RightShift),
+            LEFT_SHIFT_SCANCODE => Some(VirtualKey::LeftShift),
+            _ => Some(VirtualKey::Shift),
+        },
+        0x11 => {
+            if raw.flags & LLKHF_EXTENDED_BIT != 0 {
+                Some(VirtualKey::RightCtrl)
+            } else {
+                Some(VirtualKey::LeftCtrl)
+            }
+        }
+        0x12 => {
+            if raw.flags & LLKHF_EXTENDED_BIT != 0 {
+                Some(VirtualKey::RightAlt)
+            } else {
+                Some(VirtualKey::LeftAlt)
+            }
+        }
+        0x5B => Some(VirtualKey::LeftWin),
+        0x5C => Some(VirtualKey::RightWin),
+        _ => VirtualKey::from_vk_code(raw.vk_code),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decode_vk_menu_extended_is_rightalt() {
+        let key = decode_virtual_key_from_hook(RawKeyboardHookEvent {
+            vk_code: 0x12,
+            scan_code: 0,
+            flags: LLKHF_EXTENDED_BIT,
+            is_down: true,
+        });
+        assert_eq!(key, Some(VirtualKey::RightAlt));
+    }
+
+    #[test]
+    fn decode_vk_menu_nonextended_is_leftalt() {
+        let key = decode_virtual_key_from_hook(RawKeyboardHookEvent {
+            vk_code: 0x12,
+            scan_code: 0,
+            flags: 0,
+            is_down: true,
+        });
+        assert_eq!(key, Some(VirtualKey::LeftAlt));
+    }
+
+    #[test]
+    fn decode_vk_control_extended_is_rightctrl() {
+        let key = decode_virtual_key_from_hook(RawKeyboardHookEvent {
+            vk_code: 0x11,
+            scan_code: 0,
+            flags: LLKHF_EXTENDED_BIT,
+            is_down: true,
+        });
+        assert_eq!(key, Some(VirtualKey::RightCtrl));
+    }
+
+    #[test]
+    fn decode_vk_control_nonextended_is_leftctrl() {
+        let key = decode_virtual_key_from_hook(RawKeyboardHookEvent {
+            vk_code: 0x11,
+            scan_code: 0,
+            flags: 0,
+            is_down: true,
+        });
+        assert_eq!(key, Some(VirtualKey::LeftCtrl));
+    }
+
+    #[test]
+    fn decode_shift_left_right_by_scancode() {
+        let left = decode_virtual_key_from_hook(RawKeyboardHookEvent {
+            vk_code: 0x10,
+            scan_code: 0x2A,
+            flags: 0,
+            is_down: true,
+        });
+        let right = decode_virtual_key_from_hook(RawKeyboardHookEvent {
+            vk_code: 0x10,
+            scan_code: 0x36,
+            flags: 0,
+            is_down: true,
+        });
+
+        assert_eq!(left, Some(VirtualKey::LeftShift));
+        assert_eq!(right, Some(VirtualKey::RightShift));
+    }
+}

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -145,6 +145,8 @@ pub enum VirtualKey {
     RightCtrl,
     LeftAlt,
     RightAlt,
+    LeftWin,
+    RightWin,
 }
 
 impl VirtualKey {
@@ -282,6 +284,8 @@ impl VirtualKey {
             "RIGHTCTRL" => Some(Self::RightCtrl),
             "LEFTALT" => Some(Self::LeftAlt),
             "RIGHTALT" | "RIGHT_ALT" | "RALT" => Some(Self::RightAlt),
+            "LEFTWIN" | "LWIN" => Some(Self::LeftWin),
+            "RIGHTWIN" | "RWIN" => Some(Self::RightWin),
 
             _ => None,
         }
@@ -422,6 +426,8 @@ impl VirtualKey {
             Self::RightCtrl => 0xA3,
             Self::LeftAlt => 0xA4,
             Self::RightAlt => 0xA5,
+            Self::LeftWin => 0x5B,
+            Self::RightWin => 0x5C,
         }
     }
 
@@ -559,6 +565,8 @@ impl VirtualKey {
             0xA3 => Some(Self::RightCtrl),
             0xA4 => Some(Self::LeftAlt),
             0xA5 => Some(Self::RightAlt),
+            0x5B => Some(Self::LeftWin),
+            0x5C => Some(Self::RightWin),
 
             _ => None,
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ mod config_audit;
 mod grid_session;
 mod help_overlay;
 mod indicator;
+mod input_decode;
 mod jump_grid;
 mod jump_overlay;
 mod jump_session;
@@ -38,6 +39,7 @@ use indicator::{
 use jump_overlay::{
     hide_jump_overlay, show_jump_overlay, update_jump_overlay, virtual_screen_region,
 };
+use input_decode::{decode_virtual_key_from_hook, ModifierSnapshot, RawKeyboardHookEvent};
 use jump_session::JumpSessionUpdate;
 use jump_view::{JumpLabelMetadata, JumpVisuals};
 use key_chord::{KeyChord, RuntimeSystemBindings};
@@ -2731,29 +2733,33 @@ fn should_run_modifier_reconcile(
 }
 
 fn decode_key_event(w_param: WPARAM, kbd: KBDLLHOOKSTRUCT) -> Option<KeyEvent> {
-    let key = VirtualKey::from_vk_code(kbd.vkCode)?;
     let is_down = w_param.0 as u32 == WM_KEYDOWN || w_param.0 as u32 == WM_SYSKEYDOWN;
-    let right_alt_down =
-        modifier_down(VirtualKey::RightAlt.to_vk_code() as i32) || key == VirtualKey::RightAlt;
-    let alt_down = right_alt_down
-        || (kbd.flags & LLKHF_ALTDOWN)
-            != windows::Win32::UI::WindowsAndMessaging::KBDLLHOOKSTRUCT_FLAGS(0);
-
-    Some(KeyEvent {
-        key,
+    let raw = RawKeyboardHookEvent {
+        vk_code: kbd.vkCode,
+        scan_code: kbd.scanCode,
+        flags: kbd.flags.0,
         is_down,
-        alt_down,
-        right_alt_down,
-        ctrl_down: modifier_down(0x11)
-            || key == VirtualKey::Ctrl
-            || key == VirtualKey::LeftCtrl
-            || key == VirtualKey::RightCtrl,
-        shift_down: modifier_down(0x10)
-            || key == VirtualKey::Shift
-            || key == VirtualKey::LeftShift
-            || key == VirtualKey::RightShift,
-        win_down: modifier_down(0x5B) || modifier_down(0x5C),
-    })
+    };
+    let key = decode_virtual_key_from_hook(raw)?;
+    let modifiers = ModifierSnapshot {
+        left_alt: modifier_down(VirtualKey::LeftAlt.to_vk_code() as i32)
+            || (key == VirtualKey::LeftAlt && is_down),
+        right_alt: modifier_down(VirtualKey::RightAlt.to_vk_code() as i32)
+            || (key == VirtualKey::RightAlt && is_down),
+        left_ctrl: modifier_down(VirtualKey::LeftCtrl.to_vk_code() as i32)
+            || (key == VirtualKey::LeftCtrl && is_down),
+        right_ctrl: modifier_down(VirtualKey::RightCtrl.to_vk_code() as i32)
+            || (key == VirtualKey::RightCtrl && is_down),
+        left_shift: modifier_down(VirtualKey::LeftShift.to_vk_code() as i32)
+            || (key == VirtualKey::LeftShift && is_down),
+        right_shift: modifier_down(VirtualKey::RightShift.to_vk_code() as i32)
+            || (key == VirtualKey::RightShift && is_down),
+        left_win: modifier_down(VirtualKey::LeftWin.to_vk_code() as i32)
+            || (key == VirtualKey::LeftWin && is_down),
+        right_win: modifier_down(VirtualKey::RightWin.to_vk_code() as i32)
+            || (key == VirtualKey::RightWin && is_down),
+    };
+    Some(KeyEvent::with_modifier_state(key, is_down, modifiers))
 }
 
 fn is_keyboard_hook_key_message(code: i32, w_param: WPARAM) -> bool {


### PR DESCRIPTION
### Motivation
- Make Win32 keyboard hook decoding deterministic and testable by moving decoding logic into a pure function and exposing explicit side-aware modifier semantics.
- Keep the low-level hook adapter in `src/main.rs` thin so it only converts the raw Windows payload into a small raw representation and then builds a `KeyEvent` from the decoded result.
- Make modifier state explicit (left/right) so higher-level logic can rely on precise modifier identity and derive generic modifier booleans from those side-specific flags.

### Description
- Added a new decoding module `src/input_decode.rs` that defines `RawKeyboardHookEvent`, `ModifierSnapshot`, and the pure function `decode_virtual_key_from_hook(raw) -> Option<VirtualKey>` with explicit rules for Alt/Ctrl/Shift/Win decoding (VK_MENU and VK_CONTROL extended bit behavior, Shift by scan code, `VK_LWIN`/`VK_RWIN`).
- Kept the hook adapter thin in `src/main.rs` by constructing a `RawKeyboardHookEvent` from the `KBDLLHOOKSTRUCT`, decoding the virtual key with `decode_virtual_key_from_hook`, building a `ModifierSnapshot` using `GetAsyncKeyState` and the decoded key, and producing a `KeyEvent` via `KeyEvent::with_modifier_state(...)`.
- Expanded `KeyEvent` in `src/app_state.rs` to include side-specific booleans (`left_alt_down`, `right_alt_down`, `left_ctrl_down`, `right_ctrl_down`, `left_shift_down`, `right_shift_down`, `left_win_down`, `right_win_down`) and provided `with_modifier_state` which sets these and derives generic booleans (`alt_down`, `ctrl_down`, `shift_down`, `win_down`).
- Extended `VirtualKey` in `src/keyboard.rs` with `LeftWin` and `RightWin` and added the corresponding string parsing and VK-code mappings so the decoder and higher layers can represent Win keys explicitly.
- Added unit tests in `src/input_decode.rs` validating the decode rules: `decode_vk_menu_extended_is_rightalt`, `decode_vk_menu_nonextended_is_leftalt`, `decode_vk_control_extended_is_rightctrl`, `decode_vk_control_nonextended_is_leftctrl`, and `decode_shift_left_right_by_scancode`.

### Testing
- Ran `cargo test -q` in the environment which failed due to a missing system dependency required by the `x11` crate (`pkg-config` could not find `xi`), so the full test suite did not complete.
- The new decoder unit tests are included under `src/input_decode.rs` and are written as standard `#[test]` cases, but they were not executed successfully in this environment because the overall `cargo test` invocation failed for the reason above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1782aa7cc08332b15117f0181815f7)