### PR TITLE
Refine keybinding resolution to choose best specificity deterministically

### DIFF
--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -734,8 +734,6 @@ impl KeyBindings {
         } else {
             self.bindings.push((chord, action));
         }
-        self.bindings
-            .sort_by_key(|(chord, _)| std::cmp::Reverse(chord.specificity()));
     }
 
     pub fn clear(&mut self) {
@@ -760,29 +758,27 @@ impl KeyBindings {
             return None;
         }
 
-        if let Some((chord, action)) = self
-            .bindings
-            .iter()
-            .find(|(chord, _)| chord.matches_event(event))
-        {
-            return Some(ResolvedBinding {
-                chord: *chord,
-                action: action.clone(),
-            });
+        if let Some(resolved) = self.resolve_best_match(|chord| chord.matches_event(event)) {
+            return Some(resolved);
         }
 
         if !shift_can_modify_plain_movement {
             return None;
         }
 
-        self.bindings.iter().find_map(|(chord, action)| {
-            chord
-                .matches_event_allowing_shift_modifier(event)
-                .then(|| ResolvedBinding {
-                    chord: *chord,
-                    action: action.clone(),
-                })
-        })
+        self.resolve_best_match(|chord| chord.matches_event_allowing_shift_modifier(event))
+    }
+
+    fn resolve_best_match(&self, matcher: impl Fn(&KeyChord) -> bool) -> Option<ResolvedBinding> {
+        self.bindings
+            .iter()
+            .enumerate()
+            .filter(|(_, (chord, _))| matcher(chord))
+            .max_by_key(|(idx, (chord, _))| (chord.specificity(), std::cmp::Reverse(*idx)))
+            .map(|(_, (chord, action))| ResolvedBinding {
+                chord: *chord,
+                action: action.clone(),
+            })
     }
 
     pub fn get_action_for_event(
@@ -1060,7 +1056,7 @@ mod tests {
     }
 
     #[test]
-    fn shift_exact_binding_wins_over_plain_binding() {
+    fn shift_explicit_binding_wins_over_plain_binding() {
         let mut bindings = KeyBindings::new();
         bindings.add_chord_binding(KeyChord::parse("E").unwrap(), Action::MoveRight);
         bindings.add_chord_binding(KeyChord::parse("Shift+E").unwrap(), Action::MoveLeft);
@@ -1131,6 +1127,41 @@ mod tests {
                 .resolve_for_key_down_event(&plain, true)
                 .map(|r| r.action),
             Some(Action::MoveUp)
+        );
+    }
+
+    #[test]
+    fn deterministic_tie_break_uses_insertion_order() {
+        let chord = KeyChord::parse("W").unwrap();
+        let bindings = KeyBindings {
+            bindings: vec![(chord, Action::MoveUp), (chord, Action::MoveDown)],
+        };
+
+        let event = KeyEvent::new(VirtualKey::W, true);
+        for _ in 0..10 {
+            assert_eq!(
+                bindings
+                    .resolve_for_key_down_event(&event, true)
+                    .map(|r| r.action.clone()),
+                Some(Action::MoveUp)
+            );
+        }
+    }
+
+    #[test]
+    fn shift_relaxed_fallback_does_not_override_explicit_match() {
+        let mut bindings = KeyBindings::new();
+        bindings.add_chord_binding(KeyChord::parse("W").unwrap(), Action::MoveUp);
+        bindings.add_chord_binding(KeyChord::parse("Shift+W").unwrap(), Action::MoveDown);
+
+        let mut event = KeyEvent::new(VirtualKey::W, true);
+        event.shift_down = true;
+
+        assert_eq!(
+            bindings
+                .resolve_for_key_down_event(&event, true)
+                .map(|r| r.action),
+            Some(Action::MoveDown)
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,10 +36,10 @@ use indicator::IndicatorState;
 use indicator::{
     resolve_indicator_snapshot, IndicatorInput, MouseIndicatorInput, WheelIndicatorInput,
 };
+use input_decode::{decode_virtual_key_from_hook, ModifierSnapshot, RawKeyboardHookEvent};
 use jump_overlay::{
     hide_jump_overlay, show_jump_overlay, update_jump_overlay, virtual_screen_region,
 };
-use input_decode::{decode_virtual_key_from_hook, ModifierSnapshot, RawKeyboardHookEvent};
 use jump_session::JumpSessionUpdate;
 use jump_view::{JumpLabelMetadata, JumpVisuals};
 use key_chord::{KeyChord, RuntimeSystemBindings};
@@ -7692,6 +7692,15 @@ enabled = true"#,
 
     #[test]
     fn ui_hint_query_timeout_exits_mode_and_stale_result_is_ignored() {
+        {
+            let mut app_state = APP_STATE.write().unwrap();
+            app_state.exit_ui_hint_mode();
+            while app_state.pop_command().is_some() {}
+        }
+        *UI_HINT_QUERY_DEADLINE.lock().unwrap() = None;
+        *UI_HINT_QUERY_RX.lock().unwrap() = None;
+        *UI_HINT_SESSION.lock().unwrap() = None;
+
         let query_id = UI_HINT_QUERY_ID.fetch_add(1, Ordering::Relaxed) + 1;
         APP_STATE
             .write()


### PR DESCRIPTION
### Motivation
- Ensure `KeyBindings` chooses the best matching chord by explicitly evaluating all candidates and preferring the highest `KeyChord::specificity()` instead of relying on incidental ordering.
- Provide a stable, documented tie-breaker so equal-specificity matches resolve deterministically.
- Preserve existing two-phase matching semantics (exact-match phase first, then shift-relaxed fallback) and the `event.is_down` gating behavior.
- Keep modifier-ownership semantics driven by `ModifierRequirements`, including side-specific ownership marking for families like Alt/RightAlt.

### Description
- Implemented `resolve_best_match` and updated `resolve_for_key_down_event` to evaluate all matching chords per phase and pick the winner by highest `KeyChord::specificity()` with a deterministic tie-breaker based on binding list/insertion order (earlier entries win), using enumeration and `max_by_key` on `(specificity, Reverse(index))`.
- Removed the previous sort-by-specificity in `add_chord_binding` so storage/insertion order remains stable and unrelated operations no longer affect resolution outcome.
- Left the two-phase behavior intact so exact matches are resolved first and `matches_event_allowing_shift_modifier` is used only when `shift_can_modify_plain_movement` is true.
- Preserved `owned_modifiers` logic to derive owned families from `ModifierRequirements` and to mark side-specific keys (e.g., `RightAlt`) plus the generic family (e.g., `Alt`) where applicable.
- Added/adjusted unit tests in `src/keyboard.rs` to cover the requested scenarios including `Alt+W` vs `RightAlt+W`, `W` vs `Shift+W` explicit precedence, deterministic tie-breaking stability, and that the shift-relaxed fallback does not override stricter explicit matches.

### Testing
- Added and updated unit tests: `chord_specificity_prefers_right_alt_over_plain_key`, `right_alt_binding_wins_over_shift_relaxed_plain_key`, `shift_explicit_binding_wins_over_plain_binding`, `deterministic_tie_break_uses_insertion_order`, `shift_relaxed_fallback_does_not_override_explicit_match`, and the existing owned-modifier tests; these are present under `#[cfg(test)]` in `src/keyboard.rs`.
- Attempted to run `cargo test` (targeting keyboard tests), but the test run failed to build due to missing system development libraries required by a transitive `x11` dependency (pkg-config could not find `xi`), so automated tests could not be executed in this environment.
- Tests themselves are small and deterministic (explicit event flags like `ctrl_down`, `alt_down`, `right_alt_down`, `shift_down`, `win_down` are set directly) and should pass once the build environment provides the required system libs and `pkg-config` configuration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a178adcd07483329817f60fbc9da807)