### PR TITLE
Add diagonal movement reconcile regression test

### DIFF
--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -1919,8 +1919,12 @@ mod tests {
     }
 
     fn state_with_bound_key(key: VirtualKey) -> AppState {
+        state_with_bound_keys([key])
+    }
+
+    fn state_with_bound_keys(keys: impl IntoIterator<Item = VirtualKey>) -> AppState {
         let mut state = AppState::default();
-        state.set_bound_keys([key]);
+        state.set_bound_keys(keys);
         state
     }
 
@@ -4248,6 +4252,21 @@ mod tests {
         assert!(state.held_physical_keys.contains_key(&VirtualKey::E));
         assert!(!state.reconciled_released_keys.contains(&VirtualKey::E));
         assert!(state.should_swallow_key(&KeyEvent::new(VirtualKey::E, false)));
+    }
+
+    #[test]
+    fn diagonal_movement_keys_survive_modifier_reconcile() {
+        let mut state = state_with_bound_keys([VirtualKey::S, VirtualKey::D]);
+        state.route_key_event(KeyEvent::new(VirtualKey::S, true), Some(Action::MoveLeft));
+        state.route_key_event(KeyEvent::new(VirtualKey::D, true), Some(Action::MoveDown));
+        let _ = collect_commands(&mut state);
+
+        state.reconcile_stale_keys(Duration::ZERO, |_| false);
+
+        assert_eq!(collect_commands(&mut state), Vec::new());
+        assert!(state.held_physical_keys.contains_key(&VirtualKey::S));
+        assert!(state.held_physical_keys.contains_key(&VirtualKey::D));
+        assert!(state.has_active_action_keys());
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Prevent a regression where simultaneous non-modifier movement keys pressed for diagonal movement could be treated like modifiers and be synthetically released by stale-key reconciliation.

### Description
- Add `state_with_bound_keys` test helper and make `state_with_bound_key` delegate to it to simplify multi-key setup using `set_bound_keys`.
- Add `diagonal_movement_keys_survive_modifier_reconcile` test which binds `VirtualKey::S` and `VirtualKey::D`, routes down events for `Action::MoveLeft` and `Action::MoveDown`, drains initial key-down commands with `collect_commands`, calls `state.reconcile_stale_keys(Duration::ZERO, |_| false)`, and asserts no synthetic key-up commands are produced while both physical keys remain held and active.
- The test asserts the behavior in terms of movement actions (`Action::MoveDown` + `Action::MoveLeft`) rather than specific physical layout semantics.

### Testing
- `cargo fmt --check` was run and succeeded.
- `cargo test diagonal_movement_keys_survive_modifier_reconcile` was attempted but could not complete in this Linux environment because the project contains platform-specific dependencies (Windows APIs) that fail to compile for the current target, so the test was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e121f8b8c833288f4c3036533f967)