### PR TITLE
Track held key metadata and side-aware owned modifier semantics

### DIFF
--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -7,11 +7,11 @@ use crate::jump_view::{
     FinalAdjustOverlayView, GridOverlayMetadata, JumpOverlayView, JumpStageMetadata, JumpVisuals,
 };
 use crate::key_chord::{KeyChord, RuntimeSystemBindings};
-use crate::keyboard::VirtualKey;
+use crate::keyboard::{OwnedModifierKeys, VirtualKey};
 #[cfg(test)]
 use crate::Config;
 use crate::JumpConfig;
-use std::collections::{HashSet, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct KeyEvent {
@@ -133,9 +133,9 @@ pub struct AppState {
     active_keys: HashSet<VirtualKey>,
     active_trigger_chords: HashSet<KeyChord>,
     active_triggers: std::collections::HashMap<VirtualKey, ActiveTrigger>,
-    owned_modifiers: HashSet<VirtualKey>,
+    owned_modifiers: OwnedModifierKeys,
     reconciled_released_keys: HashSet<VirtualKey>,
-    held_physical_keys: HashSet<VirtualKey>,
+    held_physical_keys: HashMap<VirtualKey, HeldKeyState>,
     swallow_owned_modifiers: bool,
     debug_input: bool,
     jump: JumpState,
@@ -150,6 +150,15 @@ pub struct AppState {
     grid_direction_labels: GridDirectionLabels,
     bookmark_cancel_key: VirtualKey,
     bookmark_clear_modifier_key: VirtualKey,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct HeldKeyState {
+    pub pressed_at: std::time::Instant,
+    pub last_event_at: std::time::Instant,
+    pub was_action_trigger: bool,
+    pub was_owned_modifier: bool,
+    pub reconciled_release_sent: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -276,9 +285,9 @@ impl Default for AppState {
             active_keys: HashSet::new(),
             active_trigger_chords: HashSet::new(),
             active_triggers: std::collections::HashMap::new(),
-            owned_modifiers: HashSet::new(),
+            owned_modifiers: OwnedModifierKeys::default(),
             reconciled_released_keys: HashSet::new(),
-            held_physical_keys: HashSet::new(),
+            held_physical_keys: HashMap::new(),
             swallow_owned_modifiers: true,
             debug_input: false,
             jump: JumpState::Inactive,
@@ -333,7 +342,10 @@ impl AppState {
     where
         I: IntoIterator<Item = VirtualKey>,
     {
-        self.owned_modifiers = modifiers.into_iter().collect();
+        self.owned_modifiers = OwnedModifierKeys::default();
+        for key in modifiers {
+            self.owned_modifiers.insert(key);
+        }
     }
 
     pub fn set_debug_input(&mut self, enabled: bool) {
@@ -344,16 +356,15 @@ impl AppState {
     where
         F: FnMut(VirtualKey) -> bool,
     {
-        let stale_keys: Vec<VirtualKey> = self
+        let stale_keys: Vec<(VirtualKey, HeldKeyState)> = self
             .held_physical_keys
             .iter()
-            .copied()
-            .filter(|key| !is_key_physically_down(*key))
+            .filter_map(|(key, state)| (!is_key_physically_down(*key)).then_some((*key, *state)))
             .collect();
 
-        for key in stale_keys {
-            let stale_owned_modifier = self.owned_modifiers.contains(&key);
-            let stale_trigger = self.active_triggers.contains_key(&key);
+        for (key, held_state) in stale_keys {
+            let stale_owned_modifier = held_state.was_owned_modifier;
+            let stale_trigger = held_state.was_action_trigger;
             let mut synthesized_action = None;
 
             self.held_physical_keys.remove(&key);
@@ -372,8 +383,8 @@ impl AppState {
 
             if self.debug_input {
                 eprintln!(
-                    "[debug-input] reconciled stale key={:?} trigger={} owned_modifier={}",
-                    key, stale_trigger, stale_owned_modifier
+                    "[debug-input] reconciled stale key={:?} trigger={} owned_modifier={} held_ms={} reconciled_release_sent={}",
+                    key, stale_trigger, stale_owned_modifier, held_state.pressed_at.elapsed().as_millis(), held_state.reconciled_release_sent
                 );
             }
         }
@@ -970,8 +981,8 @@ impl AppState {
 
         if self.active_mode
             && self.swallow_owned_modifiers
-            && self.owned_modifiers.contains(&event.key)
-            && (self.held_physical_keys.contains(&event.key)
+            && self.owned_modifiers.owns_key(event.key)
+            && (self.held_physical_keys.contains_key(&event.key)
                 || (event.is_down && !self.reconciled_released_keys.contains(&event.key)))
         {
             self.debug_swallow("owned_modifier_active", event, true);
@@ -1135,10 +1146,27 @@ impl AppState {
         if event.is_down {
             self.reconciled_released_keys.remove(&event.key);
             self.active_keys.insert(event.key);
-            self.held_physical_keys.insert(event.key);
+            let now = std::time::Instant::now();
+            let mut was_action_trigger = false;
             if let Some(resolved_action) = action.clone() {
                 self.track_active_trigger(event, resolved_action);
+                was_action_trigger = true;
             }
+            self.held_physical_keys
+                .entry(event.key)
+                .and_modify(|state| {
+                    state.last_event_at = now;
+                    state.was_action_trigger |= was_action_trigger;
+                    state.was_owned_modifier |= self.owned_modifiers.owns_key(event.key);
+                    state.reconciled_release_sent = false;
+                })
+                .or_insert(HeldKeyState {
+                    pressed_at: now,
+                    last_event_at: now,
+                    was_action_trigger,
+                    was_owned_modifier: self.owned_modifiers.owns_key(event.key),
+                    reconciled_release_sent: false,
+                });
         } else {
             self.active_keys.remove(&event.key);
             self.held_physical_keys.remove(&event.key);
@@ -3564,6 +3592,36 @@ mod tests {
         assert!(!state.should_swallow_key(&KeyEvent::new(VirtualKey::RightAlt, true)));
     }
 
+    #[test]
+    fn held_key_insert_on_down_remove_on_up() {
+        let mut state = state_with_bound_key(VirtualKey::E);
+        state.route_key_event(KeyEvent::new(VirtualKey::E, true), Some(Action::MoveUp));
+        assert!(state.held_physical_keys.contains_key(&VirtualKey::E));
+        state.route_key_event(KeyEvent::new(VirtualKey::E, false), None);
+        assert!(!state.held_physical_keys.contains_key(&VirtualKey::E));
+    }
+
+    #[test]
+    fn reconcile_releases_only_physically_up_keys() {
+        let mut state = state_with_bound_key(VirtualKey::E);
+        state.route_key_event(KeyEvent::new(VirtualKey::E, true), Some(Action::MoveUp));
+        state.route_key_event(KeyEvent::new(VirtualKey::W, true), Some(Action::MoveDown));
+        let _ = collect_commands(&mut state);
+
+        state.reconcile_stale_keys(|key| key == VirtualKey::W);
+
+        let cmds = collect_commands(&mut state);
+        assert_eq!(cmds.len(), 1);
+        assert_eq!(
+            cmds[0],
+            AppCommand::KeyAction {
+                action: Action::MoveUp,
+                is_down: false,
+            }
+        );
+        assert!(state.held_physical_keys.contains_key(&VirtualKey::W));
+        assert!(!state.held_physical_keys.contains_key(&VirtualKey::E));
+    }
     #[test]
     fn reconcile_removes_active_trigger_for_stale_key() {
         let mut state = state_with_bound_key(VirtualKey::E);

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -38,19 +38,17 @@ impl OwnedModifierKeys {
                 self.contains_exact(VirtualKey::LeftAlt)
                     || self.contains_exact(VirtualKey::RightAlt)
             }
-            VirtualKey::LeftAlt | VirtualKey::RightAlt => self.contains_exact(VirtualKey::Alt),
+            VirtualKey::LeftAlt | VirtualKey::RightAlt => false,
             VirtualKey::Ctrl => {
                 self.contains_exact(VirtualKey::LeftCtrl)
                     || self.contains_exact(VirtualKey::RightCtrl)
             }
-            VirtualKey::LeftCtrl | VirtualKey::RightCtrl => self.contains_exact(VirtualKey::Ctrl),
+            VirtualKey::LeftCtrl | VirtualKey::RightCtrl => false,
             VirtualKey::Shift => {
                 self.contains_exact(VirtualKey::LeftShift)
                     || self.contains_exact(VirtualKey::RightShift)
             }
-            VirtualKey::LeftShift | VirtualKey::RightShift => {
-                self.contains_exact(VirtualKey::Shift)
-            }
+            VirtualKey::LeftShift | VirtualKey::RightShift => false,
             VirtualKey::LeftWin | VirtualKey::RightWin => false,
             _ => false,
         }

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -57,6 +57,24 @@ impl OwnedModifierKeys {
     }
 }
 
+impl IntoIterator for OwnedModifierKeys {
+    type Item = VirtualKey;
+    type IntoIter = std::collections::hash_set::IntoIter<VirtualKey>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.keys.into_iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a OwnedModifierKeys {
+    type Item = &'a VirtualKey;
+    type IntoIter = std::collections::hash_set::Iter<'a, VirtualKey>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.keys.iter()
+    }
+}
+
 /// Enum representing virtual key codes
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum VirtualKey {

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -11,6 +11,52 @@ use windows::Win32::UI::Input::KeyboardAndMouse::{
 const LLKHF_INJECTED_BITS: u32 = 0x10;
 const LLKHF_LOWER_IL_INJECTED_BITS: u32 = 0x02;
 
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct OwnedModifierKeys {
+    keys: HashSet<VirtualKey>,
+}
+
+impl OwnedModifierKeys {
+    pub fn insert(&mut self, key: VirtualKey) {
+        self.keys.insert(key);
+    }
+
+    pub fn contains(&self, key: &VirtualKey) -> bool {
+        self.keys.contains(key)
+    }
+
+    pub fn contains_exact(&self, key: VirtualKey) -> bool {
+        self.keys.contains(&key)
+    }
+
+    pub fn owns_key(&self, key: VirtualKey) -> bool {
+        if self.contains_exact(key) {
+            return true;
+        }
+        match key {
+            VirtualKey::Alt => {
+                self.contains_exact(VirtualKey::LeftAlt)
+                    || self.contains_exact(VirtualKey::RightAlt)
+            }
+            VirtualKey::LeftAlt | VirtualKey::RightAlt => self.contains_exact(VirtualKey::Alt),
+            VirtualKey::Ctrl => {
+                self.contains_exact(VirtualKey::LeftCtrl)
+                    || self.contains_exact(VirtualKey::RightCtrl)
+            }
+            VirtualKey::LeftCtrl | VirtualKey::RightCtrl => self.contains_exact(VirtualKey::Ctrl),
+            VirtualKey::Shift => {
+                self.contains_exact(VirtualKey::LeftShift)
+                    || self.contains_exact(VirtualKey::RightShift)
+            }
+            VirtualKey::LeftShift | VirtualKey::RightShift => {
+                self.contains_exact(VirtualKey::Shift)
+            }
+            VirtualKey::LeftWin | VirtualKey::RightWin => false,
+            _ => false,
+        }
+    }
+}
+
 /// Enum representing virtual key codes
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum VirtualKey {
@@ -798,8 +844,8 @@ impl KeyBindings {
         self.bindings.iter().map(|(chord, action)| (*chord, action))
     }
 
-    pub fn owned_modifiers(&self) -> HashSet<VirtualKey> {
-        let mut owned = HashSet::new();
+    pub fn owned_modifiers(&self) -> OwnedModifierKeys {
+        let mut owned = OwnedModifierKeys::default();
         for (chord, _) in &self.bindings {
             match chord.modifiers.alt {
                 crate::key_chord::ModifierSideRequirement::NotRequired => {}
@@ -1192,6 +1238,32 @@ mod tests {
         assert!(owned.contains(&VirtualKey::Alt));
     }
 
+    #[test]
+    fn alt_chord_owns_both_alts() {
+        let mut bindings = KeyBindings::new();
+        bindings.add_chord_binding(KeyChord::parse("Alt+W").unwrap(), Action::MoveUp);
+        let owned = bindings.owned_modifiers();
+        assert!(owned.owns_key(VirtualKey::LeftAlt));
+        assert!(owned.owns_key(VirtualKey::RightAlt));
+    }
+
+    #[test]
+    fn rightalt_chord_owns_only_rightalt() {
+        let mut bindings = KeyBindings::new();
+        bindings.add_chord_binding(KeyChord::parse("RightAlt+W").unwrap(), Action::MoveUp);
+        let owned = bindings.owned_modifiers();
+        assert!(owned.owns_key(VirtualKey::RightAlt));
+        assert!(!owned.owns_key(VirtualKey::LeftAlt));
+    }
+
+    #[test]
+    fn leftshift_chord_owns_only_leftshift() {
+        let mut bindings = KeyBindings::new();
+        bindings.add_chord_binding(KeyChord::parse("LeftShift+W").unwrap(), Action::MoveUp);
+        let owned = bindings.owned_modifiers();
+        assert!(owned.owns_key(VirtualKey::LeftShift));
+        assert!(!owned.owns_key(VirtualKey::RightShift));
+    }
     #[test]
     fn alt_chord_marks_alt_owned() {
         let mut bindings = KeyBindings::new();

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -38,17 +38,19 @@ impl OwnedModifierKeys {
                 self.contains_exact(VirtualKey::LeftAlt)
                     || self.contains_exact(VirtualKey::RightAlt)
             }
-            VirtualKey::LeftAlt | VirtualKey::RightAlt => false,
+            VirtualKey::LeftAlt | VirtualKey::RightAlt => self.contains_exact(VirtualKey::Alt),
             VirtualKey::Ctrl => {
                 self.contains_exact(VirtualKey::LeftCtrl)
                     || self.contains_exact(VirtualKey::RightCtrl)
             }
-            VirtualKey::LeftCtrl | VirtualKey::RightCtrl => false,
+            VirtualKey::LeftCtrl | VirtualKey::RightCtrl => self.contains_exact(VirtualKey::Ctrl),
             VirtualKey::Shift => {
                 self.contains_exact(VirtualKey::LeftShift)
                     || self.contains_exact(VirtualKey::RightShift)
             }
-            VirtualKey::LeftShift | VirtualKey::RightShift => false,
+            VirtualKey::LeftShift | VirtualKey::RightShift => {
+                self.contains_exact(VirtualKey::Shift)
+            }
             VirtualKey::LeftWin | VirtualKey::RightWin => false,
             _ => false,
         }
@@ -870,11 +872,9 @@ impl KeyBindings {
                 }
                 crate::key_chord::ModifierSideRequirement::Left => {
                     owned.insert(VirtualKey::LeftAlt);
-                    owned.insert(VirtualKey::Alt);
                 }
                 crate::key_chord::ModifierSideRequirement::Right => {
                     owned.insert(VirtualKey::RightAlt);
-                    owned.insert(VirtualKey::Alt);
                 }
             }
             match chord.modifiers.ctrl {
@@ -884,11 +884,9 @@ impl KeyBindings {
                 }
                 crate::key_chord::ModifierSideRequirement::Left => {
                     owned.insert(VirtualKey::LeftCtrl);
-                    owned.insert(VirtualKey::Ctrl);
                 }
                 crate::key_chord::ModifierSideRequirement::Right => {
                     owned.insert(VirtualKey::RightCtrl);
-                    owned.insert(VirtualKey::Ctrl);
                 }
             }
             match chord.modifiers.shift {
@@ -898,11 +896,9 @@ impl KeyBindings {
                 }
                 crate::key_chord::ModifierSideRequirement::Left => {
                     owned.insert(VirtualKey::LeftShift);
-                    owned.insert(VirtualKey::Shift);
                 }
                 crate::key_chord::ModifierSideRequirement::Right => {
                     owned.insert(VirtualKey::RightShift);
-                    owned.insert(VirtualKey::Shift);
                 }
             }
             // There is currently no generic Win virtual key variant in `VirtualKey`.
@@ -1246,12 +1242,13 @@ mod tests {
     }
 
     #[test]
-    fn right_alt_in_chord_marks_right_alt_and_alt_owned() {
+    fn right_alt_in_chord_marks_right_alt_owned() {
         let mut bindings = KeyBindings::new();
         bindings.add_chord_binding(KeyChord::parse("RightAlt+W").unwrap(), Action::MoveUp);
         let owned = bindings.owned_modifiers();
         assert!(owned.contains(&VirtualKey::RightAlt));
-        assert!(owned.contains(&VirtualKey::Alt));
+        assert!(owned.owns_key(VirtualKey::Alt));
+        assert!(!owned.contains(&VirtualKey::Alt));
     }
 
     #[test]


### PR DESCRIPTION
### Motivation

- Reduce incorrect synthetic releases and improve modifier-swallowing by tracking per-key metadata instead of a plain set of held keys.
- Support side-aware owned-modifier semantics so generic vs left/right Alt/Ctrl/Shift ownership is handled correctly during swallowing and reconciliation.
- Ensure reconciliation only synthesizes releases when the OS reports a physical key-up and provide richer debug diagnostics for stale recoveries.

### Description

- Replaced the raw `owned_modifiers: HashSet<VirtualKey>` with a side-aware `OwnedModifierKeys` type in `src/keyboard.rs` and added `owns_key(VirtualKey)` semantics for Alt/Ctrl/Shift families.
- Replaced `held_physical_keys: HashSet<VirtualKey>` with `held_physical_keys: HashMap<VirtualKey, HeldKeyState>` in `src/app_state.rs`, and added the `HeldKeyState` struct fields `pressed_at`, `last_event_at`, `was_action_trigger`, `was_owned_modifier`, and `reconciled_release_sent`.
- Updated keydown/keyup handling in `AppState::route_key_event` to insert/update/remove `HeldKeyState` entries atomically and to record whether a held key was an action trigger or owned modifier.
- Rewrote stale-key reconciliation in `AppState::reconcile_stale_keys` to iterate metadata entries, only synthesize a release when a key is physically up and it had been an action trigger, remove held entries atomically, and enqueue corresponding `AppCommand::KeyAction` releases when appropriate.
- Added debug logging behind `input.debug_input` that reports stale recovery details including held duration and ownership/trigger metadata.
- Added unit tests validating modifier ownership and held-key behavior: `alt_chord_owns_both_alts`, `rightalt_chord_owns_only_rightalt`, `leftshift_chord_owns_only_leftshift`, `held_key_insert_on_down_remove_on_up`, and `reconcile_releases_only_physically_up_keys`.

### Testing

- Ran `cargo fmt` successfully on the codebase.
- Attempted targeted `cargo test` runs for the new tests, but an initial multi-argument `cargo test` invocation was adjusted to sequential `cargo test` commands when testing locally.
- Test execution failed during build in this Linux CI/container environment because a transitive dependency (`x11` crate) requires the system X11 Xi dev package (`xi.pc`) which is missing; therefore unit tests were not able to complete here.
- The new unit tests were added and are ready to run in an environment with the required system dependencies; they exercise owned-modifier ownership and held-key insert/remove and reconciliation behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17909dd4548332ab9f6622a21ecbc8)