### PR TITLE
Preserve user keybinding display labels and add shortest-display lookup

### DIFF
--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -804,10 +804,18 @@ pub fn preserved_shortcut_risk_for_chord(chord: &KeyChord) -> Option<&'static st
     None
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KeyBindingEntry {
+    pub chord: KeyChord,
+    pub action: Action,
+    pub display: String,
+    pub order: usize,
+}
+
 /// Struct for managing keybindings
 #[derive(Debug)]
 pub struct KeyBindings {
-    bindings: Vec<(KeyChord, Action)>,
+    bindings: Vec<KeyBindingEntry>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -837,15 +845,37 @@ impl KeyBindings {
     }
 
     pub fn add_chord_binding(&mut self, chord: KeyChord, action: Action) {
-        if let Some((_, existing_action)) = self
-            .bindings
-            .iter_mut()
-            .find(|(existing_chord, _)| *existing_chord == chord)
-        {
-            *existing_action = action;
+        self.add_chord_binding_with_display(chord, action, chord.display_label());
+    }
+
+    pub fn add_chord_binding_with_display(
+        &mut self,
+        chord: KeyChord,
+        action: Action,
+        display: impl Into<String>,
+    ) {
+        let order = self.next_binding_order();
+        let display = display.into();
+        if let Some(existing) = self.bindings.iter_mut().find(|entry| entry.chord == chord) {
+            existing.action = action;
+            existing.display = display;
+            existing.order = order;
         } else {
-            self.bindings.push((chord, action));
+            self.bindings.push(KeyBindingEntry {
+                chord,
+                action,
+                display,
+                order,
+            });
         }
+    }
+
+    fn next_binding_order(&self) -> usize {
+        self.bindings
+            .iter()
+            .map(|entry| entry.order)
+            .max()
+            .map_or(0, |order| order + 1)
     }
 
     pub fn clear(&mut self) {
@@ -858,7 +888,7 @@ impl KeyBindings {
         let chord = KeyChord::from_key(key);
         self.bindings
             .iter()
-            .find_map(|(bound_chord, action)| (*bound_chord == chord).then_some(action))
+            .find_map(|entry| (entry.chord == chord).then_some(&entry.action))
     }
 
     pub fn resolve_for_key_down_event(
@@ -896,11 +926,11 @@ impl KeyBindings {
         let mut candidates: Vec<_> = self
             .bindings
             .iter()
-            .enumerate()
-            .filter(|(_, (chord, _))| matcher(chord))
-            .map(|(idx, (chord, action))| (idx, *chord, action.clone()))
+            .filter(|entry| matcher(&entry.chord))
+            .map(|entry| (entry.order, entry.chord, entry.action.clone()))
             .collect();
-        candidates.sort_by_key(|(idx, chord, _)| (std::cmp::Reverse(chord.specificity()), *idx));
+        candidates
+            .sort_by_key(|(order, chord, _)| (std::cmp::Reverse(chord.specificity()), *order));
         candidates
             .into_iter()
             .map(|(_, chord, action)| BindingCandidate { chord, action })
@@ -926,17 +956,31 @@ impl KeyBindings {
     }
 
     pub fn bound_chords(&self) -> impl Iterator<Item = KeyChord> + '_ {
-        self.bindings.iter().map(|(chord, _)| *chord)
+        self.bindings.iter().map(|entry| entry.chord)
     }
 
     pub fn entries(&self) -> impl Iterator<Item = (KeyChord, &Action)> + '_ {
-        self.bindings.iter().map(|(chord, action)| (*chord, action))
+        self.bindings
+            .iter()
+            .map(|entry| (entry.chord, &entry.action))
+    }
+
+    pub fn shortest_display_for_action(&self, action: &Action) -> Option<String> {
+        self.bindings
+            .iter()
+            .filter(|entry| &entry.action == action)
+            .min_by_key(|entry| (entry.display.chars().count(), entry.order))
+            .map(|entry| entry.display.clone())
+    }
+
+    pub fn display_for_bookmark_slot(&self, slot: u8) -> Option<String> {
+        self.shortest_display_for_action(&Action::BookmarkSlot(slot))
     }
 
     pub fn owned_modifiers(&self) -> OwnedModifierKeys {
         let mut owned = OwnedModifierKeys::default();
-        for (chord, _) in &self.bindings {
-            match chord.modifiers.alt {
+        for entry in &self.bindings {
+            match entry.chord.modifiers.alt {
                 crate::key_chord::ModifierSideRequirement::NotRequired => {}
                 crate::key_chord::ModifierSideRequirement::Any => {
                     owned.insert(VirtualKey::Alt);
@@ -948,7 +992,7 @@ impl KeyBindings {
                     owned.insert(VirtualKey::RightAlt);
                 }
             }
-            match chord.modifiers.ctrl {
+            match entry.chord.modifiers.ctrl {
                 crate::key_chord::ModifierSideRequirement::NotRequired => {}
                 crate::key_chord::ModifierSideRequirement::Any => {
                     owned.insert(VirtualKey::Ctrl);
@@ -960,7 +1004,7 @@ impl KeyBindings {
                     owned.insert(VirtualKey::RightCtrl);
                 }
             }
-            match chord.modifiers.shift {
+            match entry.chord.modifiers.shift {
                 crate::key_chord::ModifierSideRequirement::NotRequired => {}
                 crate::key_chord::ModifierSideRequirement::Any => {
                     owned.insert(VirtualKey::Shift);
@@ -975,7 +1019,7 @@ impl KeyBindings {
             // There is currently no generic Win virtual key variant in `VirtualKey`.
             // We still track Win in chord matching via the event's `win_down` flag,
             // but owned-modifier swallowing only applies to representable key events.
-            let _ = chord.modifiers.win;
+            let _ = entry.chord.modifiers.win;
         }
         owned
     }
@@ -1016,6 +1060,20 @@ mod tests {
         event.alt_down = true;
         event.right_alt_down = true;
         event
+    }
+
+    fn binding_entry(
+        chord: KeyChord,
+        action: Action,
+        display: &str,
+        order: usize,
+    ) -> KeyBindingEntry {
+        KeyBindingEntry {
+            chord,
+            action,
+            display: display.to_string(),
+            order,
+        }
     }
 
     #[test]
@@ -1374,7 +1432,10 @@ mod tests {
     fn deterministic_tie_break_uses_insertion_order() {
         let chord = KeyChord::parse("W").unwrap();
         let bindings = KeyBindings {
-            bindings: vec![(chord, Action::MoveUp), (chord, Action::MoveDown)],
+            bindings: vec![
+                binding_entry(chord, Action::MoveUp, "W", 0),
+                binding_entry(chord, Action::MoveDown, "W", 1),
+            ],
         };
 
         let event = KeyEvent::new(VirtualKey::W, true);
@@ -1386,6 +1447,124 @@ mod tests {
                 Some(Action::MoveUp)
             );
         }
+    }
+
+    #[test]
+    fn bookmark_slot_with_configured_one_displays_one() {
+        let mut bindings = KeyBindings::new();
+        bindings.add_chord_binding_with_display(
+            KeyChord::parse("1").unwrap(),
+            Action::BookmarkSlot(1),
+            "1",
+        );
+
+        assert_eq!(bindings.display_for_bookmark_slot(1), Some("1".to_string()));
+    }
+
+    #[test]
+    fn bookmark_slot_with_only_rightalt_one_displays_rightalt_one() {
+        let mut bindings = KeyBindings::new();
+        bindings.add_chord_binding_with_display(
+            KeyChord::parse("RightAlt+1").unwrap(),
+            Action::BookmarkSlot(1),
+            "RightAlt+1",
+        );
+
+        assert_eq!(
+            bindings.display_for_bookmark_slot(1),
+            Some("RightAlt+1".to_string())
+        );
+    }
+
+    #[test]
+    fn multiple_bindings_for_bookmark_slot_choose_shortest_configured_display() {
+        let mut bindings = KeyBindings::new();
+        bindings.add_chord_binding_with_display(
+            KeyChord::parse("RightAlt+1").unwrap(),
+            Action::BookmarkSlot(1),
+            "RightAlt+1",
+        );
+        bindings.add_chord_binding_with_display(
+            KeyChord::parse("1").unwrap(),
+            Action::BookmarkSlot(1),
+            "1",
+        );
+
+        assert_eq!(bindings.display_for_bookmark_slot(1), Some("1".to_string()));
+    }
+
+    #[test]
+    fn equal_length_bookmark_bindings_choose_earlier_config_order() {
+        let mut bindings = KeyBindings::new();
+        bindings.add_chord_binding_with_display(
+            KeyChord::parse("Alt+1").unwrap(),
+            Action::BookmarkSlot(1),
+            "Alt+1",
+        );
+        bindings.add_chord_binding_with_display(
+            KeyChord::parse("Ctrl+1").unwrap(),
+            Action::BookmarkSlot(1),
+            "Ctl+1",
+        );
+
+        assert_eq!(
+            bindings.display_for_bookmark_slot(1),
+            Some("Alt+1".to_string())
+        );
+    }
+
+    #[test]
+    fn numpad_one_and_one_remain_distinct_display_strings() {
+        let mut bindings = KeyBindings::new();
+        bindings.add_chord_binding_with_display(
+            KeyChord::parse("Numpad1").unwrap(),
+            Action::BookmarkSlot(1),
+            "Numpad1",
+        );
+        bindings.add_chord_binding_with_display(
+            KeyChord::parse("1").unwrap(),
+            Action::BookmarkSlot(2),
+            "1",
+        );
+
+        assert_eq!(
+            bindings.display_for_bookmark_slot(1),
+            Some("Numpad1".to_string())
+        );
+        assert_eq!(bindings.display_for_bookmark_slot(2), Some("1".to_string()));
+    }
+
+    #[test]
+    fn duplicate_chord_replaces_action_display_and_order() {
+        let mut bindings = KeyBindings::new();
+        bindings.add_chord_binding_with_display(
+            KeyChord::parse("Alt+1").unwrap(),
+            Action::BookmarkSlot(1),
+            "first",
+        );
+        bindings.add_chord_binding_with_display(
+            KeyChord::parse("Ctrl+1").unwrap(),
+            Action::BookmarkSlot(2),
+            "tie-a",
+        );
+        bindings.add_chord_binding_with_display(
+            KeyChord::parse("Alt+1").unwrap(),
+            Action::BookmarkSlot(2),
+            "tie-b",
+        );
+
+        assert_eq!(bindings.display_for_bookmark_slot(1), None);
+        assert_eq!(
+            bindings.display_for_bookmark_slot(2),
+            Some("tie-a".to_string())
+        );
+        let mut event = KeyEvent::new(VirtualKey::Num1, true);
+        event.alt_down = true;
+        event.left_alt_down = true;
+        assert_eq!(
+            bindings.get_action_for_event(&event, true),
+            Some(Action::BookmarkSlot(2))
+        );
     }
 
     #[test]
@@ -1491,7 +1670,10 @@ mod tests {
     fn bug_binding_resolution_tie_break_stays_first_inserted_across_repeated_resolves() {
         let chord = KeyChord::parse("RightAlt+E").unwrap();
         let bindings = KeyBindings {
-            bindings: vec![(chord, Action::MoveUp), (chord, Action::MoveDown)],
+            bindings: vec![
+                binding_entry(chord, Action::MoveUp, "RightAlt+E", 0),
+                binding_entry(chord, Action::MoveDown, "RightAlt+E", 1),
+            ],
         };
         let mut event = KeyEvent::new(VirtualKey::E, true);
         event.alt_down = true;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2608,7 +2608,7 @@ impl Config {
             if let Ok(chord) = KeyChord::parse(key) {
                 if let Some(action) = Action::from_string(action_str) {
                     println!("✅ Binding key: {:?} -> {:?}", chord, action);
-                    key_actions.add_chord_binding(chord, action);
+                    key_actions.add_chord_binding_with_display(chord, action, key.clone());
                 } else {
                     println!(
                         "❌ Action '{}' does not exist for key '{}'",


### PR DESCRIPTION
### Motivation
- Bookmark marker labels should show the shortest user-authored key string instead of canonicalized labels while preserving side-specific names (e.g. `Numpad1` vs `1`).
- Key binding storage must track the original configured display and the configuration order so tie-breaking matches existing “later entry wins” semantics for duplicate chords.
- Keep existing runtime behavior and convenience API so existing call-sites continue working.

### Description
- Added `KeyBindingEntry { chord: KeyChord, action: Action, display: String, order: usize }` and changed `KeyBindings.bindings` to `Vec<KeyBindingEntry>` in `src/keyboard.rs`.
- Implemented `add_chord_binding_with_display(chord, action, display)` which preserves config order via `next_binding_order()` and retains duplicate-chord replacement semantics while updating `display` and `order` consistently; `add_chord_binding()` is kept as a wrapper that forwards a canonical `chord.display_label()`.
- Updated all `KeyBindings` iteration/lookup logic to use the new entry type (including `get_action`, `matching_candidates` / candidate ordering, `bound_chords`, `entries`, and `owned_modifiers`).
- Added lookup helpers `shortest_display_for_action(&self) -> Option<String>` and `display_for_bookmark_slot(&self, slot: u8) -> Option<String>` which select by `entry.display.chars().count()` and break ties by `entry.order`.
- Updated config initialization in `src/main.rs` to call `key_actions.add_chord_binding_with_display(chord, action, key.clone())` so the original config string is preserved for display.
- Added unit tests in `src/keyboard.rs` covering: configured `1` displays `1`, `RightAlt+1` displays `RightAlt+1`, shortest-display selection across multiple bindings, equal-length tie broken by earlier config order, `Numpad1` vs `1` remain distinct, and duplicate-chord replacement updates action/display/order; existing duplicate-chord and side-specific resolution tests were kept.

### Testing
- Ran `cargo fmt` (succeeded).
- Compiled the unit tests for the Windows target with `cargo test --target x86_64-pc-windows-gnu --no-run` to verify the test binary builds (succeeded).
- Attempted to run the Windows test executable on the Linux host produced an exec-format error, so tests could not be executed in this environment; compilation confirms the new tests and changes integrate cleanly.
- Existing keyboard resolution unit tests compile under the cross-target build and the deterministic tie-break and duplicate-chord behaviors are preserved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2452a0f504833298af3f6cf8c3b844)