### PR TITLE
Handle AltGr (RightAlt) synthetic Ctrl in binding precedence

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -128,6 +128,29 @@ key_bindings = [
 ]
 ```
 
+### AltGr (`RightAlt`) synthetic Ctrl compatibility
+
+Many layouts emit AltGr as `RightAlt` plus a synthetic `Ctrl` state. To keep `RightAlt+<key>` bindings usable, the input flag below defaults to enabled:
+
+- `input.right_alt_suppresses_synthetic_ctrl = true`
+
+When enabled, binding matching and swallow/passthrough shortcut decisions treat `Ctrl` as **not held** if all of the following are true:
+
+- `RightAlt` is down,
+- `ctrl_down` is true only because of synthetic AltGr behavior, and
+- neither physical Ctrl key (`left_ctrl_down` / `right_ctrl_down`) is pressed.
+
+This preserves distinctions such as:
+
+- `RightAlt+E` matching without requiring physical Ctrl.
+- `RightAlt+Ctrl+E` still requiring a real physical Ctrl key.
+
+Swallow precedence is:
+
+1. Explicit configured/system bindings claim the key event first.
+2. If no explicit binding matches, preserved shortcuts (for example `Ctrl+W`, `Alt+Tab`, `Alt+F4`, and Win shortcuts) pass through.
+3. Remaining active-mode trigger release cleanup still swallows where needed.
+
 ## Config Paths
 
 | Config path | Type | Default | Connected? | Status | Notes |
@@ -146,6 +169,7 @@ key_bindings = [
 | `input.stuck_key_timeout_ms` | integer milliseconds | `10000` | Yes | Active | Stale-duration threshold used to classify tracked held keys as stuck for diagnostics/recovery; normalized to `500..=60000` and reset to default when `0`. |
 | `input.debug_input` | boolean | `false` | Yes | Active | Enables verbose debug-input logs (raw keys, swallow reasons, system matches, trigger tracking). |
 | `input.shift_can_modify_plain_movement` | boolean | `true` | Yes | Active | Keeps shift-relaxed plain-movement matching enabled. |
+| `input.right_alt_suppresses_synthetic_ctrl` | boolean | `true` | Yes | Active | When true, AltGr-style synthetic Ctrl is ignored for matching/passthrough decisions while RightAlt is held, unless a physical Ctrl key is also down. |
 | `mouse_speed.default_speed` | integer | `1` | Yes | Active | Normal held-movement speed and replacement for legacy `starting_speed`. |
 | `mouse_speed.min_speed` | integer | `1` | Yes | Active | Lower bound for runtime mouse speed changes. |
 | `mouse_speed.max_speed` | integer | `12` | Yes | Active | Upper bound for runtime mouse speed changes. |

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -144,6 +144,7 @@ pub struct AppState {
     bookmark_mode: BookmarkModeState,
     active_mode: bool,
     preserve_global_shortcuts: bool,
+    right_alt_suppresses_synthetic_ctrl: bool,
     system_bindings: RuntimeSystemBindings,
     help_visible: bool,
     grid_direction_labels: GridDirectionLabels,
@@ -286,6 +287,7 @@ impl Default for AppState {
             bookmark_mode: BookmarkModeState::Inactive,
             active_mode: true,
             preserve_global_shortcuts: true,
+            right_alt_suppresses_synthetic_ctrl: true,
             system_bindings: RuntimeSystemBindings::default(),
             help_visible: false,
             grid_direction_labels: GridDirectionLabels::default(),
@@ -976,22 +978,36 @@ impl AppState {
             return true;
         }
 
+        let has_explicit_binding = self.has_explicit_configured_binding_for_event(event);
+        if has_explicit_binding {
+            self.debug_swallow("explicit_configured_binding", event, true);
+            return true;
+        }
+
         if self.is_preserved_shortcut(event) {
             self.debug_swallow("preserved_shortcut", event, false);
             return false;
         }
 
         let swallow = self.active_mode
-            && (self.bound_chords.iter().any(|chord| {
-                (event.is_down && chord.matches_dispatch_event(event))
-                    || (!event.is_down && self.active_trigger_chords.contains(chord))
-            }) || (!event.is_down
+            && (!event.is_down
                 && self
                     .active_trigger_chords
                     .iter()
-                    .any(|chord| chord.key == event.key)));
+                    .any(|chord| chord.key == event.key));
         self.debug_swallow("binding_resolution", event, swallow);
         swallow
+    }
+
+    pub fn has_explicit_configured_binding_for_event(&self, event: &KeyEvent) -> bool {
+        if !self.active_mode {
+            return false;
+        }
+        let event = self.with_effective_ctrl_state(event);
+        self.bound_chords.iter().any(|chord| {
+            (event.is_down && chord.matches_dispatch_event(&event))
+                || (!event.is_down && self.active_trigger_chords.contains(chord))
+        })
     }
 
     pub fn route_key_event(&mut self, event: KeyEvent, mut action: Option<Action>) {
@@ -1326,6 +1342,7 @@ impl AppState {
         if !self.preserve_global_shortcuts {
             return false;
         }
+        let event = self.with_effective_ctrl_state(event);
 
         event.win_down
             || (event.ctrl_down
@@ -1346,6 +1363,19 @@ impl AppState {
                         | VirtualKey::Z
                 ))
             || (event.alt_down && matches!(event.key, VirtualKey::F4 | VirtualKey::Tab))
+    }
+
+    fn with_effective_ctrl_state(&self, event: &KeyEvent) -> KeyEvent {
+        let mut effective = *event;
+        let synthetic_ctrl = event.ctrl_down && !event.left_ctrl_down && !event.right_ctrl_down;
+        if self.right_alt_suppresses_synthetic_ctrl && event.right_alt_down && synthetic_ctrl {
+            effective.ctrl_down = false;
+        }
+        effective
+    }
+
+    pub fn set_right_alt_suppresses_synthetic_ctrl(&mut self, enabled: bool) {
+        self.right_alt_suppresses_synthetic_ctrl = enabled;
     }
 }
 
@@ -1504,6 +1534,14 @@ mod tests {
 
     fn ctrl_w_down() -> KeyEvent {
         let mut event = KeyEvent::new(VirtualKey::W, true);
+        event.ctrl_down = true;
+        event
+    }
+
+    fn right_alt_e_with_synthetic_ctrl() -> KeyEvent {
+        let mut event = KeyEvent::new(VirtualKey::E, true);
+        event.alt_down = true;
+        event.right_alt_down = true;
         event.ctrl_down = true;
         event
     }
@@ -2525,6 +2563,60 @@ mod tests {
         state.route_key_event(ctrl_w, Some(Action::MoveLeft));
 
         assert_eq!(collect_commands(&mut state), Vec::new());
+    }
+
+    #[test]
+    fn rightalt_e_matches_when_synthetic_ctrl_present() {
+        let state = state_with_bound_chords([KeyChord::parse("RightAlt+E").unwrap()]);
+        let event = right_alt_e_with_synthetic_ctrl();
+
+        assert!(state.has_explicit_configured_binding_for_event(&event));
+        assert!(state.should_swallow_key(&event));
+    }
+
+    #[test]
+    fn rightalt_ctrl_e_requires_physical_ctrl() {
+        let state = state_with_bound_chords([KeyChord::parse("RightAlt+Ctrl+E").unwrap()]);
+        let synthetic = right_alt_e_with_synthetic_ctrl();
+        assert!(!state.has_explicit_configured_binding_for_event(&synthetic));
+
+        let mut physical = synthetic;
+        physical.left_ctrl_down = true;
+        assert!(state.has_explicit_configured_binding_for_event(&physical));
+    }
+
+    #[test]
+    fn ctrl_w_unconfigured_passthrough() {
+        let state = state_with_bound_key(VirtualKey::W);
+        let ctrl_w = ctrl_w_down();
+        assert!(!state.should_swallow_key(&ctrl_w));
+    }
+
+    #[test]
+    fn ctrl_w_configured_swallowed() {
+        let mut state = state_with_bound_key(VirtualKey::W);
+        state.set_system_bindings(RuntimeSystemBindings::new(
+            KeyChord::parse("Ctrl+W").unwrap(),
+            KeyChord::parse("Escape").unwrap(),
+        ));
+        let ctrl_w = ctrl_w_down();
+        assert!(state.should_swallow_key(&ctrl_w));
+    }
+
+    #[test]
+    fn alt_tab_unconfigured_passthrough() {
+        let state = state_with_bound_key(VirtualKey::Tab);
+        let mut event = KeyEvent::new(VirtualKey::Tab, true);
+        event.alt_down = true;
+        assert!(!state.should_swallow_key(&event));
+    }
+
+    #[test]
+    fn alt_f4_unconfigured_passthrough() {
+        let state = state_with_bound_key(VirtualKey::F4);
+        let mut event = KeyEvent::new(VirtualKey::F4, true);
+        event.alt_down = true;
+        assert!(!state.should_swallow_key(&event));
     }
 
     #[test]

--- a/src/config_audit.rs
+++ b/src/config_audit.rs
@@ -381,6 +381,7 @@ fn is_known_active_path(path: &str) -> bool {
         "input.stuck_key_timeout_ms",
         "input.debug_input",
         "input.shift_can_modify_plain_movement",
+        "input.right_alt_suppresses_synthetic_ctrl",
         "grid_mode.enabled",
         "grid_mode.start_region",
         "grid_mode.width_percent",

--- a/src/main.rs
+++ b/src/main.rs
@@ -498,6 +498,7 @@ struct InputConfig {
     stuck_key_timeout_ms: u64,
     debug_input: bool,
     shift_can_modify_plain_movement: bool,
+    right_alt_suppresses_synthetic_ctrl: bool,
 }
 
 impl Default for InputConfig {
@@ -509,6 +510,7 @@ impl Default for InputConfig {
             stuck_key_timeout_ms: 10_000,
             debug_input: false,
             shift_can_modify_plain_movement: true,
+            right_alt_suppresses_synthetic_ctrl: true,
         }
     }
 }
@@ -2323,6 +2325,9 @@ impl Config {
         app_state.set_bound_chords(key_actions.bound_chords());
         app_state.set_owned_modifiers(key_actions.owned_modifiers());
         app_state.set_debug_input(self.input.debug_input);
+        app_state.set_right_alt_suppresses_synthetic_ctrl(
+            self.input.right_alt_suppresses_synthetic_ctrl,
+        );
         *SHIFT_CAN_MODIFY_PLAIN_MOVEMENT.write().unwrap() =
             self.input.shift_can_modify_plain_movement;
     }


### PR DESCRIPTION
### Motivation
- Some keyboard layouts emit AltGr as `RightAlt` plus a synthetic `Ctrl`, which prevents `RightAlt+<key>` bindings from matching unless handled specially. 
- Explicit configured/system bindings should claim an event before preserved OS shortcuts are allowed to passthrough. 

### Description
- Added a new input flag `input.right_alt_suppresses_synthetic_ctrl` (default `true`) and plumbed it from `Config` into runtime via `main.rs` and `AppState`. 
- Implemented effective-Ctrl normalization with `with_effective_ctrl_state(&KeyEvent) -> KeyEvent` so `Ctrl` is treated as not-held when it appears only synthetically while `RightAlt` is down and the flag is enabled. 
- Reordered swallow logic in `AppState::should_swallow_key` so explicit configured bindings are checked first using the new helper `has_explicit_configured_binding_for_event(&KeyEvent) -> bool`, then preserved-shortcut passthrough is evaluated with the effective Ctrl state, and finally trigger-release cleanup is applied. 
- Added unit tests for the new behavior (`rightalt_e_matches_when_synthetic_ctrl_present`, `rightalt_ctrl_e_requires_physical_ctrl`, `ctrl_w_unconfigured_passthrough`, `ctrl_w_configured_swallowed`, `alt_tab_unconfigured_passthrough`, `alt_f4_unconfigured_passthrough`) and updated `docs/config.md` with an AltGr explanation and swallow precedence notes. 

### Testing
- Added the six targeted unit tests to `src/app_state.rs` to exercise synthetic-Ctrl handling and preserved-shortcut precedence. 
- An attempt was made to run the tests via `cargo test` (per-test loop), but the build failed before tests ran due to a missing system library dependency required by the `x11` crate (`xi` / `xi.pc`). 
- Because the environment lacked the `xi` pkg-config entry, automated tests could not complete here (build failed), so the new tests are present but not executed successfully in this run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17837d97c8833287898be6f52b30d3)