### PR TITLE
Refine debug logging for reconciled stale modifier keys

### DIFF
--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -531,12 +531,15 @@ impl AppState {
 
         if self.debug_input {
             eprintln!(
-                "[debug-input] reconciled stale key={:?} trigger={} owned_modifier={} held_ms={} reconciled_release_sent={}",
+                "[debug-input] reconciled stale modifier key={:?} trigger={} owned_modifier={} held_ms={} up_for_ms={}",
                 key,
                 stale_trigger,
                 stale_owned_modifier,
                 held_state.pressed_at.elapsed().as_millis(),
-                held_state.reconciled_release_sent
+                held_state
+                    .physically_up_since
+                    .map(|t| t.elapsed().as_millis())
+                    .unwrap_or(0)
             );
         }
     }


### PR DESCRIPTION
### Motivation
- Improve observability for modifier-only stale-key reconciliation by making debug logs explicit about modifier recovery and including timing fields (`key`, `trigger`, `owned_modifier`, `held_ms`, `up_for_ms`) while avoiding per-tick log spam.

### Description
- Update `release_reconciled_stale_key` to use the prefix `[debug-input] reconciled stale modifier ...`, include the fields `key`, `trigger`, `owned_modifier`, `held_ms`, and compute `up_for_ms` with `held_state.physically_up_since.map(|t| t.elapsed().as_millis()).unwrap_or(0)`, remove `reconciled_release_sent`, and keep the message gated by `debug_input` to prevent noisy logging.

### Testing
- Ran `cargo test`, which could not complete in this environment because the system `xi` pkg-config dependency required by the `x11` crate is missing, so unit tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e02b442508332a8496caaa61af76d)