### PR TITLE
Ensure bookmark marker labels use keybindings

### DIFF
--- a/src/bookmark_markers.rs
+++ b/src/bookmark_markers.rs
@@ -358,11 +358,54 @@ mod tests {
     fn bookmark_names_never_appear_in_marker_labels() {
         let config = config();
         let mut named = record(1, 1, 1);
-        named.name = Some("Secret bookmark name".into());
+        named.name = Some("Secret Name".into());
         let store = store_with([named]);
-        let bindings = bindings(&[1]);
+        let mut bindings = KeyBindings::new();
+        bindings.add_chord_binding_with_display(
+            KeyChord::parse("1").unwrap(),
+            Action::BookmarkSlot(1),
+            "1",
+        );
 
-        assert_eq!(view(&config, &store, &bindings).markers[0].label, "B1");
+        let marker_view = view(&config, &store, &bindings);
+        let labels = marker_view
+            .markers
+            .iter()
+            .map(|marker| marker.label.as_str())
+            .collect::<Vec<_>>();
+
+        assert!(labels.contains(&"1"));
+        assert!(!labels.contains(&"Secret Name"));
+        assert!(labels.iter().all(|label| !label.contains("Secret Name")));
+    }
+
+    #[test]
+    fn rebuilding_marker_view_after_keybinding_change_updates_label() {
+        let config = config();
+        let mut named = record(1, 1, 1);
+        named.name = Some("Secret Name".into());
+        let store = store_with([named]);
+        let mut initial_bindings = KeyBindings::new();
+        initial_bindings.add_chord_binding_with_display(
+            KeyChord::parse("1").unwrap(),
+            Action::BookmarkSlot(1),
+            "1",
+        );
+        let mut updated_bindings = KeyBindings::new();
+        updated_bindings.add_chord_binding_with_display(
+            KeyChord::parse("RightAlt+1").unwrap(),
+            Action::BookmarkSlot(1),
+            "RightAlt+1",
+        );
+
+        assert_eq!(
+            view(&config, &store, &initial_bindings).markers[0].label,
+            "1"
+        );
+        assert_eq!(
+            view(&config, &store, &updated_bindings).markers[0].label,
+            "RightAlt+1"
+        );
     }
 
     #[test]

--- a/src/keyboard.rs
+++ b/src/keyboard.rs
@@ -813,7 +813,7 @@ pub struct KeyBindingEntry {
 }
 
 /// Struct for managing keybindings
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct KeyBindings {
     bindings: Vec<KeyBindingEntry>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3617,10 +3617,67 @@ fn bookmark_marker_overlay_is_visible() -> bool {
     BOOKMARK_MARKER_OVERLAY.with(|overlay| overlay.borrow().is_visible())
 }
 
+trait BookmarkMarkerOverlayFacade {
+    fn show(
+        &mut self,
+        view: bookmark_markers::BookmarkMarkerOverlayView,
+    ) -> windows::core::Result<()>;
+    fn hide(&mut self);
+    fn is_visible(&self) -> bool;
+    fn refresh(
+        &mut self,
+        view: bookmark_markers::BookmarkMarkerOverlayView,
+    ) -> windows::core::Result<()>;
+}
+
+impl BookmarkMarkerOverlayFacade for BookmarkMarkerOverlay {
+    fn show(
+        &mut self,
+        view: bookmark_markers::BookmarkMarkerOverlayView,
+    ) -> windows::core::Result<()> {
+        BookmarkMarkerOverlay::show(self, view)
+    }
+
+    fn hide(&mut self) {
+        BookmarkMarkerOverlay::hide(self);
+    }
+
+    fn is_visible(&self) -> bool {
+        BookmarkMarkerOverlay::is_visible(self)
+    }
+
+    fn refresh(
+        &mut self,
+        view: bookmark_markers::BookmarkMarkerOverlayView,
+    ) -> windows::core::Result<()> {
+        BookmarkMarkerOverlay::refresh(self, view)
+    }
+}
+
 fn refresh_bookmark_marker_overlay_if_visible() {
+    let current_desktop_id = virtual_desktop::current_virtual_desktop_id();
+    let virtual_screen = current_bookmark_marker_virtual_screen();
+    BOOKMARK_MARKER_OVERLAY.with(|overlay| {
+        refresh_bookmark_marker_overlay_if_visible_with(
+            &mut *overlay.borrow_mut(),
+            current_desktop_id.as_deref(),
+            virtual_screen,
+            |record| {
+                virtual_desktop::is_anchor_window_on_current_virtual_desktop(record.anchor_hwnd)
+            },
+        );
+    });
+}
+
+fn refresh_bookmark_marker_overlay_if_visible_with(
+    overlay: &mut impl BookmarkMarkerOverlayFacade,
+    current_desktop_id: Option<&str>,
+    virtual_screen: BookmarkMarkerVirtualScreenRect,
+    desktop_checker: impl Fn(&BookmarkRecord) -> bool,
+) {
     let active_reasons = bookmark_marker_overlay_active_reasons();
     if active_reasons.is_empty() {
-        BOOKMARK_MARKER_OVERLAY.with(|overlay| overlay.borrow_mut().hide());
+        overlay.hide();
         return;
     }
 
@@ -3638,41 +3695,36 @@ fn refresh_bookmark_marker_overlay_if_visible() {
     restore_bookmark_marker_overlay_reasons(allowed_reasons);
 
     if allowed_reasons.is_empty() || !config.bookmark_markers.enabled {
-        BOOKMARK_MARKER_OVERLAY.with(|overlay| overlay.borrow_mut().hide());
+        overlay.hide();
         return;
     }
 
     let store = {
         let guard = BOOKMARK_RUNTIME.lock().unwrap();
         let Some(runtime) = guard.as_ref() else {
-            BOOKMARK_MARKER_OVERLAY.with(|overlay| overlay.borrow_mut().hide());
+            overlay.hide();
             return;
         };
         runtime.store.clone()
     };
-    let current_desktop_id = virtual_desktop::current_virtual_desktop_id();
-    let virtual_screen = current_bookmark_marker_virtual_screen();
     let key_bindings = KEY_ACTIONS.read().unwrap();
     let view = build_bookmark_marker_overlay_view(
         &config,
         &store,
         &key_bindings,
-        current_desktop_id.as_deref(),
+        current_desktop_id,
         virtual_screen,
-        |record| virtual_desktop::is_anchor_window_on_current_virtual_desktop(record.anchor_hwnd),
+        desktop_checker,
     );
     drop(key_bindings);
 
-    BOOKMARK_MARKER_OVERLAY.with(|overlay| {
-        let mut overlay = overlay.borrow_mut();
-        if view.markers.is_empty() {
-            overlay.hide();
-        } else if overlay.is_visible() {
-            let _ = overlay.refresh(view);
-        } else {
-            let _ = overlay.show(view);
-        }
-    });
+    if view.markers.is_empty() {
+        overlay.hide();
+    } else if overlay.is_visible() {
+        let _ = overlay.refresh(view);
+    } else {
+        let _ = overlay.show(view);
+    }
 }
 
 fn exit_bookmark_mode_runtime() {
@@ -9437,6 +9489,141 @@ mod bookmark_runtime_logic_tests {
     }
 
     #[test]
+    fn bookmark_list_tooltip_fallback_includes_secret_name_when_markers_disabled() {
+        let mut config = Config::default();
+        config.bookmark_markers.enabled = false;
+        let mut store = BookmarkStore::new(9);
+        let mut r = rec(12, 34);
+        r.name = Some("Secret Name".into());
+        store.set_slot(1, r);
+
+        assert!(!show_bookmarks_uses_marker_overlay(&config));
+        assert!(bookmark_list_tooltip_body(&config, &store).contains("Secret Name"));
+    }
+
+    #[test]
+    fn refresh_bookmark_marker_overlay_if_visible_rebuilds_label_after_keybinding_change() {
+        static TEST_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+        struct FakeBookmarkMarkerOverlay {
+            visible: bool,
+            last_view: Option<bookmark_markers::BookmarkMarkerOverlayView>,
+        }
+
+        impl BookmarkMarkerOverlayFacade for FakeBookmarkMarkerOverlay {
+            fn show(
+                &mut self,
+                view: bookmark_markers::BookmarkMarkerOverlayView,
+            ) -> windows::core::Result<()> {
+                self.visible = true;
+                self.last_view = Some(view);
+                Ok(())
+            }
+
+            fn hide(&mut self) {
+                self.visible = false;
+                self.last_view = None;
+            }
+
+            fn is_visible(&self) -> bool {
+                self.visible
+            }
+
+            fn refresh(
+                &mut self,
+                view: bookmark_markers::BookmarkMarkerOverlayView,
+            ) -> windows::core::Result<()> {
+                self.last_view = Some(view);
+                Ok(())
+            }
+        }
+
+        let _guard = TEST_LOCK.lock().unwrap();
+        let original_config = ACTION_HANDLER.read().unwrap().mouse_master.config.clone();
+        let original_runtime = BOOKMARK_RUNTIME.lock().unwrap().clone();
+        let original_reasons = bookmark_marker_overlay_active_reasons();
+        let original_key_actions = KEY_ACTIONS.read().unwrap().clone();
+
+        let mut config = Config::default();
+        config.bookmark_markers.enabled = true;
+        config.bookmark_markers.show_with_show_bookmarks = true;
+        config.bookmark_markers.filter_current_virtual_desktop = false;
+        config.bookmark_markers.hide_offscreen = false;
+        ACTION_HANDLER.write().unwrap().mouse_master.config = config;
+
+        let mut store = BookmarkStore::new(9);
+        let mut r = rec(12, 34);
+        r.name = Some("Secret Name".into());
+        store.set_slot(1, r);
+        *BOOKMARK_RUNTIME.lock().unwrap() = Some(BookmarkRuntime {
+            bookmark_path: PathBuf::from("test-bookmarks.json"),
+            store,
+        });
+        let mut reasons = BookmarkMarkerDisplayReasons::default();
+        reasons.insert(BookmarkMarkerDisplayReason::ShowBookmarks);
+        restore_bookmark_marker_overlay_reasons(reasons);
+
+        {
+            let mut key_actions = KEY_ACTIONS.write().unwrap();
+            key_actions.clear();
+            key_actions.add_chord_binding_with_display(
+                KeyChord::parse("1").unwrap(),
+                Action::BookmarkSlot(1),
+                "1",
+            );
+        }
+
+        let mut overlay = FakeBookmarkMarkerOverlay {
+            visible: true,
+            last_view: None,
+        };
+        let screen = BookmarkMarkerVirtualScreenRect {
+            left: 0,
+            top: 0,
+            width: 100,
+            height: 100,
+        };
+        refresh_bookmark_marker_overlay_if_visible_with(
+            &mut overlay,
+            Some("desktop-a"),
+            screen,
+            |_| true,
+        );
+        assert_eq!(overlay.last_view.as_ref().unwrap().markers[0].label, "1");
+
+        {
+            let mut key_actions = KEY_ACTIONS.write().unwrap();
+            key_actions.clear();
+            key_actions.add_chord_binding_with_display(
+                KeyChord::parse("RightAlt+1").unwrap(),
+                Action::BookmarkSlot(1),
+                "RightAlt+1",
+            );
+        }
+        refresh_bookmark_marker_overlay_if_visible_with(
+            &mut overlay,
+            Some("desktop-a"),
+            screen,
+            |_| true,
+        );
+        let labels = overlay
+            .last_view
+            .as_ref()
+            .unwrap()
+            .markers
+            .iter()
+            .map(|marker| marker.label.as_str())
+            .collect::<Vec<_>>();
+        assert!(labels.contains(&"RightAlt+1"));
+        assert!(labels.iter().all(|label| !label.contains("Secret Name")));
+
+        ACTION_HANDLER.write().unwrap().mouse_master.config = original_config;
+        *BOOKMARK_RUNTIME.lock().unwrap() = original_runtime;
+        restore_bookmark_marker_overlay_reasons(original_reasons);
+        *KEY_ACTIONS.write().unwrap() = original_key_actions;
+    }
+
+    #[test]
     fn bookmark_list_tooltip_marks_empty_slots() {
         let config = Config::default();
         let store = BookmarkStore::new(3);
@@ -9509,6 +9696,15 @@ mod bookmark_runtime_logic_tests {
         let mut config = Config::default();
         config.bookmark_markers.enabled = false;
         config.bookmark_markers.show_with_show_bookmarks = true;
+
+        assert!(!show_bookmarks_uses_marker_overlay(&config));
+    }
+
+    #[test]
+    fn show_bookmarks_falls_back_to_tooltip_when_show_bookmarks_marker_flag_is_false() {
+        let mut config = Config::default();
+        config.bookmark_markers.enabled = true;
+        config.bookmark_markers.show_with_show_bookmarks = false;
 
         assert!(!show_bookmarks_uses_marker_overlay(&config));
     }


### PR DESCRIPTION
### Motivation
- Ensure visual bookmark markers never reveal stored bookmark names and always derive their labels from configured keybindings, while preserving the old bookmark-list text tooltip as a fallback.
- Make bookmark marker overlay refresh behavior testable without invoking the real Windows overlay so label rebuilds can be validated in unit tests.

### Description
- Marker construction is driven exclusively by `key_bindings.display_for_bookmark_slot(slot)` and skips slots that do not have a display binding (changes/test coverage in `src/bookmark_markers.rs`).
- Kept `bookmark_list_tooltip_body(config, store)` in `src/main.rs` for the textual fallback and only use it when marker display is disabled or `show_with_show_bookmarks` is false in config.
- Introduced a small overlay facade and a testable helper `refresh_bookmark_marker_overlay_if_visible_with(...)` and refactored the original `refresh_bookmark_marker_overlay_if_visible()` to call it so tests can inject a fake overlay implementation (`src/main.rs`).
- Added unit tests that assert marker labels use the keybinding display strings (not bookmark `name`), that the textual fallback still contains the bookmark name when markers are disabled, and that rebuilding/refreshing the overlay after keybinding changes updates labels (`src/bookmark_markers.rs` and `src/main.rs`).
- Made `KeyBindings` `Clone` so tests can snapshot and restore global binding state safely (`src/keyboard.rs`).

### Testing
- Ran `cargo fmt --check` which succeeded.
- Built the unit tests for the Windows target with `cargo test --target x86_64-pc-windows-gnu bookmark_marker --no-run`, which completed successfully (tests compiled for the Windows target).
- Running the bookmark-marker tests on the native Linux target (`cargo test bookmark_marker -- --nocapture`) is expected to fail to run the Windows GUI overlay code in this environment; this was observed and is an environment limitation rather than a functional regression.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2478dfaa0c83328cbef6bce54c53f9)