### PR TITLE
Make ergonomic ESDF keymap canonical

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,56 +27,51 @@ System bindings are always available, even while the app is idle:
 
 | Key | Action |
 | --- | --- |
-| `Ctrl+E` / `Ctrl+Q` | Toggle active/idle mode (depends on checked-in config) |
-| `Escape` | Exit |
+| `Ctrl+Q` | Toggle active/idle mode |
+| `Ctrl+Escape` | Exit |
+| `RightAlt+Escape` | Panic reset |
 
-Action bindings run only while active mode is enabled:
+Action bindings run only while active mode is enabled. The checked-in and runtime-default keymap is the ergonomic `E/S/D/F` layout:
 
 | Key | Action |
 | --- | --- |
-| `W` | Move up |
-| `A` | Move left |
-| `S` | Move down |
-| `D` | Move right |
+| `E` / `S` / `D` / `F` | Move up / left / down / right |
 | `LeftShift` | Slow held movement |
-| `B` | Surgical held precision modifier (hold with movement key) |
-| `SPACE` | Left click |
-| `L` | Right click |
-| `RightShift` | Middle click |
+| `Z` | Surgical held precision modifier (hold with movement key) |
+| `J` / `K` / `L` | Left / right / middle click |
 | `N` | Toggle left-button drag mode |
 | `.` | Click, then switch to idle |
 | `W` / `R` | Wheel up / down |
-| `X` / `Z` | Mouse speed down / reset |
-| `U` / `I` | Wheel speed up / down |
+| `M` / `,` | Mouse speed down / up |
+| `U` / `I` | Wheel speed down / up |
 | `RightAlt+C` / `RightAlt+X` | Next / previous movement profile |
 | `RightAlt+V` / `RightAlt+B` | Next / previous wheel profile |
-| `F` | Jump mode |
+| `T` | Jump mode |
 | `G` | Grid mode |
-| `C` | Screen select |
-| `Shift+B` | Enter bookmark mode (default binding) |
-| `Shift+Ctrl+B` | Clear all bookmarks (default binding) |
-| `B` | Enter bookmark mode (example ergonomic remap) |
-| `Backspace+1..9` | Clear bookmark slot 1..9 (in bookmark mode) |
+| `0` | UI Hints mode |
+| `B` | Enter bookmark mode |
 | `1..9` | Save bookmark slot 1..9 (in bookmark mode) / recall slot 1..9 (outside bookmark mode) |
-| `Escape` | Cancel bookmark mode |
+| `` ` `` | Show bookmark list |
+| `Backspace+1..9` | Clear bookmark slot 1..9 (in bookmark mode) |
+| `Escape` | Cancel bookmark mode or active exclusive overlays/modes |
+| `C` | Screen select |
 | `H` | Navigate back |
 | `Y` | Navigate forward |
 | `Q` / `P` | Switch to idle |
-| `RightAlt+W` / `RightAlt+A` / `RightAlt+S` / `RightAlt+D` | Jump to **monitor edge** (top / left / bottom / right) |
-| `RightAlt+Ctrl+W` / `RightAlt+Ctrl+A` / `RightAlt+Ctrl+S` / `RightAlt+Ctrl+D` | Jump to **active-window edge** (top / left / bottom / right) |
-| `RightAlt+Ctrl+Q` / `RightAlt+Ctrl+E` | Jump to active-window center / titlebar |
+| `RightAlt+E` / `RightAlt+S` / `RightAlt+D` / `RightAlt+F` | Jump to **monitor edge** (top / left / bottom / right) |
+| `RightAlt+Ctrl+E` / `RightAlt+Ctrl+S` / `RightAlt+Ctrl+D` / `RightAlt+Ctrl+F` | Jump to **active-window edge** (top / left / bottom / right) |
+| `RightAlt+Ctrl+H` / `RightAlt+Ctrl+Y` | Jump to active-window center / titlebar |
 | `Alt+E` / `Alt+S` / `Alt+D` / `Alt+F` | Step move up / left / down / right (normal tier) |
 | `Alt+Ctrl+E` / `Alt+Ctrl+S` / `Alt+Ctrl+D` / `Alt+Ctrl+F` | Step move up / left / down / right (small tier) |
 | `Alt+Shift+E` / `Alt+Shift+S` / `Alt+Shift+D` / `Alt+Shift+F` | Step move up / left / down / right (large tier) |
 | `RightAlt+R` | Reload `config.toml` |
-| `RightAlt+Escape` | Panic reset |
 | `/` | Toggle help tooltip/panel with runtime stats + keybinds |
 
 ## Active And Idle
 
-The app starts active. Press `Ctrl+E` (or `Ctrl+Q` in configs that set that as `system_bindings.toggle_active`) to switch between active and idle mode. In active mode, configured action bindings are swallowed and translated into mouse commands. In idle mode, normal action bindings are ignored so the same keys can pass through to Windows and other apps.
+The app starts active. Press `Ctrl+Q` to switch between active and idle mode. In active mode, configured action bindings are swallowed and translated into mouse commands. In idle mode, normal action bindings are ignored so the same keys can pass through to Windows and other apps.
 
-System bindings bypass the active-mode gate. The configured toggle-active chord (commonly `Ctrl+E` or `Ctrl+Q`) can always reactivate control, and `Escape` remains the configured exit key.
+System bindings bypass the active-mode gate. The configured toggle-active chord can always reactivate control, and `Ctrl+Escape` remains the configured exit key.
 
 Bookmark mode is configurable under `[bookmarks]` in `config.toml` (including slot count, key validation fallbacks, desktop behavior, and coordinate policy). The bookmark JSON file path is resolved relative to the resolved config file path when a relative `bookmarks.file` value is used.
 
@@ -84,13 +79,13 @@ Bookmark mode is configurable under `[bookmarks]` in `config.toml` (including sl
 
 Press `N` to toggle left-button drag mode. When drag is on, Multi MouseMover holds the left mouse button down so movement keys can drag windows, text selections, sliders, or canvas objects. Press `N` again to release it.
 
-`RightAlt+Escape` performs a panic reset: it releases drag, clears currently held actions, exits jump mode, hides overlays, resets runtime speed tiers, and returns to active mode.
+`RightAlt+Escape` performs a panic reset: it releases drag, clears currently held actions, exits jump mode, hides overlays, resets runtime speed tiers, and follows `system_bindings.panic_reset_sets_idle` (the default is `true`, so it returns to idle mode).
 
 ## Wheel And Speed Controls
 
 Hold `W` or `R` for repeated vertical wheel ticks. Horizontal wheel bindings are commented out in the checked-in `config.toml` by default. Wheel repeat timing comes from `[wheel].tick_interval`; wheel strength comes from the current wheel speed and axis multipliers.
 
-Mouse movement has two layers. `[mouse_speed]` controls the baseline tier changed by `X` and `Z`; `acceleration`, `acceleration_rate`, and `top_speed` then shape how held movement ramps while a direction key is down. `LeftShift` slows movement while held.
+Mouse movement has two layers. `[mouse_speed]` controls the baseline tier changed by `M` and `,`; `acceleration`, `acceleration_rate`, and `top_speed` then shape how held movement ramps while a direction key is down. `LeftShift` slows movement while held.
 
 Profiles let you swap groups of speed settings at runtime:
 
@@ -105,16 +100,16 @@ Runtime action syntax also supports direct profile selection with either `moveme
 
 ## Jump Stages And Profiles
 
-Press `F` to enter jump mode. A labeled grid appears over the start region. Type the visible cell label to narrow the target or complete the jump. The default config uses precision mode with `coarse`, `fine`, and `precise` stages.
+Press `T` to enter jump mode. A labeled grid appears over the start region. Type the visible cell label to narrow the target or complete the jump. The default config uses precision mode with `coarse`, `fine`, and `precise` stages.
 
 The base `[jump]` table chooses the mode, start region, cursor behavior between stages, preview edge behavior, and visuals. Each stage table controls grid size, target region behavior, zoom, context margin, aim point, and labels.
 
 Jump profiles live under `jump.profiles.<name>` and merge over the base jump settings for one launch. Profiles can override just the fields they need:
 
 ```toml
-["F", "jump_mode"]
+["T", "jump_mode"]
 ["RightAlt+F", "jump_mode_profile:precise"]
-["RightAlt+W", "jump_mode_profile.window"]
+["RightAlt+3", "jump_mode_profile.window"]
 ```
 
 The default config includes `fast`, `precise`, `window`, and `monitor` profiles. `fast` is a single-stage jump. `precise` keeps multiple stages and previews between them. `window` starts from the active window bounds. `monitor` starts from the current monitor.
@@ -259,7 +254,7 @@ Jump overlays are configured under `[jump.visuals]` and per-stage label tables. 
 
 ## Safety
 
-`Escape` exits through `[system_bindings]`. `RightAlt+Escape` is the runtime panic reset and is useful if drag is stuck, a jump overlay is active, or held keys need to be cleared.
+`Ctrl+Escape` exits through `[system_bindings]`. `RightAlt+Escape` is the runtime panic reset and is useful if drag is stuck, a jump overlay is active, or held keys need to be cleared.
 
 `RightAlt+R` reloads `config.toml` atomically from the user perspective: invalid configs are rejected and the last valid runtime config remains active. Compatibility fields are still accepted for older configs, but new configs should use the current field names documented in [DEVELOPMENT.md](DEVELOPMENT.md).
 

--- a/config.toml
+++ b/config.toml
@@ -51,7 +51,7 @@ key_bindings = [
 # ["O", "wheel_right"]
 # ["Z", "mouse_speed_reset"]
 # ["RightAlt+F", "jump_mode_profile:precise"]
-# ["RightAlt+W", "jump_mode_profile.window"]
+# ["RightAlt+3", "jump_mode_profile.window"]
 # ["RightAlt+1", "movement_profile:precision"]
 # ["RightAlt+2", "wheel_profile:fast"]
 # ["Backspace+1", "clear_bookmark_1"]

--- a/docs/config.md
+++ b/docs/config.md
@@ -67,28 +67,71 @@ Full default `key_bindings` list:
 
 ```toml
 key_bindings = [
-  ["E", "move_up"], ["S", "move_left"], ["D", "move_down"], ["F", "move_right"],
+  ["E", "move_up"],
+  ["S", "move_left"],
+  ["D", "move_down"],
+  ["F", "move_right"],
   ["LeftShift", "slow_mouse"],
-  ["J", "left_click"], ["K", "right_click"], ["L", "middle_click"],
-  ["N", "toggle_drag_mode"], [".", "click_then_disable"],
-  ["W", "wheel_up"], ["R", "wheel_down"],
-  ["M", "mouse_speed_down"], [",", "mouse_speed_up"],
-  ["U", "wheel_speed_down"], ["I", "wheel_speed_up"],
-  ["RightAlt+C", "movement_profile_next"], ["RightAlt+X", "movement_profile_previous"],
-  ["RightAlt+V", "wheel_profile_next"], ["RightAlt+B", "wheel_profile_previous"],
-  ["T", "jump_mode"], ["G", "grid_mode"], ["C", "screen_select"],
-  ["H", "navigate_back"], ["Y", "navigate_forward"],
-  ["Q", "disable"], ["P", "disable"],
-  ["RightAlt+E", "move_to_top_edge"], ["RightAlt+S", "move_to_left_edge"],
-  ["RightAlt+D", "move_to_bottom_edge"], ["RightAlt+F", "move_to_right_edge"],
-  ["RightAlt+Ctrl+E", "move_to_window_top_edge"], ["RightAlt+Ctrl+S", "move_to_window_left_edge"],
-  ["RightAlt+Ctrl+D", "move_to_window_bottom_edge"], ["RightAlt+Ctrl+F", "move_to_window_right_edge"],
-  ["RightAlt+Ctrl+H", "move_to_window_center"], ["RightAlt+Ctrl+Y", "move_to_window_titlebar"],
-  ["RightAlt+R", "reload_config"], ["RightAlt+Escape", "panic_reset"],
-  ["Alt+E", "step_move_up"], ["Alt+S", "step_move_left"], ["Alt+D", "step_move_down"], ["Alt+F", "step_move_right"],
-  ["Alt+Ctrl+E", "step_move_small_up"], ["Alt+Ctrl+S", "step_move_small_left"], ["Alt+Ctrl+D", "step_move_small_down"], ["Alt+Ctrl+F", "step_move_small_right"],
-  ["Alt+Shift+E", "step_move_large_up"], ["Alt+Shift+S", "step_move_large_left"], ["Alt+Shift+D", "step_move_large_down"], ["Alt+Shift+F", "step_move_large_right"],
-  ["/", "show_help"]
+  ["Z", "surgical_mode"],
+  ["J", "left_click"],
+  ["K", "right_click"],
+  ["L", "middle_click"],
+  ["N", "toggle_drag_mode"],
+  [".", "click_then_disable"],
+  ["W", "wheel_up"],
+  ["R", "wheel_down"],
+  ["M", "mouse_speed_down"],
+  [",", "mouse_speed_up"],
+  ["U", "wheel_speed_down"],
+  ["I", "wheel_speed_up"],
+  ["RightAlt+C", "movement_profile_next"],
+  ["RightAlt+X", "movement_profile_previous"],
+  ["RightAlt+V", "wheel_profile_next"],
+  ["RightAlt+B", "wheel_profile_previous"],
+  ["T", "jump_mode"],
+  ["G", "grid_mode"],
+  ["C", "screen_select"],
+  ["H", "navigate_back"],
+  ["Y", "navigate_forward"],
+  ["Q", "disable"],
+  ["P", "disable"],
+  ["RightAlt+E", "move_to_top_edge"],
+  ["RightAlt+S", "move_to_left_edge"],
+  ["RightAlt+D", "move_to_bottom_edge"],
+  ["RightAlt+F", "move_to_right_edge"],
+  ["RightAlt+Ctrl+E", "move_to_window_top_edge"],
+  ["RightAlt+Ctrl+S", "move_to_window_left_edge"],
+  ["RightAlt+Ctrl+D", "move_to_window_bottom_edge"],
+  ["RightAlt+Ctrl+F", "move_to_window_right_edge"],
+  ["RightAlt+Ctrl+H", "move_to_window_center"],
+  ["RightAlt+Ctrl+Y", "move_to_window_titlebar"],
+  ["RightAlt+R", "reload_config"],
+  ["RightAlt+Escape", "panic_reset"],
+  ["Alt+E", "step_move_up"],
+  ["Alt+S", "step_move_left"],
+  ["Alt+D", "step_move_down"],
+  ["Alt+F", "step_move_right"],
+  ["Alt+Ctrl+E", "step_move_small_up"],
+  ["Alt+Ctrl+S", "step_move_small_left"],
+  ["Alt+Ctrl+D", "step_move_small_down"],
+  ["Alt+Ctrl+F", "step_move_small_right"],
+  ["Alt+Shift+E", "step_move_large_up"],
+  ["Alt+Shift+S", "step_move_large_left"],
+  ["Alt+Shift+D", "step_move_large_down"],
+  ["Alt+Shift+F", "step_move_large_right"],
+  ["/", "show_help"],
+  ["0", "ui_hint_mode"],
+  ["B", "bookmark_mode"],
+  ["1", "bookmark_slot_1"],
+  ["2", "bookmark_slot_2"],
+  ["3", "bookmark_slot_3"],
+  ["4", "bookmark_slot_4"],
+  ["5", "bookmark_slot_5"],
+  ["6", "bookmark_slot_6"],
+  ["7", "bookmark_slot_7"],
+  ["8", "bookmark_slot_8"],
+  ["9", "bookmark_slot_9"],
+  ["`", "show_bookmarks"],
 ]
 ```
 
@@ -157,12 +200,12 @@ Swallow precedence is:
 | --- | --- | --- | --- | --- | --- |
 | `polling_rate` | integer milliseconds | `8` | Yes | Active | Main input loop delay. Lower values poll more often. |
 | `key_bindings` | array of `[key, action]` pairs | built-in movement/click/jump bindings | Yes | Active | Active-mode action bindings. |
-| `system_bindings.toggle_active` | key chord string | `"Ctrl+E"` | Yes | Active | Global active/idle toggle. |
-| `system_bindings.exit` | key chord string | `"Escape"` | Yes | Active | Global exit binding. Routed before mode-local handlers. |
+| `system_bindings.toggle_active` | key chord string | `"Ctrl+Q"` | Yes | Active | Global active/idle toggle. |
+| `system_bindings.exit` | key chord string | `"Ctrl+Escape"` | Yes | Active | Global exit binding. Routed before mode-local handlers. |
 | `system_bindings.exit_ignore_extra_modifiers` | boolean | `true` | Yes | Active | When true, `exit` matches if required modifiers are present even when extra modifiers are held. |
 | `system_bindings.panic_reset` | key chord string | `"RightAlt+Escape"` | Yes | Active | Global non-exiting panic cleanup binding, routed before mode-local handlers. |
 | `system_bindings.panic_reset_ignore_extra_modifiers` | boolean | `true` | Yes | Active | When true, `panic_reset` allows extra held modifiers. |
-| `system_bindings.panic_reset_sets_idle` | boolean | `true` | Yes | Active | When true, panic reset also sets idle mode (`SetActiveMode { active = false }`). |
+| `system_bindings.panic_reset_sets_idle` | boolean | `true` | Yes | Active | When true, panic reset stays non-exiting and sets idle mode (`SetActiveMode { active = false }`). |
 | `input.swallow_owned_modifiers` | boolean | `true` | Yes | Active | Swallow app-owned modifier down/up transitions while active mode is enabled. |
 | `input.modifier_reconcile_on_tick` | boolean | `true` | Yes | Active | Enables periodic modifier reconciliation checks. |
 | `input.modifier_reconcile_interval_ms` | integer milliseconds | `50` | Yes | Active | Polling interval for periodic modifier reconciliation; normalized to `10..=5000` and reset to default when `0`. |

--- a/src/main.rs
+++ b/src/main.rs
@@ -5792,36 +5792,42 @@ mod tests {
         let labels: std::collections::HashSet<_> = view
             .bindings
             .iter()
-            .map(|binding| (binding.key.as_str(), binding.action.as_str()))
+            .map(|binding| (binding.key.clone(), binding.action.clone()))
             .collect();
+        let label_pair = |key: &str, action: &str| {
+            (
+                KeyChord::parse(key).unwrap().display_label(),
+                action.to_string(),
+            )
+        };
 
         for expected in [
-            ("E", "Move up"),
-            ("S", "Move left"),
-            ("D", "Move down"),
-            ("F", "Move right"),
-            ("Z", "Held precision modifier (surgical)"),
-            ("J", "Left click"),
-            ("K", "Right click"),
-            ("L", "Middle click"),
-            ("T", "Jump"),
-            ("G", "Grid"),
-            ("0", "UI Hints"),
-            ("B", "Bookmark mode"),
-            ("/", "Hints / Help"),
-            ("RightAlt+E", "Jump to monitor top edge"),
-            ("RightAlt+S", "Jump to monitor left edge"),
-            ("RightAlt+D", "Jump to monitor bottom edge"),
-            ("RightAlt+F", "Jump to monitor right edge"),
+            label_pair("E", "Move up"),
+            label_pair("S", "Move left"),
+            label_pair("D", "Move down"),
+            label_pair("F", "Move right"),
+            label_pair("Z", "Held precision modifier (surgical)"),
+            label_pair("J", "Left click"),
+            label_pair("K", "Right click"),
+            label_pair("L", "Middle click"),
+            label_pair("T", "Jump"),
+            label_pair("G", "Grid"),
+            label_pair("0", "UI Hints"),
+            label_pair("B", "Bookmark mode"),
+            label_pair("/", "Hints / Help"),
+            label_pair("RightAlt+E", "Jump to monitor top edge"),
+            label_pair("RightAlt+S", "Jump to monitor left edge"),
+            label_pair("RightAlt+D", "Jump to monitor bottom edge"),
+            label_pair("RightAlt+F", "Jump to monitor right edge"),
         ] {
             assert!(labels.contains(&expected), "missing {expected:?}");
         }
         for stale in [
-            ("W", "Move up"),
-            ("A", "Move left"),
-            ("B", "Held precision modifier (surgical)"),
-            ("RightAlt+W", "Jump to monitor top edge"),
-            ("RightAlt+A", "Jump to monitor left edge"),
+            label_pair("W", "Move up"),
+            label_pair("A", "Move left"),
+            label_pair("B", "Held precision modifier (surgical)"),
+            label_pair("RightAlt+W", "Jump to monitor top edge"),
+            label_pair("RightAlt+A", "Jump to monitor left edge"),
         ] {
             assert!(!labels.contains(&stale), "stale label present {stale:?}");
         }
@@ -7146,15 +7152,19 @@ mod tests {
         let cases = [
             Case {
                 name: "surgical_mode",
-                config_toml: "[surgical_mode]
-enabled = true",
+                config_toml: r#"key_bindings = []
+
+[surgical_mode]
+enabled = true"#,
                 expected_substring:
                     "surgical_mode.enabled=true but no key binding targets action \"surgical_mode\"",
             },
             Case {
                 name: "scroll_mode",
-                config_toml: "[scroll_mode]
-enabled = true",
+                config_toml: r#"key_bindings = []
+
+[scroll_mode]
+enabled = true"#,
                 expected_substring:
                     "scroll_mode.enabled=true but no key binding targets action \"scroll_modifier\"",
             },
@@ -7259,7 +7269,7 @@ enabled = true"#,
         assert!(summary.contains("wheel default=1 range=1..10 step=1 tick=120ms"));
         assert!(summary.contains("slow_mouse strategy=Fixed speed=1 (default 1, range 1..2) acceleration=0 every 1 tick(s)"));
         assert!(summary.contains("features: [enabled, bindings]"));
-        assert!(summary.contains("surgical_mode: enabled=false bindings=0"));
+        assert!(summary.contains("surgical_mode: enabled=false bindings=1"));
         assert!(summary.contains("scroll_mode: enabled=false bindings=0"));
         assert!(summary.contains("window_jump: enabled=true bindings=6"));
         assert!(summary.contains("warnings=1"));

--- a/src/main.rs
+++ b/src/main.rs
@@ -547,54 +547,44 @@ impl Default for InputConfig {
 
 fn default_key_bindings() -> Vec<(String, String)> {
     [
-        ("W", "move_up"),
-        ("A", "move_left"),
-        ("S", "move_down"),
-        ("D", "move_right"),
+        ("E", "move_up"),
+        ("S", "move_left"),
+        ("D", "move_down"),
+        ("F", "move_right"),
         ("LeftShift", "slow_mouse"),
-        ("SPACE", "left_click"),
-        ("L", "right_click"),
-        ("RightShift", "middle_click"),
+        ("Z", "surgical_mode"),
+        ("J", "left_click"),
+        ("K", "right_click"),
+        ("L", "middle_click"),
         ("N", "toggle_drag_mode"),
         (".", "click_then_disable"),
         ("W", "wheel_up"),
         ("R", "wheel_down"),
-        ("X", "mouse_speed_down"),
-        ("Z", "mouse_speed_reset"),
-        ("U", "wheel_speed_up"),
-        ("I", "wheel_speed_down"),
+        ("M", "mouse_speed_down"),
+        (",", "mouse_speed_up"),
+        ("U", "wheel_speed_down"),
+        ("I", "wheel_speed_up"),
         ("RightAlt+C", "movement_profile_next"),
         ("RightAlt+X", "movement_profile_previous"),
         ("RightAlt+V", "wheel_profile_next"),
         ("RightAlt+B", "wheel_profile_previous"),
-        ("F", "jump_mode"),
+        ("T", "jump_mode"),
         ("G", "grid_mode"),
         ("C", "screen_select"),
-        ("Shift+B", "bookmark_mode"),
-        ("Shift+Ctrl+B", "clear_all_bookmarks"),
-        ("1", "bookmark_slot_1"),
-        ("2", "bookmark_slot_2"),
-        ("3", "bookmark_slot_3"),
-        ("4", "bookmark_slot_4"),
-        ("5", "bookmark_slot_5"),
-        ("6", "bookmark_slot_6"),
-        ("7", "bookmark_slot_7"),
-        ("8", "bookmark_slot_8"),
-        ("9", "bookmark_slot_9"),
         ("H", "navigate_back"),
         ("Y", "navigate_forward"),
         ("Q", "disable"),
         ("P", "disable"),
-        ("RightAlt+W", "move_to_top_edge"),
-        ("RightAlt+A", "move_to_left_edge"),
-        ("RightAlt+S", "move_to_bottom_edge"),
-        ("RightAlt+D", "move_to_right_edge"),
-        ("RightAlt+Ctrl+W", "move_to_window_top_edge"),
-        ("RightAlt+Ctrl+A", "move_to_window_left_edge"),
-        ("RightAlt+Ctrl+S", "move_to_window_bottom_edge"),
-        ("RightAlt+Ctrl+D", "move_to_window_right_edge"),
-        ("RightAlt+Ctrl+Q", "move_to_window_center"),
-        ("RightAlt+Ctrl+E", "move_to_window_titlebar"),
+        ("RightAlt+E", "move_to_top_edge"),
+        ("RightAlt+S", "move_to_left_edge"),
+        ("RightAlt+D", "move_to_bottom_edge"),
+        ("RightAlt+F", "move_to_right_edge"),
+        ("RightAlt+Ctrl+E", "move_to_window_top_edge"),
+        ("RightAlt+Ctrl+S", "move_to_window_left_edge"),
+        ("RightAlt+Ctrl+D", "move_to_window_bottom_edge"),
+        ("RightAlt+Ctrl+F", "move_to_window_right_edge"),
+        ("RightAlt+Ctrl+H", "move_to_window_center"),
+        ("RightAlt+Ctrl+Y", "move_to_window_titlebar"),
         ("RightAlt+R", "reload_config"),
         ("RightAlt+Escape", "panic_reset"),
         ("Alt+E", "step_move_up"),
@@ -610,6 +600,18 @@ fn default_key_bindings() -> Vec<(String, String)> {
         ("Alt+Shift+D", "step_move_large_down"),
         ("Alt+Shift+F", "step_move_large_right"),
         ("/", "show_help"),
+        ("0", "ui_hint_mode"),
+        ("B", "bookmark_mode"),
+        ("1", "bookmark_slot_1"),
+        ("2", "bookmark_slot_2"),
+        ("3", "bookmark_slot_3"),
+        ("4", "bookmark_slot_4"),
+        ("5", "bookmark_slot_5"),
+        ("6", "bookmark_slot_6"),
+        ("7", "bookmark_slot_7"),
+        ("8", "bookmark_slot_8"),
+        ("9", "bookmark_slot_9"),
+        ("`", "show_bookmarks"),
     ]
     .into_iter()
     .map(|(key, action)| (key.to_string(), action.to_string()))
@@ -1179,8 +1181,8 @@ struct SystemBindings {
 impl Default for SystemBindings {
     fn default() -> Self {
         Self {
-            toggle_active: "Ctrl+E".to_string(),
-            exit: "Escape".to_string(),
+            toggle_active: "Ctrl+Q".to_string(),
+            exit: "Ctrl+Escape".to_string(),
             exit_ignore_extra_modifiers: true,
             panic_reset: Some("RightAlt+Escape".to_string()),
             panic_reset_ignore_extra_modifiers: true,
@@ -5060,6 +5062,23 @@ mod tests {
         parse_config(include_str!("../config.toml"))
     }
 
+    fn docs_toml_block_after(marker: &str) -> &'static str {
+        let docs = include_str!("../docs/config.md");
+        let marker_start = docs
+            .find(marker)
+            .unwrap_or_else(|| panic!("missing docs marker {marker}"));
+        let after_marker = &docs[marker_start..];
+        let block_start = after_marker
+            .find("```toml")
+            .unwrap_or_else(|| panic!("missing TOML block after {marker}"))
+            + "```toml".len();
+        let after_fence = &after_marker[block_start..];
+        let block_end = after_fence
+            .find("```")
+            .unwrap_or_else(|| panic!("unterminated TOML block after {marker}"));
+        after_fence[..block_end].trim()
+    }
+
     fn readme_section(heading: &str, next_heading: &str) -> &'static str {
         let readme = include_str!("../README.md");
         let start = readme
@@ -5689,7 +5708,11 @@ mod tests {
         assert!(config
             .key_bindings
             .iter()
-            .any(|(key, action)| key == "RightShift" && action == "middle_click"));
+            .any(|(key, action)| key == "Z" && action == "surgical_mode"));
+        assert!(config
+            .key_bindings
+            .iter()
+            .any(|(key, action)| key == "B" && action == "bookmark_mode"));
         for (key, action) in &config.key_bindings {
             assert!(KeyChord::parse(key).is_ok(), "{key}");
             assert!(Action::from_string(action).is_some(), "{key} -> {action}");
@@ -5730,10 +5753,94 @@ mod tests {
     }
 
     #[test]
+    fn checked_in_config_matches_runtime_defaults() {
+        let config = checked_in_config();
+        let defaults = Config::default().normalize().unwrap();
+
+        assert_eq!(config.key_bindings, defaults.key_bindings);
+        assert_eq!(
+            config.system_bindings.toggle_active,
+            defaults.system_bindings.toggle_active
+        );
+        assert_eq!(config.system_bindings.exit, defaults.system_bindings.exit);
+        assert_eq!(
+            config.system_bindings.panic_reset,
+            defaults.system_bindings.panic_reset
+        );
+        assert_eq!(
+            config.system_bindings.panic_reset_sets_idle,
+            defaults.system_bindings.panic_reset_sets_idle
+        );
+        for (key, action) in &config.key_bindings {
+            assert!(KeyChord::parse(key).is_ok(), "{key}");
+            assert!(Action::from_string(action).is_some(), "{key} -> {action}");
+        }
+    }
+
+    #[test]
+    fn help_overlay_defaults_match_config() {
+        let config = checked_in_config();
+        let view = help_overlay::help_view_from_bindings(
+            config.key_bindings.iter().map(|(key, action)| {
+                (
+                    KeyChord::parse(key).unwrap(),
+                    Action::from_string(action).unwrap(),
+                )
+            }),
+            crate::app_state::ModeContext::Active,
+        );
+        let labels: std::collections::HashSet<_> = view
+            .bindings
+            .iter()
+            .map(|binding| (binding.key.as_str(), binding.action.as_str()))
+            .collect();
+
+        for expected in [
+            ("E", "Move up"),
+            ("S", "Move left"),
+            ("D", "Move down"),
+            ("F", "Move right"),
+            ("Z", "Held precision modifier (surgical)"),
+            ("J", "Left click"),
+            ("K", "Right click"),
+            ("L", "Middle click"),
+            ("T", "Jump"),
+            ("G", "Grid"),
+            ("0", "UI Hints"),
+            ("B", "Bookmark mode"),
+            ("/", "Hints / Help"),
+            ("RightAlt+E", "Jump to monitor top edge"),
+            ("RightAlt+S", "Jump to monitor left edge"),
+            ("RightAlt+D", "Jump to monitor bottom edge"),
+            ("RightAlt+F", "Jump to monitor right edge"),
+        ] {
+            assert!(labels.contains(&expected), "missing {expected:?}");
+        }
+        for stale in [
+            ("W", "Move up"),
+            ("A", "Move left"),
+            ("B", "Held precision modifier (surgical)"),
+            ("RightAlt+W", "Jump to monitor top edge"),
+            ("RightAlt+A", "Jump to monitor left edge"),
+        ] {
+            assert!(!labels.contains(&stale), "stale label present {stale:?}");
+        }
+    }
+
+    #[test]
+    fn docs_default_keymap_snapshot_matches_config() {
+        let snippet = docs_toml_block_after("Full default `key_bindings` list:");
+        let docs_config = parse_config(snippet);
+        let checked_in = checked_in_config();
+
+        assert_eq!(docs_config.key_bindings, checked_in.key_bindings);
+    }
+
+    #[test]
     fn default_bindings_are_known_and_defaults_are_sane() {
         let config = Config::default().normalize().unwrap();
 
-        assert_eq!(config.system_bindings.exit, "Escape");
+        assert_eq!(config.system_bindings.exit, "Ctrl+Escape");
         assert_eq!(config.key_bindings, default_key_bindings());
         for (key, action) in &config.key_bindings {
             assert!(KeyChord::parse(key).is_ok(), "{key}");
@@ -5787,60 +5894,104 @@ mod tests {
         let config = parse_config(
             r#"
             key_bindings = [
-                ["A", "move_left"],
-                ["D", "move_right"],
+                ["E", "move_up"],
+                ["S", "move_left"],
+                ["D", "move_down"],
+                ["F", "move_right"],
+                ["LeftShift", "slow_mouse"],
+                ["Z", "surgical_mode"],
+                ["J", "left_click"],
+                ["K", "right_click"],
+                ["L", "middle_click"],
                 ["N", "toggle_drag_mode"],
-                [";", "middle_click"],
+                [".", "click_then_disable"],
                 ["W", "wheel_up"],
                 ["R", "wheel_down"],
-                ["H", "center_current_monitor"],
-                [".", "click_then_disable"],
-                ["RightAlt+W", "move_to_top_edge"],
-                ["RightAlt+A", "move_to_left_edge"],
-                ["RightAlt+S", "move_to_bottom_edge"],
-                ["RightAlt+D", "move_to_right_edge"],
-                ["RightAlt+Ctrl+W", "move_to_window_top_edge"],
-                ["RightAlt+Ctrl+A", "move_to_window_left_edge"],
-                ["RightAlt+Ctrl+S", "move_to_window_bottom_edge"],
-                ["RightAlt+Ctrl+D", "move_to_window_right_edge"],
-                ["RightAlt+Ctrl+Q", "move_to_window_center"],
-                ["RightAlt+Ctrl+E", "move_to_window_titlebar"],
-                ["U", "wheel_speed_up"],
-                ["I", "wheel_speed_down"],
-                ["C", "mouse_speed_up"],
-                ["X", "mouse_speed_down"],
-                ["Z", "mouse_speed_reset"]
+                ["M", "mouse_speed_down"],
+                [",", "mouse_speed_up"],
+                ["U", "wheel_speed_down"],
+                ["I", "wheel_speed_up"],
+                ["RightAlt+C", "movement_profile_next"],
+                ["RightAlt+X", "movement_profile_previous"],
+                ["RightAlt+V", "wheel_profile_next"],
+                ["RightAlt+B", "wheel_profile_previous"],
+                ["T", "jump_mode"],
+                ["G", "grid_mode"],
+                ["C", "screen_select"],
+                ["H", "navigate_back"],
+                ["Y", "navigate_forward"],
+                ["Q", "disable"],
+                ["P", "disable"],
+                ["RightAlt+E", "move_to_top_edge"],
+                ["RightAlt+S", "move_to_left_edge"],
+                ["RightAlt+D", "move_to_bottom_edge"],
+                ["RightAlt+F", "move_to_right_edge"],
+                ["RightAlt+Ctrl+E", "move_to_window_top_edge"],
+                ["RightAlt+Ctrl+S", "move_to_window_left_edge"],
+                ["RightAlt+Ctrl+D", "move_to_window_bottom_edge"],
+                ["RightAlt+Ctrl+F", "move_to_window_right_edge"],
+                ["RightAlt+Ctrl+H", "move_to_window_center"],
+                ["RightAlt+Ctrl+Y", "move_to_window_titlebar"],
+                ["RightAlt+R", "reload_config"],
+                ["RightAlt+Escape", "panic_reset"],
+                ["Alt+E", "step_move_up"],
+                ["Alt+S", "step_move_left"],
+                ["Alt+D", "step_move_down"],
+                ["Alt+F", "step_move_right"],
+                ["Alt+Ctrl+E", "step_move_small_up"],
+                ["Alt+Ctrl+S", "step_move_small_left"],
+                ["Alt+Ctrl+D", "step_move_small_down"],
+                ["Alt+Ctrl+F", "step_move_small_right"],
+                ["Alt+Shift+E", "step_move_large_up"],
+                ["Alt+Shift+S", "step_move_large_left"],
+                ["Alt+Shift+D", "step_move_large_down"],
+                ["Alt+Shift+F", "step_move_large_right"],
+                ["/", "show_help"],
+                ["0", "ui_hint_mode"],
+                ["B", "bookmark_mode"],
+                ["1", "bookmark_slot_1"],
+                ["2", "bookmark_slot_2"],
+                ["3", "bookmark_slot_3"],
+                ["4", "bookmark_slot_4"],
+                ["5", "bookmark_slot_5"],
+                ["6", "bookmark_slot_6"],
+                ["7", "bookmark_slot_7"],
+                ["8", "bookmark_slot_8"],
+                ["9", "bookmark_slot_9"],
+                ["`", "show_bookmarks"],
             ]
             "#,
         );
 
         let expected = [
-            ("A", Action::MoveLeft),
-            ("D", Action::MoveRight),
-            ("N", Action::ToggleDragMode),
-            (";", Action::MiddleClick),
-            ("W", Action::WheelUp),
-            ("R", Action::WheelDown),
-            ("H", Action::CenterCurrentMonitor),
-            (".", Action::ClickThenDisable),
-            ("RightAlt+W", Action::MoveToTopEdge),
-            ("RightAlt+A", Action::MoveToLeftEdge),
-            ("RightAlt+S", Action::MoveToBottomEdge),
-            ("RightAlt+D", Action::MoveToRightEdge),
-            ("RightAlt+Ctrl+W", Action::MoveToWindowTopEdge),
-            ("RightAlt+Ctrl+A", Action::MoveToWindowLeftEdge),
-            ("RightAlt+Ctrl+S", Action::MoveToWindowBottomEdge),
-            ("RightAlt+Ctrl+D", Action::MoveToWindowRightEdge),
-            ("RightAlt+Ctrl+Q", Action::MoveToWindowCenter),
-            ("RightAlt+Ctrl+E", Action::MoveToWindowTitlebar),
-            ("U", Action::WheelSpeedUp),
-            ("I", Action::WheelSpeedDown),
-            ("C", Action::MouseSpeedUp),
-            ("X", Action::MouseSpeedDown),
-            ("Z", Action::MouseSpeedReset),
+            ("E", Action::MoveUp),
+            ("S", Action::MoveLeft),
+            ("D", Action::MoveDown),
+            ("F", Action::MoveRight),
+            ("Z", Action::SurgicalMode),
+            ("J", Action::LeftClick),
+            ("K", Action::RightClick),
+            ("L", Action::MiddleClick),
+            ("T", Action::JumpMode),
+            ("G", Action::GridMode),
+            ("0", Action::UiHintMode),
+            ("B", Action::BookmarkMode),
+            ("RightAlt+E", Action::MoveToTopEdge),
+            ("RightAlt+S", Action::MoveToLeftEdge),
+            ("RightAlt+D", Action::MoveToBottomEdge),
+            ("RightAlt+F", Action::MoveToRightEdge),
+            ("RightAlt+Ctrl+E", Action::MoveToWindowTopEdge),
+            ("RightAlt+Ctrl+S", Action::MoveToWindowLeftEdge),
+            ("RightAlt+Ctrl+D", Action::MoveToWindowBottomEdge),
+            ("RightAlt+Ctrl+F", Action::MoveToWindowRightEdge),
+            ("RightAlt+Ctrl+H", Action::MoveToWindowCenter),
+            ("RightAlt+Ctrl+Y", Action::MoveToWindowTitlebar),
+            ("M", Action::MouseSpeedDown),
+            (",", Action::MouseSpeedUp),
+            ("/", Action::ShowHelp),
         ];
 
-        assert_eq!(config.key_bindings.len(), expected.len());
+        assert_eq!(config.key_bindings.len(), default_key_bindings().len());
         for (key, action) in expected {
             let parsed = config
                 .key_bindings


### PR DESCRIPTION
### Motivation
- Make the checked-in ergonomic `E/S/D/F` keymap the single canonical default everywhere (runtime defaults, docs, help overlay, and tests).
- Remove stale references to the old WASD/Space-based layout and align system bindings and panic/exit behavior with the checked-in `config.toml` sample.
- Add test coverage to prevent docs/config/runtime drift for key bindings and help labels.

### Description
- Updated runtime defaults in `src/main.rs`: `default_key_bindings()` now matches the checked-in `config.toml` ergonomic layout (`E/S/D/F` movement, `Z` surgical, `J/K/L` clicks, `N` drag, `.` click_then_disable, `W/R` wheel, `M/,` speed, `T/G/0` jump/grid/UI hints, `B` bookmark mode, `RightAlt+E/S/D/F` monitor-edge movement), and added the bookmarked/help/ui hint entries to the runtime default list.
- Adjusted `SystemBindings::default()` in `src/main.rs` to match checked-in config (`toggle_active = "Ctrl+Q"`, `exit = "Ctrl+Escape"`, `panic_reset = "RightAlt+Escape"`, `panic_reset_sets_idle = true`).
- Synchronized documentation: updated `README.md` and `docs/config.md` to remove stale WASD/Space/old edge-movement and exit references and to document the canonical ESDF layout, `Ctrl+Escape` exit, `RightAlt+Escape` panic reset semantics, and `M/,` speed keys.
- Made small `config.toml` example tweaks (e.g. avoided reusing `RightAlt+W` for a jump-profile example by changing it to `RightAlt+3`) so examples do not conflict with edge-movement bindings.
- Added/updated tests and helpers in `src/main.rs` test module to assert parity across checked-in config, runtime defaults, help overlay labels, and docs snapshot: added `checked_in_config_matches_runtime_defaults`, `help_overlay_defaults_match_config`, and `docs_default_keymap_snapshot_matches_config`, and a helper `docs_toml_block_after` to extract TOML blocks from `docs/config.md` for snapshot testing.

### Testing
- Ran `cargo fmt -- --check` which succeeded.
- Verified docs/config snapshot matches `config.toml` with a Python check that loads the TOML block from `docs/config.md` and compares `key_bindings`, which succeeded (`docs key_bindings match config.toml`).
- Ran `cargo test` in this environment but the test run could not complete successfully due to platform limitations for this Windows-focused crate (Windows APIs referenced via `windows::Win32` are unavailable on the current Linux target), so unit test compilation failed in this environment; the new/modified tests are present and intended to run successfully on a Windows build CI or a matching target where Windows APIs are available.
- All edits were formatted (`cargo fmt`) and a commit was created with these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1cd570d2c88332b63d7d021282abaa)