### PR TITLE
Increase default stuck key timeout to 10_000ms

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -540,7 +540,7 @@ impl Default for InputConfig {
             swallow_owned_modifiers: true,
             modifier_reconcile_on_tick: true,
             modifier_reconcile_interval_ms: 50,
-            stuck_key_timeout_ms: 500,
+            stuck_key_timeout_ms: 10_000,
             debug_input: false,
             shift_can_modify_plain_movement: true,
             right_alt_suppresses_synthetic_ctrl: true,
@@ -7009,7 +7009,7 @@ mod tests {
     #[test]
     fn input_config_default_uses_safer_stuck_timeout() {
         let config = parse_config("");
-        assert_eq!(config.input.stuck_key_timeout_ms, 500);
+        assert_eq!(config.input.stuck_key_timeout_ms, 10_000);
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Reduce accidental “stuck key” behavior by increasing the safer default timeout for input handling. 
- Preserve backward compatibility for existing user configs by keeping the legacy lower clamp while ensuring zero-valued user fields normalize to the new default. 

### Description
- Update `InputConfig::default()` to set `stuck_key_timeout_ms` from `500` to `10_000`. 
- Update the test `input_config_default_uses_safer_stuck_timeout` to expect `10_000`. 
- Leave `Config::normalize()` behavior unchanged: zero-value normalization continues to use `InputConfig::default().stuck_key_timeout_ms`, and the non-zero clamp remains `500` to `60_000`. 
- Ensure the existing test `input_config_normalizes_zero_and_out_of_range_values` still validates zero normalization against `InputConfig::default()`. 

### Testing
- Ran `cargo fmt -- --check`, which succeeded. 
- Ran `git diff --check`, which succeeded. 
- Attempted `cargo test input_config`; the run encountered platform/tooling failures when building native dependencies and Windows-specific crates (the change itself compiles locally), so the input-focused tests could not be fully executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1df8fc549c8332a52d91be8bea3512)