### PR TITLE
Add keybind lookup mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,11 @@ Limitations and caveats:
 
 `[tooltip_overlay]` controls temporary explanatory messages and the larger help panel toggled by `/`. Temporary tooltips are short-lived notices for runtime changes such as mouse speed, wheel speed, profile changes, drag, reload, and panic reset. The help panel does not auto-expire; it shows current runtime stats plus configured keybinds until `/` toggles it again, Escape dismisses it, or the app enters an exclusive mode such as jump.
 
+
+### Keybind lookup
+
+Press `RightAlt+/` (or bind `keybind_lookup_mode` to another chord) to enter keybind lookup mode. The next key-down is swallowed and shown in the help/tooltip overlay with the matched action or system binding, competing bindings, preserved-shortcut status, and an explanation of the routing decision. This uses the same chord specificity as runtime dispatch, so side-specific bindings such as `RightAlt+E` are reported as winning over generic `Alt+E`.
+
 Use `enabled = false` to disable all tooltip/help overlay rendering, `show_temporary_tooltips = false` to keep `/` help while hiding short runtime notices, and `show_help = false` to keep runtime notices while disabling the help panel. Individual temporary trigger classes can be controlled under `[tooltip_overlay.events]`:
 
 ```toml

--- a/config.toml
+++ b/config.toml
@@ -106,6 +106,7 @@ key_bindings = [
     ["Alt+Shift+D", "step_move_large_down"],
     ["Alt+Shift+F", "step_move_large_right"],
     ["/", "show_help"],
+    ["RightAlt+/", "keybind_lookup_mode"],
     ["0", "ui_hint_mode"],
     ["B", "bookmark_mode"],
     ["1", "bookmark_slot_1"],

--- a/docs/config.md
+++ b/docs/config.md
@@ -120,6 +120,7 @@ key_bindings = [
   ["Alt+Shift+D", "step_move_large_down"],
   ["Alt+Shift+F", "step_move_large_right"],
   ["/", "show_help"],
+  ["RightAlt+/", "keybind_lookup_mode"],
   ["0", "ui_hint_mode"],
   ["B", "bookmark_mode"],
   ["1", "bookmark_slot_1"],
@@ -690,6 +691,10 @@ show_mode_specific_sections = true
 ```
 
 Help opens from the configured `show_help` binding (default `/`). While help is visible, input is routed to the overlay first: `/` focuses/continues search, normal text edits the filter, `Backspace` removes filter text, `Tab` and `Shift+Tab` change section, `PageDown` and `PageUp` move between pages, and `Escape` closes help. Configured help actions (`help_search`, `help_next_section`, `help_previous_section`, `help_next_page`, and `help_previous_page`) can also drive the same controls.
+
+### Keybind lookup mode
+
+Bind `keybind_lookup_mode` (default `RightAlt+/`) to inspect how the next pressed chord routes. The lookup prompt swallows the next key-down event, resolves the same `KeyChord` specificity rules used by normal dispatch, and shows the matched action/system binding, whether the event would be swallowed, whether it is a preserved shortcut, any competing lower-priority bindings, and a short explanation. This is useful for confirming cases such as `RightAlt+E` winning over generic `Alt+E`.
 
 Interactive help is paged rather than truncated: every filtered binding remains reachable by changing pages. `show_conflicts` displays shadow/overlap warnings found by config audit, and `show_unbound_actions` lists known actions that currently do not have a key binding.
 

--- a/src/action.rs
+++ b/src/action.rs
@@ -84,6 +84,7 @@ pub enum Action {
     BookmarkSlot(u8),
     ClearBookmarkSlot(u8),
     ClearAllBookmarks,
+    KeybindLookupMode,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -209,6 +210,9 @@ impl Action {
             "navigate_forward" | "browser_forward" => Some(Self::NavigateForward),
             "disable" | "disable_app" | "idle_mode" => Some(Self::Disable),
             "show_help" | "help" | "toggle_help" | "hints" | "show_hints" => Some(Self::ShowHelp),
+            "keybind_lookup_mode" | "lookup_keybind" | "keybind_lookup" => {
+                Some(Self::KeybindLookupMode)
+            }
             "help_mode" => Some(Self::HelpMode),
             "help_search" => Some(Self::HelpSearch),
             "help_next_section" => Some(Self::HelpNextSection),
@@ -362,6 +366,7 @@ mod tests {
             ("navigate_forward", Action::NavigateForward),
             ("disable", Action::Disable),
             ("show_help", Action::ShowHelp),
+            ("keybind_lookup_mode", Action::KeybindLookupMode),
             ("ui_hint_mode", Action::UiHintMode),
             (
                 "step_move_up",

--- a/src/action_handler.rs
+++ b/src/action_handler.rs
@@ -370,6 +370,7 @@ impl<B: MouseBackend> MouseMaster<B> {
             | Action::NavigateBack
             | Action::NavigateForward
             | Action::ShowHelp
+            | Action::KeybindLookupMode
             | Action::HelpMode
             | Action::HelpSearch
             | Action::HelpNextSection

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -7,7 +7,9 @@ use crate::jump_view::{
     FinalAdjustOverlayView, GridOverlayMetadata, JumpOverlayView, JumpStageMetadata, JumpVisuals,
 };
 use crate::key_chord::{KeyChord, RuntimeSystemBindings};
-use crate::keyboard::{OwnedModifierKeys, VirtualKey};
+use crate::keyboard::{
+    preserved_shortcut_risk_for_chord, BindingCandidate, KeyBindings, OwnedModifierKeys, VirtualKey,
+};
 #[cfg(test)]
 use crate::Config;
 use crate::JumpConfig;
@@ -105,6 +107,8 @@ pub enum AppCommand {
     JumpInput(KeyEvent, Option<Action>),
     GridInput(KeyEvent, Option<Action>),
     UiHintInput(KeyEvent),
+    EnterKeybindLookupMode,
+    KeybindLookupInput(KeyEvent),
     EnterBookmarkMode {
         activation_key: VirtualKey,
     },
@@ -144,6 +148,7 @@ pub struct AppState {
     grid: GridState,
     ui_hints: UiHintState,
     bookmark_mode: BookmarkModeState,
+    keybind_lookup: KeybindLookupState,
     active_mode: bool,
     preserve_global_shortcuts: bool,
     right_alt_suppresses_synthetic_ctrl: bool,
@@ -185,6 +190,29 @@ pub enum UiHintState {
         query_id: u64,
         foreground_hwnd: isize,
     },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum KeybindLookupState {
+    Inactive,
+    WaitingForChord,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KeybindLookupResult {
+    pub chord_display: String,
+    pub matched_action: Option<Action>,
+    pub matched_binding: Option<KeyChord>,
+    pub swallowed: bool,
+    pub preserved_shortcut: bool,
+    pub competing_bindings: Vec<KeybindLookupBinding>,
+    pub explanation: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KeybindLookupBinding {
+    pub chord: KeyChord,
+    pub action: Action,
 }
 
 #[derive(Debug)]
@@ -380,6 +408,7 @@ impl Default for AppState {
             grid: GridState::Inactive,
             ui_hints: UiHintState::Inactive,
             bookmark_mode: BookmarkModeState::Inactive,
+            keybind_lookup: KeybindLookupState::Inactive,
             active_mode: true,
             preserve_global_shortcuts: true,
             right_alt_suppresses_synthetic_ctrl: true,
@@ -508,6 +537,7 @@ impl AppState {
         self.exit_grid_mode();
         self.exit_ui_hint_mode();
         self.exit_bookmark_mode();
+        self.exit_keybind_lookup_mode();
     }
 
     pub fn clear_runtime_input_state(&mut self) {
@@ -675,10 +705,28 @@ impl AppState {
             || self.is_ui_hint_active()
             || self.is_ui_hint_querying()
             || self.is_bookmark_mode_active()
+            || self.is_keybind_lookup_waiting()
     }
 
     pub fn is_bookmark_mode_active(&self) -> bool {
         matches!(self.bookmark_mode, BookmarkModeState::Active { .. })
+    }
+
+    pub fn is_keybind_lookup_waiting(&self) -> bool {
+        matches!(self.keybind_lookup, KeybindLookupState::WaitingForChord)
+    }
+
+    pub fn enter_keybind_lookup_mode(&mut self) {
+        self.clear_active_action_keys();
+        self.exit_jump_mode();
+        self.exit_grid_mode();
+        self.exit_ui_hint_mode();
+        self.exit_bookmark_mode();
+        self.keybind_lookup = KeybindLookupState::WaitingForChord;
+    }
+
+    pub fn exit_keybind_lookup_mode(&mut self) {
+        self.keybind_lookup = KeybindLookupState::Inactive;
     }
 
     pub fn enter_bookmark_mode(&mut self, activation_key: VirtualKey) {
@@ -1135,6 +1183,13 @@ impl AppState {
             self.enqueue_command(AppCommand::PanicReset);
             return;
         }
+        if self.is_keybind_lookup_waiting() {
+            if event.is_down {
+                self.exit_keybind_lookup_mode();
+                self.enqueue_command(AppCommand::KeybindLookupInput(event));
+            }
+            return;
+        }
         if self.help_visible && event.is_down {
             if let Some(input) = help_input_from_event(&event, action.as_ref()) {
                 match input {
@@ -1286,6 +1341,11 @@ impl AppState {
             self.active_keys.remove(&event.key);
             self.held_physical_keys.remove(&event.key);
             action = self.resolve_key_up_action(event, action);
+        }
+
+        if event.is_down && matches!(action.as_ref(), Some(Action::KeybindLookupMode)) {
+            self.enqueue_command(AppCommand::EnterKeybindLookupMode);
+            return;
         }
 
         if event.is_down && matches!(action.as_ref(), Some(Action::ShowHelp)) {
@@ -1519,6 +1579,177 @@ impl AppState {
 
     pub fn set_right_alt_suppresses_synthetic_ctrl(&mut self, enabled: bool) {
         self.right_alt_suppresses_synthetic_ctrl = enabled;
+    }
+
+    pub fn resolve_keybind_lookup(
+        &self,
+        event: &KeyEvent,
+        bindings: &KeyBindings,
+        shift_can_modify_plain_movement: bool,
+    ) -> KeybindLookupResult {
+        let normalized = self.with_effective_ctrl_state(event);
+        let chord_display = lookup_chord_display(&normalized);
+        let system_binding = self.lookup_system_binding(&normalized);
+        let candidates = bindings
+            .resolve_candidates_for_key_down_event(&normalized, shift_can_modify_plain_movement);
+        let winning_action_binding = candidates.first().cloned();
+        let competing_bindings: Vec<KeybindLookupBinding> = candidates
+            .iter()
+            .skip(1)
+            .map(|candidate| KeybindLookupBinding {
+                chord: candidate.chord,
+                action: candidate.action.clone(),
+            })
+            .collect();
+
+        let preserved_shortcut = self.preserve_global_shortcuts
+            && preserved_shortcut_risk_for_chord(&event_chord_for_lookup(&normalized)).is_some();
+
+        let (matched_action, matched_binding, swallowed, explanation) = if let Some((name, chord)) =
+            system_binding
+        {
+            let explanation = format!(
+                "{chord_display} matches system binding {name} ({}), so system routing wins before action dispatch and the key is swallowed.",
+                chord.display_label()
+            );
+            (None, Some(chord), true, explanation)
+        } else if let Some(BindingCandidate { chord, action }) = winning_action_binding {
+            let specificity_note = if competing_bindings.is_empty() {
+                String::new()
+            } else {
+                format!(
+                    " It wins over {} competing binding(s) by KeyChord specificity/order.",
+                    competing_bindings.len()
+                )
+            };
+            if self.active_mode {
+                let explanation = format!(
+                    "{chord_display} resolves to action {action:?} via binding {} while active mode is enabled, so the event is swallowed and dispatched.{specificity_note}",
+                    chord.display_label()
+                );
+                (Some(action.clone()), Some(chord), true, explanation)
+            } else {
+                let explanation = format!(
+                    "{chord_display} has action binding {} -> {action:?}, but active mode is disabled, so action bindings are inactive and the key passes through.",
+                    chord.display_label()
+                );
+                (Some(action.clone()), Some(chord), false, explanation)
+            }
+        } else if self.active_mode && preserved_shortcut {
+            let explanation = format!(
+                "{chord_display} is a preserved Windows/app shortcut and no explicit action binding matched, so it passes through."
+            );
+            (None, None, false, explanation)
+        } else if self.active_mode {
+            let explanation = format!(
+                "{chord_display} is unbound in active mode and is not a system binding, so it passes through."
+            );
+            (None, None, false, explanation)
+        } else {
+            let explanation = format!(
+                "{chord_display} was looked up while active mode is disabled; no system binding matched, so it passes through."
+            );
+            (None, None, false, explanation)
+        };
+
+        KeybindLookupResult {
+            chord_display,
+            matched_action,
+            matched_binding,
+            swallowed,
+            preserved_shortcut,
+            competing_bindings,
+            explanation,
+        }
+    }
+
+    fn lookup_system_binding(&self, event: &KeyEvent) -> Option<(String, KeyChord)> {
+        if self.system_bindings.toggle_active.matches_event(event) {
+            return Some((
+                "toggle_active".to_string(),
+                self.system_bindings.toggle_active,
+            ));
+        }
+        let exit_matches = if self.system_bindings.exit_ignore_extra_modifiers {
+            self.system_bindings
+                .exit
+                .matches_event_ignoring_extra_modifiers(event)
+        } else {
+            self.system_bindings.exit.matches_event(event)
+        };
+        if exit_matches {
+            return Some(("exit".to_string(), self.system_bindings.exit));
+        }
+        let panic_matches = if self.system_bindings.panic_reset_ignore_extra_modifiers {
+            self.system_bindings
+                .panic_reset
+                .matches_event_ignoring_extra_modifiers(event)
+        } else {
+            self.system_bindings.panic_reset.matches_event(event)
+        };
+        panic_matches.then_some(("panic_reset".to_string(), self.system_bindings.panic_reset))
+    }
+}
+
+fn lookup_chord_display(event: &KeyEvent) -> String {
+    let mut parts = Vec::new();
+    if event.left_ctrl_down {
+        parts.push("LeftCtrl".to_string());
+    } else if event.right_ctrl_down {
+        parts.push("RightCtrl".to_string());
+    } else if event.ctrl_down {
+        parts.push("Ctrl".to_string());
+    }
+    if event.left_alt_down {
+        parts.push("LeftAlt".to_string());
+    } else if event.right_alt_down {
+        parts.push("RightAlt".to_string());
+    } else if event.alt_down {
+        parts.push("Alt".to_string());
+    }
+    if event.left_shift_down {
+        parts.push("LeftShift".to_string());
+    } else if event.right_shift_down {
+        parts.push("RightShift".to_string());
+    } else if event.shift_down {
+        parts.push("Shift".to_string());
+    }
+    if event.left_win_down {
+        parts.push("LeftWin".to_string());
+    } else if event.right_win_down {
+        parts.push("RightWin".to_string());
+    } else if event.win_down {
+        parts.push("Win".to_string());
+    }
+    parts.push(KeyChord::from_key(event.key).display_label());
+    parts.join("+")
+}
+
+fn event_chord_for_lookup(event: &KeyEvent) -> KeyChord {
+    use crate::key_chord::{ModifierRequirements, ModifierSideRequirement};
+    fn req(any: bool, left: bool, right: bool) -> ModifierSideRequirement {
+        if right {
+            ModifierSideRequirement::Right
+        } else if left {
+            ModifierSideRequirement::Left
+        } else if any {
+            ModifierSideRequirement::Any
+        } else {
+            ModifierSideRequirement::NotRequired
+        }
+    }
+    KeyChord {
+        key: event.key,
+        modifiers: ModifierRequirements::new(
+            req(event.ctrl_down, event.left_ctrl_down, event.right_ctrl_down),
+            req(event.alt_down, event.left_alt_down, event.right_alt_down),
+            req(
+                event.shift_down,
+                event.left_shift_down,
+                event.right_shift_down,
+            ),
+            req(event.win_down, event.left_win_down, event.right_win_down),
+        ),
     }
 }
 

--- a/src/help_overlay.rs
+++ b/src/help_overlay.rs
@@ -1262,6 +1262,7 @@ fn action_description(action: &Action) -> String {
         Action::HelpMode | Action::ShowHelp => {
             "Open or close this searchable help overlay".to_string()
         }
+        Action::KeybindLookupMode => "Inspect the next key chord routing decision".to_string(),
         Action::StepMove { .. } => "Move once by the configured step size".to_string(),
         _ => format_action(action),
     }
@@ -1329,6 +1330,7 @@ fn format_action(action: &Action) -> String {
         Action::HelpNextPage => "Help next page".to_string(),
         Action::HelpPreviousPage => "Help previous page".to_string(),
         Action::UiHintMode => "UI Hints".to_string(),
+        Action::KeybindLookupMode => "Keybind lookup".to_string(),
         Action::BookmarkMode => "Bookmark mode".to_string(),
         Action::ShowBookmarks => "Show bookmark list".to_string(),
         Action::BookmarkSlot(slot) => format!("Jump to bookmark slot {slot}"),
@@ -1411,7 +1413,8 @@ fn action_section(action: &Action) -> HelpBindingSection {
         | Action::ReloadConfig
         | Action::PanicReset
         | Action::Disable
-        | Action::ShowHelp => HelpBindingSection::ProfilesRuntime,
+        | Action::ShowHelp
+        | Action::KeybindLookupMode => HelpBindingSection::ProfilesRuntime,
         Action::HelpMode
         | Action::HelpSearch
         | Action::HelpNextSection

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -1059,7 +1059,11 @@ mod tests {
     #[test]
     fn lookup_reports_system_binding() {
         let bindings = KeyBindings::new();
-        let app_state = crate::app_state::AppState::default();
+        let mut app_state = crate::app_state::AppState::default();
+        app_state.set_system_bindings(crate::key_chord::RuntimeSystemBindings::new(
+            KeyChord::parse("Ctrl+Q").unwrap(),
+            KeyChord::parse("Ctrl+Escape").unwrap(),
+        ));
 
         let result = bindings.lookup_keybind_event(&ctrl_event(VirtualKey::Q), true, &app_state);
 

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -1,5 +1,5 @@
 use crate::action::Action;
-use crate::app_state::KeyEvent;
+use crate::app_state::{KeyEvent, KeybindLookupResult};
 use crate::key_chord::KeyChord;
 use std::collections::HashSet;
 use std::mem::size_of;
@@ -816,6 +816,12 @@ pub struct ResolvedBinding {
     pub action: Action,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BindingCandidate {
+    pub chord: KeyChord,
+    pub action: Action,
+}
+
 impl KeyBindings {
     /// Create a new KeyBindings instance
     pub fn new() -> Self {
@@ -860,31 +866,45 @@ impl KeyBindings {
         event: &KeyEvent,
         shift_can_modify_plain_movement: bool,
     ) -> Option<ResolvedBinding> {
-        if !event.is_down {
-            return None;
-        }
-
-        if let Some(resolved) = self.resolve_best_match(|chord| chord.matches_event(event)) {
-            return Some(resolved);
-        }
-
-        if !shift_can_modify_plain_movement {
-            return None;
-        }
-
-        self.resolve_best_match(|chord| chord.matches_event_allowing_shift_modifier(event))
+        self.resolve_candidates_for_key_down_event(event, shift_can_modify_plain_movement)
+            .into_iter()
+            .next()
+            .map(|candidate| ResolvedBinding {
+                chord: candidate.chord,
+                action: candidate.action,
+            })
     }
 
-    fn resolve_best_match(&self, matcher: impl Fn(&KeyChord) -> bool) -> Option<ResolvedBinding> {
-        self.bindings
+    pub fn resolve_candidates_for_key_down_event(
+        &self,
+        event: &KeyEvent,
+        shift_can_modify_plain_movement: bool,
+    ) -> Vec<BindingCandidate> {
+        if !event.is_down {
+            return Vec::new();
+        }
+
+        let exact = self.matching_candidates(|chord| chord.matches_event(event));
+        if !exact.is_empty() || !shift_can_modify_plain_movement {
+            return exact;
+        }
+
+        self.matching_candidates(|chord| chord.matches_event_allowing_shift_modifier(event))
+    }
+
+    fn matching_candidates(&self, matcher: impl Fn(&KeyChord) -> bool) -> Vec<BindingCandidate> {
+        let mut candidates: Vec<_> = self
+            .bindings
             .iter()
             .enumerate()
             .filter(|(_, (chord, _))| matcher(chord))
-            .max_by_key(|(idx, (chord, _))| (chord.specificity(), std::cmp::Reverse(*idx)))
-            .map(|(_, (chord, action))| ResolvedBinding {
-                chord: *chord,
-                action: action.clone(),
-            })
+            .map(|(idx, (chord, action))| (idx, *chord, action.clone()))
+            .collect();
+        candidates.sort_by_key(|(idx, chord, _)| (std::cmp::Reverse(chord.specificity()), *idx));
+        candidates
+            .into_iter()
+            .map(|(_, chord, action)| BindingCandidate { chord, action })
+            .collect()
     }
 
     pub fn get_action_for_event(
@@ -894,6 +914,15 @@ impl KeyBindings {
     ) -> Option<Action> {
         self.resolve_for_key_down_event(event, shift_can_modify_plain_movement)
             .map(|resolved| resolved.action)
+    }
+
+    pub fn lookup_keybind_event(
+        &self,
+        event: &KeyEvent,
+        shift_can_modify_plain_movement: bool,
+        app_state: &crate::app_state::AppState,
+    ) -> KeybindLookupResult {
+        app_state.resolve_keybind_lookup(event, self, shift_can_modify_plain_movement)
     }
 
     pub fn bound_chords(&self) -> impl Iterator<Item = KeyChord> + '_ {
@@ -966,6 +995,113 @@ mod tests {
             self.events.push(event);
             Ok(())
         }
+    }
+
+    fn ctrl_event(key: VirtualKey) -> KeyEvent {
+        let mut event = KeyEvent::new(key, true);
+        event.ctrl_down = true;
+        event.left_ctrl_down = true;
+        event
+    }
+
+    fn alt_event(key: VirtualKey) -> KeyEvent {
+        let mut event = KeyEvent::new(key, true);
+        event.alt_down = true;
+        event.left_alt_down = true;
+        event
+    }
+
+    fn right_alt_event(key: VirtualKey) -> KeyEvent {
+        let mut event = KeyEvent::new(key, true);
+        event.alt_down = true;
+        event.right_alt_down = true;
+        event
+    }
+
+    #[test]
+    fn lookup_reports_unbound_ctrl_w_passthrough() {
+        let bindings = KeyBindings::new();
+        let app_state = crate::app_state::AppState::default();
+
+        let result = bindings.lookup_keybind_event(&ctrl_event(VirtualKey::W), true, &app_state);
+
+        assert_eq!(result.chord_display, "LeftCtrl+W");
+        assert_eq!(result.matched_action, None);
+        assert!(!result.swallowed);
+        assert!(result.preserved_shortcut);
+        assert!(result.explanation.contains("preserved"));
+    }
+
+    #[test]
+    fn lookup_reports_rightalt_binding_wins_over_alt_binding() {
+        let mut bindings = KeyBindings::new();
+        bindings.add_chord_binding(KeyChord::parse("Alt+E").unwrap(), Action::MoveUp);
+        bindings.add_chord_binding(
+            KeyChord::parse("RightAlt+E").unwrap(),
+            Action::MoveToTopEdge,
+        );
+        let app_state = crate::app_state::AppState::default();
+
+        let result =
+            bindings.lookup_keybind_event(&right_alt_event(VirtualKey::E), true, &app_state);
+
+        assert_eq!(result.matched_action, Some(Action::MoveToTopEdge));
+        assert_eq!(
+            result.matched_binding.map(|chord| chord.display_label()),
+            Some("RightAlt+E".to_string())
+        );
+        assert!(result.swallowed);
+        assert_eq!(result.competing_bindings.len(), 1);
+        assert_eq!(result.competing_bindings[0].action, Action::MoveUp);
+        assert!(result.explanation.contains("wins over 1 competing"));
+    }
+
+    #[test]
+    fn lookup_reports_system_binding() {
+        let bindings = KeyBindings::new();
+        let app_state = crate::app_state::AppState::default();
+
+        let result = bindings.lookup_keybind_event(&ctrl_event(VirtualKey::Q), true, &app_state);
+
+        assert_eq!(result.matched_action, None);
+        assert_eq!(
+            result.matched_binding.map(|chord| chord.display_label()),
+            Some("Ctrl+Q".to_string())
+        );
+        assert!(result.swallowed);
+        assert!(result.explanation.contains("system binding toggle_active"));
+    }
+
+    #[test]
+    fn lookup_reports_action_binding_only_active_when_enabled() {
+        let mut bindings = KeyBindings::new();
+        bindings.add_chord_binding(KeyChord::parse("Alt+E").unwrap(), Action::MoveUp);
+        let mut app_state = crate::app_state::AppState::default();
+        app_state.set_active_mode(false);
+
+        let result = bindings.lookup_keybind_event(&alt_event(VirtualKey::E), true, &app_state);
+
+        assert_eq!(result.matched_action, Some(Action::MoveUp));
+        assert!(!result.swallowed);
+        assert!(result.explanation.contains("active mode is disabled"));
+    }
+
+    #[test]
+    fn lookup_reports_competing_bindings() {
+        let mut bindings = KeyBindings::new();
+        bindings.add_chord_binding(KeyChord::parse("Alt+E").unwrap(), Action::MoveUp);
+        bindings.add_chord_binding(
+            KeyChord::parse("RightAlt+E").unwrap(),
+            Action::MoveToTopEdge,
+        );
+        let app_state = crate::app_state::AppState::default();
+
+        let result =
+            bindings.lookup_keybind_event(&right_alt_event(VirtualKey::E), true, &app_state);
+
+        assert_eq!(result.competing_bindings.len(), 1);
+        assert_eq!(result.competing_bindings[0].chord.display_label(), "Alt+E");
+        assert_eq!(result.competing_bindings[0].action, Action::MoveUp);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -603,6 +603,7 @@ fn default_key_bindings() -> Vec<(String, String)> {
         ("Alt+Shift+D", "step_move_large_down"),
         ("Alt+Shift+F", "step_move_large_right"),
         ("/", "show_help"),
+        ("RightAlt+/", "keybind_lookup_mode"),
         ("0", "ui_hint_mode"),
         ("B", "bookmark_mode"),
         ("1", "bookmark_slot_1"),
@@ -2907,6 +2908,31 @@ fn routing_action_label(event: &KeyEvent, action: Option<Action>) -> String {
     }
 }
 
+fn format_keybind_lookup_result(result: &app_state::KeybindLookupResult) -> String {
+    let matched = match (&result.matched_binding, &result.matched_action) {
+        (Some(chord), Some(action)) => format!("Matched: {} -> {action:?}", chord.display_label()),
+        (Some(chord), None) => format!("Matched system binding: {}", chord.display_label()),
+        (None, _) => "Matched: <none>".to_string(),
+    };
+    let competing = if result.competing_bindings.is_empty() {
+        "Competing: none".to_string()
+    } else {
+        format!(
+            "Competing: {}",
+            result
+                .competing_bindings
+                .iter()
+                .map(|binding| format!("{} -> {:?}", binding.chord.display_label(), binding.action))
+                .collect::<Vec<_>>()
+                .join(", ")
+        )
+    };
+    format!(
+        "{matched}\nSwallowed: {}\nPreserved shortcut: {}\n{competing}\n{}",
+        result.swallowed, result.preserved_shortcut, result.explanation
+    )
+}
+
 fn process_queued_key_events(debug_diagnostics: bool) -> LoopDiagnostics {
     let mut diagnostics = LoopDiagnostics::default();
 
@@ -3630,6 +3656,10 @@ fn execute_app_command(command: AppCommand, debug_diagnostics: bool) {
             AppCommand::EnterUiHintMode { activation_key } => {
                 println!("[command] EnterUiHintMode activation_key={activation_key:?}")
             }
+            AppCommand::EnterKeybindLookupMode => println!("[command] EnterKeybindLookupMode"),
+            AppCommand::KeybindLookupInput(event) => {
+                println!("[command] KeybindLookupInput key={:?}", event.key)
+            }
             AppCommand::KeyAction { action, is_down } => {
                 println!(
                     "[command] KeyAction action={action:?} state={}",
@@ -3845,6 +3875,30 @@ fn execute_app_command(command: AppCommand, debug_diagnostics: bool) {
             if let Some(view) = view {
                 show_jump_overlay(view);
             }
+        }
+        AppCommand::EnterKeybindLookupMode => {
+            APP_STATE.write().unwrap().enter_keybind_lookup_mode();
+            help_overlay::show_temporary_tooltip(
+                "Keybind lookup",
+                "Press the chord to inspect. The next key-down will be swallowed and explained.",
+                Duration::from_secs(10),
+            );
+        }
+        AppCommand::KeybindLookupInput(event) => {
+            let shift_can_modify_plain_movement = *SHIFT_CAN_MODIFY_PLAIN_MOVEMENT.read().unwrap();
+            let result = {
+                let app_state = APP_STATE.read().unwrap();
+                KEY_ACTIONS.read().unwrap().lookup_keybind_event(
+                    &event,
+                    shift_can_modify_plain_movement,
+                    &app_state,
+                )
+            };
+            help_overlay::show_temporary_tooltip(
+                format!("Lookup: {}", result.chord_display),
+                format_keybind_lookup_result(&result),
+                Duration::from_secs(10),
+            );
         }
         AppCommand::EnterUiHintMode { activation_key } => {
             let config = ACTION_HANDLER

--- a/src/main.rs
+++ b/src/main.rs
@@ -6089,6 +6089,7 @@ mod tests {
                 ["Alt+Shift+D", "step_move_large_down"],
                 ["Alt+Shift+F", "step_move_large_right"],
                 ["/", "show_help"],
+                ["RightAlt+/", "keybind_lookup_mode"],
                 ["0", "ui_hint_mode"],
                 ["B", "bookmark_mode"],
                 ["1", "bookmark_slot_1"],
@@ -6131,6 +6132,7 @@ mod tests {
             ("M", Action::MouseSpeedDown),
             (",", Action::MouseSpeedUp),
             ("/", Action::ShowHelp),
+            ("RightAlt+/", Action::KeybindLookupMode),
         ];
 
         assert_eq!(config.key_bindings.len(), default_key_bindings().len());


### PR DESCRIPTION
### Motivation

- Provide an interactive lookup that swallows the next chord and explains how the key routing will resolve (system binding vs action binding, preserved shortcut passthrough, competing bindings, and why a particular chord wins). 

### Description

- Add a new action `Action::KeybindLookupMode` and wire `"keybind_lookup_mode"` (and aliases) into `Action::from_string` and the default bindings, with a default `RightAlt+/` entry in `config.toml` and runtime defaults. 
- Add lookup UI state and commands: `KeybindLookupState::{Inactive, WaitingForChord}`, `AppCommand::EnterKeybindLookupMode`, and `AppCommand::KeybindLookupInput(KeyEvent)`, plus `AppState` helpers `enter_keybind_lookup_mode`, `exit_keybind_lookup_mode`, and `is_keybind_lookup_waiting`. 
- Implement `KeybindLookupResult`/`KeybindLookupBinding` and `AppState::resolve_keybind_lookup` that reuses `KeyChord`/`KeyBindings` candidate resolution to report matched binding/action, competing lower-priority bindings, whether the event would be swallowed, preserved-shortcut status, and a human explanation string. 
- Extend `KeyBindings` with `BindingCandidate` and `resolve_candidates_for_key_down_event` so the same specificity/order logic is reused for lookup explanations. 
- Render lookup prompts/results via the existing tooltip/help overlay (`help_overlay`) and add `format_keybind_lookup_result` formatting and help overlay descriptions/sections for the feature. 
- Add unit tests covering the new lookup behavior: `lookup_reports_unbound_ctrl_w_passthrough`, `lookup_reports_rightalt_binding_wins_over_alt_binding`, `lookup_reports_system_binding`, `lookup_reports_action_binding_only_active_when_enabled`, and `lookup_reports_competing_bindings`. 

### Testing

- Ran `cargo fmt -- --check`, which succeeded. 
- Ran `cargo check --target x86_64-pc-windows-gnu`, which completed successfully to validate Windows-target build. 
- Built the Windows-target test binary with `cargo test --target x86_64-pc-windows-gnu lookup_reports --no-run` to validate compilation of the new lookup tests (succeeded); the produced Windows test executable cannot be executed on the Linux CI host. 
- Attempted `cargo test lookup_reports -- --nocapture` on the default Linux target, which cannot run the Windows Win32 overlay binaries in this environment so tests were not executed natively (platform limitation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d70ba1b4c83328935ddfbc4bf2b1e)