### PR TITLE
Implement Shell-backed virtual desktop metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,5 +22,6 @@
         "Win32_System_Ole",
         "Win32_UI_Accessibility",
         "Win32_UI_Input_KeyboardAndMouse",
+        "Win32_UI_Shell",
         "Win32_UI_WindowsAndMessaging"
     ]}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3863,6 +3863,31 @@ fn bookmark_tooltip_events_enabled(config: &Config) -> bool {
     config.bookmarks.show_tooltips && config.tooltip_overlay.events.bookmarks
 }
 
+#[allow(dead_code)]
+fn bookmark_marker_passes_virtual_desktop_filter<F>(
+    record: &BookmarkRecord,
+    strict_filtering: bool,
+    current_desktop_id: Option<&str>,
+    mut desktop_checker: F,
+) -> bool
+where
+    F: FnMut(Option<isize>) -> bool,
+{
+    if !strict_filtering {
+        return true;
+    }
+    let Some(record_desktop_id) = record.virtual_desktop_id.as_deref() else {
+        return false;
+    };
+    let Some(current_desktop_id) = current_desktop_id else {
+        return false;
+    };
+    if record_desktop_id != current_desktop_id {
+        return false;
+    }
+    desktop_checker(record.anchor_hwnd)
+}
+
 fn bookmark_list_tooltip_body(config: &Config, store: &BookmarkStore) -> String {
     let mut lines = Vec::new();
     for slot in 1..=(config.bookmarks.slot_count as u8) {
@@ -8763,6 +8788,28 @@ desktop_switch_wait_ms = 999999
         assert!(err.contains("unknown variant"));
     }
 
+    fn bookmark_marker_record() -> BookmarkRecord {
+        BookmarkRecord {
+            slot: 1,
+            name: None,
+            x: 10,
+            y: 20,
+            monitor_device_name: "monitor".into(),
+            monitor_rect: BookmarkMonitorRect {
+                left: 0,
+                top: 0,
+                right: 100,
+                bottom: 100,
+            },
+            virtual_desktop_id: Some("desktop-1".into()),
+            anchor_hwnd: Some(100),
+            anchor_process_id: None,
+            anchor_window_title: None,
+            created_at_unix_ms: 0,
+            updated_at_unix_ms: 0,
+        }
+    }
+
     #[test]
     fn bookmark_marker_shape_parses_valid_values() {
         let square = parse_config("[bookmark_markers]\nshape = \"square\"\n");
@@ -8860,6 +8907,67 @@ desktop_switch_wait_ms = 999999
         assert_eq!(slot.text_color, "#000000");
         assert_eq!(slot.border_color, "#445566");
         assert_eq!(slot.opacity, 1.0);
+    }
+
+    #[test]
+    fn bookmark_marker_strict_filter_hides_missing_desktop_metadata() {
+        let mut record = BookmarkRecord {
+            virtual_desktop_id: None,
+            anchor_hwnd: Some(100),
+            ..bookmark_marker_record()
+        };
+        assert!(!bookmark_marker_passes_virtual_desktop_filter(
+            &record,
+            true,
+            Some("desktop-1"),
+            |_| true
+        ));
+
+        record.virtual_desktop_id = Some("desktop-1".into());
+        assert!(!bookmark_marker_passes_virtual_desktop_filter(
+            &record,
+            true,
+            None,
+            |_| true
+        ));
+    }
+
+    #[test]
+    fn bookmark_marker_strict_filter_hides_mismatch_and_shows_match() {
+        let record = BookmarkRecord {
+            virtual_desktop_id: Some("desktop-1".into()),
+            anchor_hwnd: Some(100),
+            ..bookmark_marker_record()
+        };
+
+        assert!(!bookmark_marker_passes_virtual_desktop_filter(
+            &record,
+            true,
+            Some("desktop-2"),
+            |_| true
+        ));
+        assert!(bookmark_marker_passes_virtual_desktop_filter(
+            &record,
+            true,
+            Some("desktop-1"),
+            |_| true
+        ));
+    }
+
+    #[test]
+    fn bookmark_marker_strict_filter_hides_when_desktop_checker_fails() {
+        let record = BookmarkRecord {
+            virtual_desktop_id: Some("desktop-1".into()),
+            anchor_hwnd: Some(100),
+            ..bookmark_marker_record()
+        };
+
+        assert!(!bookmark_marker_passes_virtual_desktop_filter(
+            &record,
+            true,
+            Some("desktop-1"),
+            |_| false
+        ));
     }
 
     #[test]

--- a/src/virtual_desktop.rs
+++ b/src/virtual_desktop.rs
@@ -1,4 +1,9 @@
+use windows::core::GUID;
 use windows::Win32::Foundation::HWND;
+use windows::Win32::System::Com::{
+    CoCreateInstance, CoInitializeEx, CoUninitialize, CLSCTX_ALL, COINIT_APARTMENTTHREADED,
+};
+use windows::Win32::UI::Shell::{IVirtualDesktopManager, VirtualDesktopManager};
 use windows::Win32::UI::WindowsAndMessaging::{
     GetForegroundWindow, GetWindowTextLengthW, GetWindowTextW, IsWindow, IsWindowVisible,
     SetForegroundWindow, ShowWindow, SW_RESTORE,
@@ -44,15 +49,55 @@ pub fn capture_foreground_desktop_metadata() -> DesktopMetadata {
     };
     let anchor_window_title = read_window_title(hwnd);
     DesktopMetadata {
-        virtual_desktop_id: None,
+        virtual_desktop_id: desktop_id_for_window(hwnd),
         anchor_hwnd: anchor,
         anchor_process_id,
         anchor_window_title,
     }
 }
 
+pub fn desktop_id_for_window(hwnd: HWND) -> Option<String> {
+    if !valid_hwnd(hwnd) {
+        return None;
+    }
+    with_virtual_desktop_manager(|manager| unsafe { manager.GetWindowDesktopId(hwnd).ok() })
+        .flatten()
+        .map(normalize_guid)
+}
+
+#[allow(dead_code)]
+pub fn is_window_on_current_virtual_desktop(hwnd: HWND) -> bool {
+    if !valid_hwnd(hwnd) {
+        return false;
+    }
+    with_virtual_desktop_manager(|manager| unsafe {
+        manager
+            .IsWindowOnCurrentVirtualDesktop(hwnd)
+            .ok()
+            .map(|on_current| on_current.as_bool())
+    })
+    .flatten()
+    .unwrap_or(false)
+}
+
 pub fn current_virtual_desktop_id() -> Option<String> {
-    None
+    let hwnd = unsafe { GetForegroundWindow() };
+    if !valid_hwnd(hwnd) {
+        return None;
+    }
+    desktop_id_for_window(hwnd)
+}
+
+#[allow(dead_code)]
+pub fn is_anchor_window_on_current_virtual_desktop(anchor_hwnd: Option<isize>) -> bool {
+    let Some(raw) = anchor_hwnd else {
+        return false;
+    };
+    let hwnd = HWND(raw as *mut core::ffi::c_void);
+    if !valid_hwnd(hwnd) {
+        return false;
+    }
+    is_window_on_current_virtual_desktop(hwnd)
 }
 
 pub fn focus_anchor_window(anchor_hwnd: Option<isize>) -> FocusAnchorResult {
@@ -92,7 +137,7 @@ pub fn focus_anchor_window(anchor_hwnd: Option<isize>) -> FocusAnchorResult {
 }
 
 pub fn switch_to_desktop(_desktop_id: Option<&str>) -> Result<(), String> {
-    Err("virtual desktop backend unavailable".to_string())
+    Err("virtual desktop switching is not supported by the Windows Shell API backend".to_string())
 }
 
 fn read_window_title(hwnd: HWND) -> Option<String> {
@@ -109,4 +154,54 @@ fn read_window_title(hwnd: HWND) -> Option<String> {
         return None;
     }
     Some(String::from_utf16_lossy(&buffer[..copied as usize]))
+}
+
+fn valid_hwnd(hwnd: HWND) -> bool {
+    !hwnd.is_invalid() && unsafe { IsWindow(Some(hwnd)).as_bool() }
+}
+
+fn with_virtual_desktop_manager<T>(f: impl FnOnce(&IVirtualDesktopManager) -> T) -> Option<T> {
+    let com = ComApartment::initialize()?;
+    let manager = unsafe {
+        CoCreateInstance::<_, IVirtualDesktopManager>(&VirtualDesktopManager, None, CLSCTX_ALL)
+            .ok()?
+    };
+    let result = f(&manager);
+    drop(manager);
+    drop(com);
+    Some(result)
+}
+
+struct ComApartment;
+
+impl ComApartment {
+    fn initialize() -> Option<Self> {
+        let hr = unsafe { CoInitializeEx(None, COINIT_APARTMENTTHREADED) };
+        if hr.is_ok() {
+            Some(Self)
+        } else {
+            None
+        }
+    }
+}
+
+impl Drop for ComApartment {
+    fn drop(&mut self) {
+        unsafe { CoUninitialize() };
+    }
+}
+
+fn normalize_guid(guid: GUID) -> String {
+    format!("{guid:?}").to_ascii_lowercase()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_guid_uses_comparable_lowercase_hyphenated_id() {
+        let guid = GUID::from_u128(0xAABBCCDD_EEFF_0011_2233_445566778899);
+        assert_eq!(normalize_guid(guid), "aabbccdd-eeff-0011-2233-445566778899");
+    }
 }


### PR DESCRIPTION
### Motivation
- Use the Windows Shell `IVirtualDesktopManager` API so bookmark metadata can capture and compare real virtual desktop IDs instead of a stub value. 
- Provide a conservative, testable way to hide/show bookmark markers based on desktop membership without coupling tests to a real Windows desktop environment.

### Description
- Added the Windows feature `"Win32_UI_Shell"` to the existing `windows` dependency in `Cargo.toml` to expose `IVirtualDesktopManager` bindings. 
- Replaced the previous virtual-desktop stub in `src/virtual_desktop.rs` with a thin COM-backed implementation that exposes `desktop_id_for_window(HWND) -> Option<String>`, `is_window_on_current_virtual_desktop(HWND) -> bool`, and `current_virtual_desktop_id() -> Option<String>`, using `IVirtualDesktopManager::GetWindowDesktopId` and `IsWindowOnCurrentVirtualDesktop`, normalizing GUIDs to comparable lowercase strings, and returning `None` on failures. 
- Updated `capture_foreground_desktop_metadata()` to populate `DesktopMetadata.virtual_desktop_id` via `desktop_id_for_window(hwnd)` while preserving `anchor_hwnd`, `anchor_process_id`, and `anchor_window_title`. 
- Added a pure seam `bookmark_marker_passes_virtual_desktop_filter` in `src/main.rs` that accepts an injected `current_desktop_id` and a `desktop_checker` closure to evaluate anchor HWND membership; this enables unit testing without requiring real virtual desktops. 
- Added unit tests validating strict filtering behavior for missing desktop metadata, desktop ID mismatch/match, and desktop-checker failures, and a `normalize_guid` test for deterministic GUID formatting.

### Testing
- Ran `cargo fmt` and formatting completed successfully. 
- Ran `cargo check --target x86_64-pc-windows-gnu` which completed successfully in this environment. 
- Ran `cargo check --tests --target x86_64-pc-windows-gnu` which completed successfully. 
- Running `cargo check` (native Linux target) failed in this environment due to missing system XInput/`xi` pkg-config files required by the `x11` crate. 
- Running `cargo test --target x86_64-pc-windows-gnu --no-run` failed in this environment due to a missing cross-tooling dependency (`x86_64-w64-mingw32-dlltool`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a245579785c8332a94d483dd689ca9b)