### PR TITLE
Add movement regression for split diagonal actions

### DIFF
--- a/src/action_handler.rs
+++ b/src/action_handler.rs
@@ -1667,6 +1667,25 @@ mod tests {
     }
 
     #[test]
+    fn separate_down_and_left_actions_produce_diagonal_movement() {
+        let config = test_config();
+        let mut current_speed = config.starting_speed;
+        let mut acceleration_counter = 0;
+        let active_actions = HashSet::from([Action::MoveDown, Action::MoveLeft]);
+
+        let movement = tick(
+            &active_actions,
+            &config,
+            config.starting_speed,
+            &mut current_speed,
+            &mut acceleration_counter,
+        );
+
+        assert!(movement.dx < 0.0);
+        assert!(movement.dy > 0.0);
+    }
+
+    #[test]
     fn acceleration_progresses_over_ticks() {
         let config = test_config();
         let mut current_speed = config.starting_speed;


### PR DESCRIPTION
### Motivation
- Add a focused regression to ensure `calculate_movement()` preserves held movement actions when two cardinal movement actions (down + left) are held separately, covering a stale-key reconciliation regression vector without changing `calculate_movement()` itself.

### Description
- Add a unit test `separate_down_and_left_actions_produce_diagonal_movement` in `src/action_handler.rs` that builds a `HashSet` with `Action::MoveDown` and `Action::MoveLeft`, calls the existing `tick()` test helper, and asserts `dx < 0.0` and `dy > 0.0`.

### Testing
- Ran `cargo fmt --check` which passed.  
- Compiled the test suite for the Windows target with `cargo test --no-run --target x86_64-pc-windows-gnu` which succeeded (test binaries produced).  
- A native `cargo test` on the Linux host was attempted but is blocked by platform-specific `windows::Win32` imports and a backend `Sync` issue in `enigo`, so native test execution did not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e1aaa58848332b1e0f6acdce464bb)