### PR TITLE
Extract helper for releasing reconciled stale keys and update tests

### DIFF
--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -4171,6 +4171,7 @@ mod tests {
         state.set_owned_modifiers([VirtualKey::RightAlt]);
         state.route_key_event(KeyEvent::new(VirtualKey::RightAlt, true), None);
         state.route_key_event(KeyEvent::new(VirtualKey::A, true), Some(Action::MoveLeft));
+        assert_eq!(collect_commands(&mut state).len(), 1);
         assert!(state.should_swallow_key(&KeyEvent::new(VirtualKey::RightAlt, true)));
 
         state.reconcile_stale_keys(Duration::ZERO, |key| key != VirtualKey::RightAlt);
@@ -4227,7 +4228,7 @@ mod tests {
         assert!(state
             .reconciled_released_keys
             .contains(&VirtualKey::LeftShift));
-        assert!(!state.should_swallow_key(&KeyEvent::new(VirtualKey::LeftShift, false)));
+        assert!(state.should_swallow_key(&KeyEvent::new(VirtualKey::RightAlt, false)));
     }
 
     #[test]

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -506,30 +506,38 @@ impl AppState {
         }
 
         for (key, held_state) in stale_keys {
-            let stale_owned_modifier = held_state.was_owned_modifier;
-            let stale_trigger = held_state.was_action_trigger;
-            let mut synthesized_action = None;
+            self.release_reconciled_stale_key(key, held_state);
+        }
+    }
 
-            self.held_physical_keys.remove(&key);
-            self.active_keys.remove(&key);
-            self.reconciled_released_keys.insert(key);
-            if stale_trigger {
-                synthesized_action = self.resolve_key_up_action(KeyEvent::new(key, false), None);
-            }
+    fn release_reconciled_stale_key(&mut self, key: VirtualKey, held_state: HeldKeyState) {
+        let stale_owned_modifier = held_state.was_owned_modifier;
+        let stale_trigger = held_state.was_action_trigger;
+        let mut synthesized_action = None;
 
-            if let Some(action) = synthesized_action {
-                self.enqueue_command(AppCommand::KeyAction {
-                    action,
-                    is_down: false,
-                });
-            }
+        self.held_physical_keys.remove(&key);
+        self.active_keys.remove(&key);
+        self.reconciled_released_keys.insert(key);
+        if stale_trigger {
+            synthesized_action = self.resolve_key_up_action(KeyEvent::new(key, false), None);
+        }
 
-            if self.debug_input {
-                eprintln!(
-                    "[debug-input] reconciled stale key={:?} trigger={} owned_modifier={} held_ms={} reconciled_release_sent={}",
-                    key, stale_trigger, stale_owned_modifier, held_state.pressed_at.elapsed().as_millis(), held_state.reconciled_release_sent
-                );
-            }
+        if let Some(action) = synthesized_action {
+            self.enqueue_command(AppCommand::KeyAction {
+                action,
+                is_down: false,
+            });
+        }
+
+        if self.debug_input {
+            eprintln!(
+                "[debug-input] reconciled stale key={:?} trigger={} owned_modifier={} held_ms={} reconciled_release_sent={}",
+                key,
+                stale_trigger,
+                stale_owned_modifier,
+                held_state.pressed_at.elapsed().as_millis(),
+                held_state.reconciled_release_sent
+            );
         }
     }
 
@@ -4001,6 +4009,9 @@ mod tests {
         assert!(state
             .held_physical_keys
             .contains_key(&VirtualKey::LeftShift));
+        assert!(!state
+            .reconciled_released_keys
+            .contains(&VirtualKey::LeftShift));
         assert!(state.should_swallow_key(&KeyEvent::new(VirtualKey::LeftShift, false)));
     }
 
@@ -4025,6 +4036,9 @@ mod tests {
             .expect("held key should be tracked")
             .physically_up_since
             .is_some());
+        assert!(!state
+            .reconciled_released_keys
+            .contains(&VirtualKey::LeftShift));
         assert!(state.should_swallow_key(&KeyEvent::new(VirtualKey::LeftShift, false)));
     }
 
@@ -4055,6 +4069,9 @@ mod tests {
         assert!(!state
             .held_physical_keys
             .contains_key(&VirtualKey::LeftShift));
+        assert!(state
+            .reconciled_released_keys
+            .contains(&VirtualKey::LeftShift));
         assert!(!state.should_swallow_key(&KeyEvent::new(VirtualKey::LeftShift, false)));
     }
 
@@ -4085,6 +4102,9 @@ mod tests {
         assert!(!state
             .held_physical_keys
             .contains_key(&VirtualKey::LeftShift));
+        assert!(state
+            .reconciled_released_keys
+            .contains(&VirtualKey::LeftShift));
         assert!(!state.should_swallow_key(&KeyEvent::new(VirtualKey::LeftShift, false)));
     }
 
@@ -4114,8 +4134,6 @@ mod tests {
 
         assert_eq!(collect_commands(&mut state), Vec::new());
         assert!(state.held_physical_keys.contains_key(&VirtualKey::E));
-        assert!(state.active_keys.contains(&VirtualKey::E));
-        assert!(state.active_triggers.contains_key(&VirtualKey::E));
         assert!(!state.reconciled_released_keys.contains(&VirtualKey::E));
         assert!(state.should_swallow_key(&KeyEvent::new(VirtualKey::E, false)));
     }
@@ -4138,6 +4156,13 @@ mod tests {
                 is_down: false,
             }]
         );
+        assert!(!state
+            .held_physical_keys
+            .contains_key(&VirtualKey::LeftShift));
+        assert!(state
+            .reconciled_released_keys
+            .contains(&VirtualKey::LeftShift));
+        assert!(!state.should_swallow_key(&KeyEvent::new(VirtualKey::LeftShift, false)));
     }
 
     #[test]
@@ -4150,6 +4175,11 @@ mod tests {
 
         state.reconcile_stale_keys(Duration::ZERO, |key| key != VirtualKey::RightAlt);
 
+        assert_eq!(collect_commands(&mut state), Vec::new());
+        assert!(!state.held_physical_keys.contains_key(&VirtualKey::RightAlt));
+        assert!(state
+            .reconciled_released_keys
+            .contains(&VirtualKey::RightAlt));
         assert!(!state.should_swallow_key(&KeyEvent::new(VirtualKey::RightAlt, true)));
     }
 
@@ -4191,6 +4221,13 @@ mod tests {
         assert!(!state
             .held_physical_keys
             .contains_key(&VirtualKey::LeftShift));
+        assert!(!state
+            .reconciled_released_keys
+            .contains(&VirtualKey::RightAlt));
+        assert!(state
+            .reconciled_released_keys
+            .contains(&VirtualKey::LeftShift));
+        assert!(!state.should_swallow_key(&KeyEvent::new(VirtualKey::LeftShift, false)));
     }
 
     #[test]
@@ -4205,9 +4242,8 @@ mod tests {
 
         assert_eq!(collect_commands(&mut state), Vec::new());
         assert!(state.held_physical_keys.contains_key(&VirtualKey::E));
-        assert!(state.active_keys.contains(&VirtualKey::E));
-        assert!(state.active_triggers.contains_key(&VirtualKey::E));
         assert!(!state.reconciled_released_keys.contains(&VirtualKey::E));
+        assert!(state.should_swallow_key(&KeyEvent::new(VirtualKey::E, false)));
     }
 
     #[test]
@@ -4217,11 +4253,25 @@ mod tests {
             KeyEvent::new(VirtualKey::LeftShift, true),
             Some(Action::SlowMouse),
         );
+        assert_eq!(collect_commands(&mut state).len(), 1);
         let up = KeyEvent::new(VirtualKey::LeftShift, false);
         assert!(state.should_swallow_key(&up));
 
         state.reconcile_stale_keys(Duration::ZERO, |_| false);
 
+        assert_eq!(
+            collect_commands(&mut state),
+            vec![AppCommand::KeyAction {
+                action: Action::SlowMouse,
+                is_down: false,
+            }]
+        );
+        assert!(!state
+            .held_physical_keys
+            .contains_key(&VirtualKey::LeftShift));
+        assert!(state
+            .reconciled_released_keys
+            .contains(&VirtualKey::LeftShift));
         assert!(!state.should_swallow_key(&up));
     }
 


### PR DESCRIPTION
### Motivation
- Keep `reconcile_stale_keys()` focused on candidate filtering and stale detection and move release side-effects into a dedicated helper. 
- Centralize the logic that mutates tracked key state and emits release actions so behavior is easier to reason about and test.

### Description
- Add a private helper `fn release_reconciled_stale_key(&mut self, key: VirtualKey, held_state: HeldKeyState)` that performs the stale-release side effects (removes from `held_physical_keys`, removes from `active_keys`, inserts into `reconciled_released_keys`, resolves an up-action via `resolve_key_up_action(KeyEvent::new(key, false), None)`, and enqueues a `AppCommand::KeyAction { action, is_down: false }` when applicable). 
- Modify `reconcile_stale_keys()` to collect stale candidates and delegate each release to `release_reconciled_stale_key()` so it only performs filtering and stale detection.
- Update existing reconcile-focused tests in `src/app_state.rs` to assert behavior via public effects: queued commands, `should_swallow_key`, `held_physical_keys`, and `reconciled_released_keys` instead of directly inspecting internal active-trigger maps.
- Keep the helper private (non-`pub`) and preserve existing debug logging output when `debug_input` is enabled.

### Testing
- Ran `cargo fmt -- --check` which succeeded. 
- Attempted `cargo test reconcile` but the build failed on this Linux host due to platform-specific dependencies (the crate imports Windows APIs via the `windows` crate), so the reconcile tests could not be executed end-to-end in this environment. 
- `cargo fmt` was run prior to committing to ensure formatting consistency.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1dfe4d7c4c83329337dba01010a979)