### PR TITLE
Adjust stale key reconcile tests

### DIFF
--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -4130,7 +4130,7 @@ mod tests {
     }
 
     #[test]
-    fn reconcile_ignores_stale_move_trigger() {
+    fn reconcile_does_not_release_plain_movement_key() {
         let mut state = state_with_bound_key(VirtualKey::E);
         state.route_key_event(KeyEvent::new(VirtualKey::E, true), Some(Action::MoveUp));
         assert_eq!(collect_commands(&mut state).len(), 1);
@@ -4201,6 +4201,30 @@ mod tests {
     }
 
     #[test]
+    fn real_movement_key_up_releases_action_through_normal_path() {
+        let mut state = state_with_bound_key(VirtualKey::E);
+        state.route_key_event(KeyEvent::new(VirtualKey::E, true), Some(Action::MoveUp));
+        assert_eq!(
+            collect_commands(&mut state),
+            vec![AppCommand::KeyAction {
+                action: Action::MoveUp,
+                is_down: true,
+            }]
+        );
+
+        state.route_key_event(KeyEvent::new(VirtualKey::E, false), None);
+
+        assert_eq!(
+            collect_commands(&mut state),
+            vec![AppCommand::KeyAction {
+                action: Action::MoveUp,
+                is_down: false,
+            }]
+        );
+        assert!(!state.held_physical_keys.contains_key(&VirtualKey::E));
+    }
+
+    #[test]
     fn reconcile_releases_only_physically_up_modifier_keys() {
         let mut state = AppState::default();
         state.set_bound_keys([VirtualKey::LeftShift, VirtualKey::RightAlt]);
@@ -4266,11 +4290,13 @@ mod tests {
         assert_eq!(collect_commands(&mut state), Vec::new());
         assert!(state.held_physical_keys.contains_key(&VirtualKey::S));
         assert!(state.held_physical_keys.contains_key(&VirtualKey::D));
+        assert!(!state.reconciled_released_keys.contains(&VirtualKey::S));
+        assert!(!state.reconciled_released_keys.contains(&VirtualKey::D));
         assert!(state.has_active_action_keys());
     }
 
     #[test]
-    fn reconcile_removes_active_trigger_for_stale_modifier_key() {
+    fn reconcile_removes_active_trigger_for_stale_key() {
         let mut state = state_with_bound_key(VirtualKey::LeftShift);
         state.route_key_event(
             KeyEvent::new(VirtualKey::LeftShift, true),


### PR DESCRIPTION
### Motivation
- Clarify and harden tests around stale-key reconciliation to ensure movement keys are not treated as modifier recoveries. 
- Ensure modifier-triggered stale recovery behavior remains covered while adding explicit assertions for reconciled release bookkeeping. 
- Add a separate test to preserve coverage for the normal (real) key-up path for movement actions.

### Description
- Rename the movement-focused reconciliation test to `reconcile_does_not_release_plain_movement_key` and keep it asserting non-modifier keys are not physically queried and remain held. 
- Add `real_movement_key_up_releases_action_through_normal_path` which routes a real `KeyEvent::new(key, false)` and asserts the movement `Action` is released through the normal key-up path. 
- Add explicit `reconciled_released_keys` negative assertions for diagonal movement keys so movement keys are not inserted into `reconciled_released_keys` after modifier reconciliation. 
- Rename `reconcile_removes_active_trigger_for_stale_modifier_key` to `reconcile_removes_active_trigger_for_stale_key` and keep the test exercising cleanup of an active trigger driven by a modifier-triggered action (e.g. `LeftShift` -> `SlowMouse`).

### Testing
- Ran `cargo fmt -- --check`, which passed. 
- Attempted `cargo test reconcile`, but the run is blocked in this Linux environment because building native dependencies and platform-specific crates failed (initial `x11` pkg-config failures were resolved by installing `libxi-dev` and `libxtst-dev`, but compilation then fails when `windows::Win32` / `windows::core` symbols are unavailable for the current target). 
- Existing unit-test logic changes are limited to `src/app_state.rs` and validated locally via `cargo fmt` and source edits; test execution on CI/Windows should exercise the updated tests fully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e16fde9008332baefc244f9200086)